### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/bobadilla-tech/requiems-api/security/code-scanning/5](https://github.com/bobadilla-tech/requiems-api/security/code-scanning/5)

To fix the problem, add an explicit `permissions:` block limiting the `GITHUB_TOKEN` to the minimal required scopes. Since most of the jobs here only need to read the repository contents (for checkout and running tests/lints) and possibly upload artifacts, a suitable minimal baseline is `contents: read` at the workflow root. That documents the intended least privilege and ensures the workflow remains restricted even if repository defaults change or the workflow is copied.

The single best fix without changing functionality is:

1. Add a top-level `permissions:` block after the `on:` block, setting `contents: read`. This applies to all jobs unless they override permissions.
2. If any specific job needed elevated permissions, it could define its own `permissions:` block, but in the visible snippet no job writes to the repo or PRs, so no per-job override is necessary.

Concretely, in `.github/workflows/ci.yml`, between the `on:` section (lines 3–7) and the `concurrency:` section (lines 9–11), insert:

```yaml
permissions:
  contents: read
```

No new imports or external dependencies are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
