### PR TITLE
fix: resolve edge-to-postgres sync bottlenecks and data loss risks

### DIFF
--- a/apps/dashboard/app/services/d1_sync_service.rb
+++ b/apps/dashboard/app/services/d1_sync_service.rb
@@ -59,11 +59,20 @@ class D1SyncService
   def bulk_insert(records)
     return 0 if records.empty?
 
-    # Map D1 records to UsageLog format
-    values = records.map do |record|
+    # Batch-load all needed API keys in a single query (fresh from DB, no stale cache).
+    # Using instance variables here would persist stale IDs across pages if a key is
+    # revoked mid-sync, so we preload per bulk_insert call instead.
+    prefixes = records.map { |r| r[:api_key][0...12] }.uniq
+    key_rows = ApiKey.where(key_prefix: prefixes).pluck(:key_prefix, :id, :user_id)
+    key_cache = key_rows.each_with_object({}) { |(prefix, id, uid), h| h[prefix] = { id: id, user_id: uid } }
+
+    values = records.filter_map do |record|
+      key_info = key_cache[record[:api_key][0...12]]
+      next unless key_info # skip records for unknown or revoked keys
+
       {
-        api_key_id: resolve_api_key_id(record[:api_key]),
-        user_id: resolve_user_id(record[:api_key]),
+        api_key_id: key_info[:id],
+        user_id: key_info[:user_id],
         endpoint: record[:endpoint],
         credits_used: record[:credits_used],
         status_code: 200, # D1 only records successful requests
@@ -73,9 +82,10 @@ class D1SyncService
         created_at: Time.current,
         updated_at: Time.current
       }
-    end.compact
+    end
 
-    # Bulk insert using ActiveRecord
+    return 0 if values.empty?
+
     UsageLog.insert_all(values, unique_by: [ :api_key_id, :used_at, :endpoint ])
 
     values.size
@@ -141,26 +151,5 @@ class D1SyncService
     else
       raise Error, "HTTP #{response.status}: #{response.body}"
     end
-  end
-
-  # Resolve API key string to database ID
-  # Uses in-memory cache to avoid repeated lookups
-  def resolve_api_key_id(key_string)
-    @api_key_cache ||= {}
-    @api_key_cache[key_string] ||= begin
-      # Extract prefix from full key (first 12 chars)
-      prefix = key_string[0...12]
-      api_key = ApiKey.find_by(key_prefix: prefix)
-      api_key&.id
-    end
-  end
-
-  # Resolve API key to user ID
-  def resolve_user_id(key_string)
-    key_id = resolve_api_key_id(key_string)
-    return nil unless key_id
-
-    @user_id_cache ||= {}
-    @user_id_cache[key_id] ||= ApiKey.find(key_id).user_id
   end
 end

--- a/apps/dashboard/config/recurring.yml
+++ b/apps/dashboard/config/recurring.yml
@@ -1,15 +1,12 @@
-# examples:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_cleanup_with_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
-
 production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+  sync_d1_usage:
+    class: SyncD1UsageJob
+    schedule: every 5 minutes
+
+  aggregate_daily_usage:
+    class: AggregateDailyUsageJob
+    schedule: every day at 00:05

--- a/apps/workers/api-management/package.json
+++ b/apps/workers/api-management/package.json
@@ -15,7 +15,9 @@
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
     "format": "biome format --write ./src",
-    "format:check": "biome format ./src"
+    "format:check": "biome format ./src",
+    "db:migrate": "wrangler d1 execute requiem-usage --local --yes --file=../auth-gateway/schema.sql",
+    "db:migrate:prod": "wrangler d1 execute requiem-usage --env production --remote --file=../auth-gateway/schema.sql"
   },
   "dependencies": {
     "@hono/swagger-ui": "^0.5.3",

--- a/apps/workers/api-management/src/routes/api-keys/create.ts
+++ b/apps/workers/api-management/src/routes/api-keys/create.ts
@@ -77,16 +77,20 @@ app.post("/", async (c) => {
       billingCycleStart: body.billingCycleStart || now,
     };
 
-    // Write to KV
-    await c.env.KV.put(keyName, JSON.stringify(keyData));
-
-    // Write metadata to D1 for audit trail
+    // Write metadata to D1 first — if this fails we haven't touched KV yet, clean failure
     await c.env.DB.prepare(
       `INSERT INTO api_keys (key_prefix, user_id, plan, created_at, billing_cycle_start, active)
        VALUES (?, ?, ?, ?, ?, 1)`,
     )
       .bind(keyPrefix, body.userId, body.plan, now, keyData.billingCycleStart)
       .run();
+
+    // Write auth key to KV
+    await c.env.KV.put(keyName, JSON.stringify(keyData));
+
+    // Write reverse-lookup index: prefix:{keyPrefix} → fullKey
+    // Used by delete/patch for O(1) lookup instead of KV.list() scan
+    await c.env.KV.put(`prefix:${keyPrefix}`, fullKey);
 
     log.info("API key created successfully", {
       userId: body.userId,

--- a/apps/workers/api-management/src/routes/api-keys/delete.ts
+++ b/apps/workers/api-management/src/routes/api-keys/delete.ts
@@ -19,29 +19,14 @@ app.delete("/:keyPrefix", async (c) => {
   }
 
   try {
-    // Find the full key in KV by searching with prefix pattern
-    const keys = await c.env.KV.list({ prefix: "key:" });
-
-    let fullKey: string | null = null;
-    for (const key of keys.keys) {
-      if (key.name.substring(4, 16) === keyPrefix) {
-        // "key:" is 4 chars, then 12 char prefix
-        fullKey = key.name.substring(4); // Remove "key:" prefix
-        break;
-      }
-    }
+    const fullKey = await c.env.KV.get(`prefix:${keyPrefix}`);
 
     if (!fullKey) {
       log.warn("API key not found for revocation", { keyPrefix });
       return jsonError(404, "API key not found");
     }
 
-    const keyName = `key:${fullKey}`;
-
-    // Delete from KV (revokes access immediately)
-    await c.env.KV.delete(keyName);
-
-    // Mark as revoked in D1
+    // Update D1 first — audit trail is preserved even if KV cleanup fails
     await c.env.DB.prepare(
       `UPDATE api_keys
        SET revoked_at = ?, active = 0
@@ -49,6 +34,10 @@ app.delete("/:keyPrefix", async (c) => {
     )
       .bind(new Date().toISOString(), keyPrefix)
       .run();
+
+    // Delete auth key and reverse-lookup index from KV
+    await c.env.KV.delete(`key:${fullKey}`);
+    await c.env.KV.delete(`prefix:${keyPrefix}`);
 
     log.info("API key revoked successfully", { keyPrefix });
 

--- a/apps/workers/api-management/src/routes/api-keys/patch.ts
+++ b/apps/workers/api-management/src/routes/api-keys/patch.ts
@@ -40,16 +40,8 @@ app.patch("/:keyPrefix", async (c) => {
   }
 
   try {
-    // Find the full key in KV
-    const keys = await c.env.KV.list({ prefix: "key:" });
-
-    let fullKey: string | null = null;
-    for (const key of keys.keys) {
-      if (key.name.substring(4, 16) === keyPrefix) {
-        fullKey = key.name.substring(4);
-        break;
-      }
-    }
+    // O(1) reverse-lookup
+    const fullKey = await c.env.KV.get(`prefix:${keyPrefix}`);
 
     if (!fullKey) {
       log.warn("API key not found for update", { keyPrefix });

--- a/apps/workers/api-management/src/routes/usage/export.ts
+++ b/apps/workers/api-management/src/routes/usage/export.ts
@@ -13,7 +13,7 @@ const app = new Hono<{ Bindings: WorkerBindings }>();
  * Query parameters:
  * - since: ISO timestamp - get records after this time (required)
  * - limit: number - max records to return (default: 1000, max: 5000)
- * - cursor: string - pagination cursor (offset)
+ * - cursor: string - pagination cursor (last seen record id)
  *
  * Auth: X-API-Management-Key header (only Rails dashboard has this)
  */
@@ -45,52 +45,45 @@ app.get("/export", async (c) => {
     return jsonError(400, "Invalid limit parameter");
   }
 
-  // Parse cursor (offset)
-  const offset = Number.parseInt(cursorParam || "0", 10);
-  if (Number.isNaN(offset) || offset < 0) {
+  // Parse cursor (last seen id — 0 means start from beginning)
+  const afterId = Number.parseInt(cursorParam || "0", 10);
+  
+  if (Number.isNaN(afterId) || afterId < 0) {
     return jsonError(400, "Invalid cursor parameter");
   }
 
   try {
-    // Get total count for hasMore calculation
-    const countResult = await c.env.DB.prepare(`
-      SELECT COUNT(*) as total
-      FROM credit_usage
-      WHERE used_at >= ?
-    `)
-      .bind(since)
-      .first<{ total: number }>();
-
-    const total = countResult?.total || 0;
-
-    // Fetch usage records with pagination
+    // Fetch usage records using keyset pagination on the autoincrement id.
+    // This is stable under concurrent inserts (unlike OFFSET which can skip rows).
     const result = await c.env.DB.prepare(`
       SELECT
+        id,
         api_key,
         endpoint,
         credits_used,
         used_at
       FROM credit_usage
-      WHERE used_at >= ?
-      ORDER BY used_at ASC
-      LIMIT ? OFFSET ?
+      WHERE used_at >= ? AND id > ?
+      ORDER BY id ASC
+      LIMIT ?
     `)
-      .bind(since, limit, offset)
+      .bind(since, afterId, limit)
       .all<UsageRecord>();
 
-    const usage = result.results || [];
-    const hasMore = offset + usage.length < total;
-    const nextCursor = hasMore ? (offset + usage.length).toString() : undefined;
+    const records = result.results || [];
+    const hasMore = records.length === limit;
+    const nextCursor = hasMore ? records[records.length - 1].id.toString() : undefined;
 
     log.info("Usage export successful", {
-      total,
-      returned: usage.length,
+      returned: records.length,
       hasMore,
     });
 
+    // Strip internal id field before returning to callers
+    const usage = records.map(({ id: _id, ...rest }) => rest);
+
     const response: UsageExportResponse = {
       usage,
-      total,
       hasMore,
       nextCursor,
     };
@@ -99,7 +92,7 @@ app.get("/export", async (c) => {
   } catch (error) {
     log.error("Error exporting usage data", {
       error,
-      params: { since, limit, offset },
+      params: { since, limit, afterId },
     });
 
     // Return more detailed error in development

--- a/apps/workers/api-management/src/routes/usage/types.ts
+++ b/apps/workers/api-management/src/routes/usage/types.ts
@@ -1,7 +1,9 @@
 /**
- * Usage data record from D1
+ * Usage data record from D1.
+ * id is used internally for cursor-based pagination and is not exposed in API responses.
  */
 export interface UsageRecord {
+  id: number;
   api_key: string;
   endpoint: string;
   credits_used: number;
@@ -9,11 +11,11 @@ export interface UsageRecord {
 }
 
 /**
- * Usage export response with pagination
+ * Usage export response with ID-based cursor pagination.
+ * Pass nextCursor as the `cursor` query param to fetch the next page.
  */
 export interface UsageExportResponse {
-  usage: UsageRecord[];
-  total: number;
+  usage: Omit<UsageRecord, "id">[];
   hasMore: boolean;
   nextCursor?: string;
 }

--- a/apps/workers/auth-gateway/migrations/001_remove_credit_usage_unique_constraint.sql
+++ b/apps/workers/auth-gateway/migrations/001_remove_credit_usage_unique_constraint.sql
@@ -1,0 +1,44 @@
+-- Migration 001: Remove UNIQUE(api_key, used_at, endpoint) from credit_usage
+--
+-- The original constraint silently drops inserts when two requests for the same
+-- api_key + endpoint arrive within the same second (datetime('now') resolution).
+-- The table already has id INTEGER PRIMARY KEY AUTOINCREMENT which is sufficient
+-- as a unique key. Deduplication during the Rails D1 sync is handled at the
+-- PostgreSQL layer via insert_all unique_by: [:api_key_id, :used_at, :endpoint].
+--
+-- SQLite does not support DROP CONSTRAINT, so we recreate the table.
+-- This file is idempotent and safe to re-run.
+--
+-- Dev (local) — run from apps/workers/auth-gateway/:
+--   pnpm run db:migrate:001
+-- Production (requires wrangler login + --remote to hit the real D1):
+--   pnpm run db:migrate:001:prod
+
+-- Clean up any leftover temp table from a failed previous run
+DROP TABLE IF EXISTS credit_usage_new;
+
+CREATE TABLE credit_usage_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  credits_used INTEGER NOT NULL,
+  used_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT OR IGNORE INTO credit_usage_new (id, api_key, user_id, endpoint, credits_used, used_at)
+SELECT id, api_key, user_id, endpoint, credits_used, used_at
+FROM credit_usage;
+
+DROP TABLE credit_usage;
+
+ALTER TABLE credit_usage_new RENAME TO credit_usage;
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_user_lookup
+ON credit_usage (user_id, used_at);
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_lookup
+ON credit_usage (api_key, used_at);
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_endpoint
+ON credit_usage (endpoint, used_at);

--- a/apps/workers/auth-gateway/package.json
+++ b/apps/workers/auth-gateway/package.json
@@ -16,8 +16,10 @@
     "lint:fix": "biome lint --write ./src",
     "format": "biome format --write ./src",
     "format:check": "biome format ./src",
-    "db:migrate": "wrangler d1 execute requiem-usage --file=schema.sql",
-    "db:migrate:prod": "wrangler d1 execute requiem-usage --file=schema.sql --env production",
+    "db:migrate": "wrangler d1 execute requiem-usage --local --yes --file=schema.sql",
+    "db:migrate:prod": "wrangler d1 execute requiem-usage --env production --remote --file=schema.sql",
+    "db:migrate:001": "wrangler d1 execute requiem-usage --local --yes --file=./migrations/001_remove_credit_usage_unique_constraint.sql",
+    "db:migrate:001:prod": "wrangler d1 execute requiem-usage --env production --remote --file=./migrations/001_remove_credit_usage_unique_constraint.sql",
     "kv:seed": "node scripts/seed-kv.ts"
   },
   "dependencies": {

--- a/apps/workers/auth-gateway/schema.sql
+++ b/apps/workers/auth-gateway/schema.sql
@@ -1,12 +1,12 @@
+-- NOTE: existing production databases must be migrated to drop the old UNIQUE constraint.
+-- See docs/migrations/d1-remove-credit-usage-unique-constraint.sql
 CREATE TABLE IF NOT EXISTS credit_usage (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   api_key TEXT NOT NULL,
   user_id TEXT NOT NULL,
   endpoint TEXT NOT NULL,
   credits_used INTEGER NOT NULL,
-  used_at TEXT NOT NULL DEFAULT (datetime('now')),
-
-  CONSTRAINT idx_api_key_date UNIQUE (api_key, used_at, endpoint)
+  used_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS api_keys (

--- a/apps/workers/auth-gateway/scripts/seed-dev.ts
+++ b/apps/workers/auth-gateway/scripts/seed-dev.ts
@@ -34,6 +34,9 @@ function run(cmd: string): void {
 console.log("Applying D1 schema...");
 run(`${WRANGLER} d1 execute requiem-usage --local --yes --file=./schema.sql`);
 
+console.log("Applying D1 migrations...");
+run(`${WRANGLER} d1 execute requiem-usage --local --yes --file=./migrations/001_remove_credit_usage_unique_constraint.sql`);
+
 console.log("\nSeeding KV with dev test keys...");
 for (const { apiKey, userId, plan } of DEV_KEYS) {
   const kvKey = `key:${apiKey}`;

--- a/apps/workers/auth-gateway/src/requests.ts
+++ b/apps/workers/auth-gateway/src/requests.ts
@@ -2,9 +2,13 @@ import type { RequestCheckResult } from "@requiem/workers-shared";
 import type { WorkerBindings } from "./env";
 
 /**
- * Get current request usage from D1
+ * Get current request usage.
  *
- * IMPORTANT: Queries by user_id because all API keys for a user share the same quota
+ * Checks a 60-second KV cache first to avoid hitting D1 on every request.
+ * On cache miss the result is written back to KV so the next request is served
+ * from cache.
+ *
+ * IMPORTANT: Queries by user_id because all API keys for a user share the same quota.
  *
  * Note: Database tables still use "credit_" naming for historical reasons,
  * but we treat these as request counts in the code.
@@ -16,7 +20,16 @@ export async function getRequestUsage(
   billingCycleStart?: string,
 ): Promise<number> {
   const startDate = period === "daily" ? getTodayStart() : billingCycleStart || getMonthStart();
+  const cacheKey = `quota:${userId}:${startDate}`;
 
+  // KV cache hit — avoids a D1 aggregate query on every request
+  const cached = await bindings.KV.get(cacheKey);
+  
+  if (cached !== null) {
+    return Number(cached);
+  }
+
+  // Cache miss — query D1 and populate cache
   const result = await bindings.DB.prepare(`
     SELECT COALESCE(SUM(credits_used), 0) as total
     FROM credit_usage
@@ -25,11 +38,19 @@ export async function getRequestUsage(
     .bind(userId, startDate)
     .first<{ total: number }>();
 
-  return result?.total || 0;
+  const usage = result?.total || 0;
+
+  // Write to KV with 60-second TTL (best-effort, don't block on failure)
+  bindings.KV.put(cacheKey, usage.toString(), { expirationTtl: 60 }).catch(() => {});
+
+  return usage;
 }
 
 /**
- * Record request usage in D1
+ * Record request usage in D1 and keep the KV quota cache warm.
+ *
+ * @param billingCycleStart - used to derive the quota cache key; optional, falls
+ *   back to the current month start so the key matches what getRequestUsage uses.
  */
 export async function recordRequestUsage(
   bindings: WorkerBindings,
@@ -37,6 +58,7 @@ export async function recordRequestUsage(
   userId: string,
   endpoint: string,
   requests: number,
+  billingCycleStart?: string,
 ): Promise<void> {
   await bindings.DB.prepare(`
     INSERT INTO credit_usage (api_key, user_id, endpoint, credits_used, used_at)
@@ -44,6 +66,18 @@ export async function recordRequestUsage(
   `)
     .bind(apiKey, userId, endpoint, requests)
     .run();
+
+  // Optimistically increment the KV cache so the next quota check stays warm.
+  // Race conditions here are acceptable: the 60-second TTL bounds any skew, and
+  // D1 is always the authoritative source on a cache miss.
+  const startDate = billingCycleStart || getMonthStart();
+  const cacheKey = `quota:${userId}:${startDate}`;
+  const cached = await bindings.KV.get(cacheKey);
+  if (cached !== null) {
+    bindings.KV.put(cacheKey, (Number(cached) + requests).toString(), {
+      expirationTtl: 60,
+    }).catch(() => {});
+  }
 }
 
 /**

--- a/apps/workers/auth-gateway/src/routes/proxy.ts
+++ b/apps/workers/auth-gateway/src/routes/proxy.ts
@@ -13,7 +13,6 @@ import { addUsageHeaders, fetchBackend, filterHeaders } from "../http";
 import { recordRequestUsage } from "../requests";
 import type { WorkerBindings } from "../env";
 
-// Extend Hono context to include auth data set by middleware
 type Variables = {
   apiKey: string;
   keyData: ApiKeyData;
@@ -86,8 +85,10 @@ app.all("/*", async (c) => {
     return response;
   }
 
-  // Record usage asynchronously (don't await)
-  void recordRequestUsage(c.env, apiKey, keyData.userId, url.pathname, requestMultiplier);
+  // Record usage after response is sent — waitUntil keeps the worker alive for the write
+  c.executionCtx.waitUntil(
+    recordRequestUsage(c.env, apiKey, keyData.userId, url.pathname, requestMultiplier, keyData.billingCycleStart),
+  );
 
   // Add usage headers to successful response
   const response = addUsageHeaders(backendResponse, {

--- a/apps/workers/shared/src/middleware/worker.ts
+++ b/apps/workers/shared/src/middleware/worker.ts
@@ -1,5 +1,7 @@
-import type { Hono, NotFoundHandler } from "hono";
 import { jsonResponse } from "../http";
+
+import type { ExecutionContext } from "@cloudflare/workers-types";
+import type { Hono, NotFoundHandler } from "hono";
 
 /**
  * Standard 404 handler for all workers.
@@ -16,14 +18,16 @@ export function createWorkerFetch<TEnv extends object>(
   validateEnv: (env: TEnv) => void,
 ) {
   return {
-    async fetch(request: Request, env: TEnv): Promise<Response> {
+    async fetch(request: Request, env: TEnv, ctx: ExecutionContext): Promise<Response> {
+      
       try {
         validateEnv(env);
       } catch (error) {
         console.error("Environment validation failed:", error);
         return jsonResponse({ error: "Configuration error" }, 500);
       }
-      return app.fetch(request, env);
+
+      return app.fetch(request, env, ctx);
     },
   };
 }

--- a/docs/migrations/d1-remove-credit-usage-unique-constraint.sql
+++ b/docs/migrations/d1-remove-credit-usage-unique-constraint.sql
@@ -1,0 +1,46 @@
+-- Migration: Remove UNIQUE(api_key, used_at, endpoint) from credit_usage
+--
+-- The original constraint silently drops inserts when two requests for the same
+-- api_key + endpoint arrive within the same second (datetime('now') resolution).
+-- The table already has id INTEGER PRIMARY KEY AUTOINCREMENT which is sufficient
+-- as a unique key. Deduplication during the Rails D1 sync is handled at the
+-- PostgreSQL layer via insert_all unique_by: [:api_key_id, :used_at, :endpoint].
+--
+-- SQLite does not support DROP CONSTRAINT, so we recreate the table.
+-- This file is idempotent and safe to re-run.
+--
+-- Canonical runnable file: apps/workers/auth-gateway/migrations/001_remove_credit_usage_unique_constraint.sql
+--
+-- Dev (local) — run from apps/workers/auth-gateway/:
+--   pnpm run db:migrate:001
+-- Production:
+--   pnpm run db:migrate:001:prod
+
+-- Clean up any leftover temp table from a failed previous run
+DROP TABLE IF EXISTS credit_usage_new;
+
+CREATE TABLE credit_usage_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  credits_used INTEGER NOT NULL,
+  used_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT OR IGNORE INTO credit_usage_new (id, api_key, user_id, endpoint, credits_used, used_at)
+SELECT id, api_key, user_id, endpoint, credits_used, used_at
+FROM credit_usage;
+
+DROP TABLE credit_usage;
+
+ALTER TABLE credit_usage_new RENAME TO credit_usage;
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_user_lookup
+ON credit_usage (user_id, used_at);
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_lookup
+ON credit_usage (api_key, used_at);
+
+CREATE INDEX IF NOT EXISTS idx_credit_usage_endpoint
+ON credit_usage (endpoint, used_at);


### PR DESCRIPTION
## Summary

Addresses a set of architectural issues in the CF Workers ↔ PostgreSQL sync
pipeline identified in a full-stack audit. Fixes span data loss, scalability
ceilings, O(n) operations, stale caches, and missing job schedules.

## Changes

### Critical fixes
- **Schedule background jobs** — `SyncD1UsageJob` (every 5 min) and
  `AggregateDailyUsageJob` (daily 00:05 UTC) were fully implemented but never
  wired into `recurring.yml`; usage data was never syncing to PostgreSQL in
  production
- **Fix fire-and-forget usage recording** — `void recordRequestUsage()` in the
  auth-gateway proxy silently discarded D1 write failures; replaced with
  `ctx.waitUntil()` so the write survives the request lifecycle. Required
  threading `ExecutionContext` through `createWorkerFetch` in the shared worker
  middleware
- **KV quota cache** — every API request triggered a `SUM(credits_used)` D1
  aggregate query with no caching; added a 60-second KV cache
  (`quota:{userId}:{billingCycleStart}`) that cuts D1 reads from N
  requests/minute down to ~1 per user per 60 seconds, with optimistic
  write-through on usage recording

### Data integrity fixes
- **Cursor-based pagination in usage export** — `LIMIT/OFFSET` pagination races
  with concurrent auth-gateway inserts, causing records to be skipped or
  duplicated during Rails sync; switched to ID keyset pagination
  (`WHERE id > ? ORDER BY id ASC`) which is stable under concurrent writes.
  Also removes the redundant `COUNT(*)` query per page
- **Remove D1 UNIQUE timestamp constraint** — `UNIQUE(api_key, used_at,
  endpoint)` on `credit_usage` silently dropped inserts when two requests for
  the same key+endpoint arrived in the same second; replaced with the existing
  `AUTOINCREMENT` primary key as the unique identifier

### Performance fixes
- **O(1) KV key lookup** — DELETE and PATCH on API keys previously did
  `KV.list({prefix: "key:"})` and scanned every key to find the target (O(n));
  added a `prefix:{keyPrefix} → fullKey` reverse-lookup entry written at key
  creation time, making delete/patch O(1)
- **D1-first write order on key creation** — KV was written before D1; if D1
  failed the key would be live but have no audit trail. Swapped order so a D1
  failure is a clean no-op before KV is touched
- **D1-first revocation** — KV delete previously fired before the D1
  `revoked_at` update; reversed so the audit trail is always written first
- **Fix stale Rails sync cache** — `@api_key_cache` and `@user_id_cache`
  instance variables in `D1SyncService` persisted for the entire job run;
  replaced with a single batch `ApiKey.where(key_prefix: prefixes)` preload at
  the start of each `bulk_insert` call (one query, always fresh)

### D1 migrations
- Added `apps/workers/auth-gateway/migrations/` as the canonical home for D1
  migration SQL files (co-located with the schema, accessible from the Docker
  container mount)
- `seed-dev.ts` now applies all migrations on every dev container start
  (idempotent, safe to re-run)
- Added `db:migrate:001` / `db:migrate:001:prod` scripts; `:prod` variants
  use `--remote` to target the real Cloudflare D1
- Migration 001 applied to both local dev and production

## Test plan

- [ ] `docker exec requiem-dev-auth-gateway-1 pnpm exec vitest run` — 71 tests pass
- [ ] `docker exec requiem-dev-api-management-1 pnpm exec vitest run` — 2 tests pass
- [ ] `docker exec requiem-dev-dashboard-1 bin/rails test` — 60 tests pass
- [ ] `docker exec -e CI=true requiem-dev-auth-gateway-1 pnpm run typecheck` — clean
- [ ] `docker exec -e CI=true requiem-dev-api-management-1 pnpm run typecheck` — clean
- [ ] Create API key → verify KV has `key:{fullKey}` and `prefix:{keyPrefix}` entries
- [ ] Make an API request → verify quota cache populates in KV (`quota:{userId}:*`)
- [ ] Revoke key → verify both KV keys deleted, D1 `revoked_at` set
- [ ] `SyncD1UsageJob.perform_now` in Rails console → verify `usage_logs` populated
- [ ] Confirm `SyncD1UsageJob` and `AggregateDailyUsageJob` appear in Solid Queue scheduler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled background jobs for usage data synchronization and daily aggregation.

* **Improvements**
  * Enhanced usage export API with improved pagination mechanism for better data retrieval.
  * Optimized API key operations and lookup performance.
  * Improved data consistency in usage tracking through batch processing.

* **Database**
  * Removed constraint on credit usage records to support duplicate tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->