### PR TITLE
Add http layer test to base64 API

### DIFF
--- a/apps/api/coverage
+++ b/apps/api/coverage
@@ -1,0 +1,16 @@
+mode: set
+requiems-api/services/technology/base64/service.go:14.28,14.49 1 1
+requiems-api/services/technology/base64/service.go:18.56,19.22 1 1
+requiems-api/services/technology/base64/service.go:19.22,21.3 1 1
+requiems-api/services/technology/base64/service.go:22.2,22.73 1 1
+requiems-api/services/technology/base64/service.go:28.65,34.22 2 1
+requiems-api/services/technology/base64/service.go:34.22,36.3 1 1
+requiems-api/services/technology/base64/service.go:36.8,38.3 1 1
+requiems-api/services/technology/base64/service.go:40.2,40.16 1 1
+requiems-api/services/technology/base64/service.go:40.16,46.3 1 1
+requiems-api/services/technology/base64/service.go:48.2,48.45 1 1
+requiems-api/services/technology/base64/transport_http.go:13.49,15.62 1 1
+requiems-api/services/technology/base64/transport_http.go:15.62,17.4 1 1
+requiems-api/services/technology/base64/transport_http.go:20.2,21.62 1 1
+requiems-api/services/technology/base64/transport_http.go:21.62,23.4 1 1
+requiems-api/services/technology/base64/type.go:20.25,20.26 0 0

--- a/apps/api/services/technology/base64/transport_http_test.go
+++ b/apps/api/services/technology/base64/transport_http_test.go
@@ -1,0 +1,171 @@
+package base64 //nolint:revive //En Go, todos los archivos que tienen el mismo package se ven entre sí automáticamente. 
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"requiems-api/platform/httpx"
+)
+
+// setupRouter arma el router con el servicio real en memoria, sin levantar ningún servidor.
+// Service no tiene dependencias externas (sin base de datos, sin HTTP)
+func setupRouter() chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService())
+	return r
+}
+
+
+// verificarJSON comprueba que la respuesta tenga Content-Type JSON y body JSON válido.
+// Se llama en todos los casos porque el ticket exige verificar estas dos cosas.
+func assertJSON(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+	if !json.Valid(w.Body.Bytes()) {
+		t.Errorf("body is not valid JSON: %s", w.Body.String())
+	}
+}
+
+// ── /base64/encode ────────────────────────────────────────────────────────────
+// TestEncode_HappyPath verifica que el endpoint responde correctamente
+// cuando recibe un request completo y válido.
+func TestEncode_HappyPath(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
+		strings.NewReader(`{"value":"Hello, world!"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+
+	var resp httpx.Response[Result]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.Result != "SGVsbG8sIHdvcmxkIQ==" {
+		t.Errorf("result: got %q, want %q", resp.Data.Result, "SGVsbG8sIHdvcmxkIQ==")
+	}
+}
+
+
+// TestEncode_MissngValue verifica que el endpoint rechaza el request
+// cuando no viene el campo obligatorio "value".
+// El framework detecta esto automáticamente y devuelve 422
+// antes de que el servicio llegue a ejecutarse.
+func TestEncode_MissingValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
+		strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+}
+
+// TestEncode_InvalidVAriant verifica que el endpoint rechaza el request
+// cuando "variant" recibe un valor que no existe (solo acepta "standard" o "url").
+// El framework lo detecta por el tag validate:"oneof=standard url" y devuelve 422.
+func TestEncode_InvalidVariant(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
+		strings.NewReader(`{"value":"Hello","variant":"invalid"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+}
+
+// ── /base64/decode ────────────────────────────────────────────────────────────
+// TestDecode_HAppyPath verifica que el endpoint decodifica correctamente
+// cuando recibe un base64 válido.
+func TestDecode_HappyPath(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
+		strings.NewReader(`{"value":"SGVsbG8sIHdvcmxkIQ=="}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+
+	var resp httpx.Response[Result] //empleando librería interna del proyecto para respuesta estandarizada
+	if err := json.NewDecoder(w.Body).Decode(&resp); 
+		err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.Result != "Hello, world!" {
+		t.Errorf("result: got %q, want %q", resp.Data.Result, "Hello, world!")
+	}
+}
+
+/// TestDecode_MissingValue verifica que el endpoint rechaza el request
+// cuando no viene el campo obligatorio "value".
+func TestDecode_MissingValue(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
+		strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+}
+
+// TestDecode_InvalidVariant verifica que el endpoint rechaza el request
+// cuando "variant" recibe un valor que no existe.
+func TestDecode_InvalidVariant(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
+		strings.NewReader(`{"value":"SGVsbG8=","variant":"invalid"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+}
+
+// TestDecode_ServiceError verifica el caso donde el request pasa la validación
+// (tiene "value", el "variant" vacío es válido), pero el servicio falla porque
+// el string no es base64 real. A diferencia de los casos anteriores, acá el
+// servicio SÍ se ejecuta y es él quien devuelve el error con código 422.
+func TestDecode_ServiceError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
+		strings.NewReader(`{"value":"not-valid-base64!!!"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	assertJSON(t, w)
+}

--- a/apps/api/services/technology/base64/transport_http_test.go
+++ b/apps/api/services/technology/base64/transport_http_test.go
@@ -1,4 +1,4 @@
-package base64 //nolint:revive //En Go, todos los archivos que tienen el mismo package se ven entre sí automáticamente. 
+package base64 //nolint:revive
 
 import (
 	"encoding/json"
@@ -11,17 +11,19 @@ import (
 	"requiems-api/platform/httpx"
 )
 
-// setupRouter arma el router con el servicio real en memoria, sin levantar ningún servidor.
-// Service no tiene dependencias externas (sin base de datos, sin HTTP)
+const (
+	encodedHello = "SGVsbG8sIHdvcmxkIQ=="
+	decodedHello = "Hello, world!"
+)
+
+// setupRouter builds a chi router with the base64 service wired up.
 func setupRouter() chi.Router {
 	r := chi.NewRouter()
 	RegisterRoutes(r, NewService())
 	return r
 }
 
-
-// verificarJSON comprueba que la respuesta tenga Content-Type JSON y body JSON válido.
-// Se llama en todos los casos porque el ticket exige verificar estas dos cosas.
+// assertJSON verifies that the response has a JSON Content-Type and a valid JSON body.
 func assertJSON(t *testing.T, w *httptest.ResponseRecorder) {
 	t.Helper()
 	ct := w.Header().Get("Content-Type")
@@ -34,11 +36,10 @@ func assertJSON(t *testing.T, w *httptest.ResponseRecorder) {
 }
 
 // ── /base64/encode ────────────────────────────────────────────────────────────
-// TestEncode_HappyPath verifica que el endpoint responde correctamente
-// cuando recibe un request completo y válido.
+
 func TestEncode_HappyPath(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
-		strings.NewReader(`{"value":"Hello, world!"}`))
+		strings.NewReader(`{"value":"` + decodedHello + `"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -53,16 +54,13 @@ func TestEncode_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.Data.Result != "SGVsbG8sIHdvcmxkIQ==" {
-		t.Errorf("result: got %q, want %q", resp.Data.Result, "SGVsbG8sIHdvcmxkIQ==")
+	if resp.Data.Result != encodedHello {
+		t.Errorf("result: got %q, want %q", resp.Data.Result, encodedHello)
 	}
 }
 
-
-// TestEncode_MissngValue verifica que el endpoint rechaza el request
-// cuando no viene el campo obligatorio "value".
-// El framework detecta esto automáticamente y devuelve 422
-// antes de que el servicio llegue a ejecutarse.
+// TestEncode_MissingValue verifies that the endpoint rejects a request
+// when the required "value" field is missing.
 func TestEncode_MissingValue(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
 		strings.NewReader(`{}`))
@@ -77,12 +75,12 @@ func TestEncode_MissingValue(t *testing.T) {
 	assertJSON(t, w)
 }
 
-// TestEncode_InvalidVAriant verifica que el endpoint rechaza el request
-// cuando "variant" recibe un valor que no existe (solo acepta "standard" o "url").
-// El framework lo detecta por el tag validate:"oneof=standard url" y devuelve 422.
+// TestEncode_InvalidVariant verifies that the endpoint rejects a request
+// when "variant" contains a value other than "standard" or "url".
 func TestEncode_InvalidVariant(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/encode",
-		strings.NewReader(`{"value":"Hello","variant":"invalid"}`))
+		strings.NewReader(`{"value":"` + decodedHello + `","variant":"invalid"}`))
+
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -95,11 +93,10 @@ func TestEncode_InvalidVariant(t *testing.T) {
 }
 
 // ── /base64/decode ────────────────────────────────────────────────────────────
-// TestDecode_HAppyPath verifica que el endpoint decodifica correctamente
-// cuando recibe un base64 válido.
+
 func TestDecode_HappyPath(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
-		strings.NewReader(`{"value":"SGVsbG8sIHdvcmxkIQ=="}`))
+		strings.NewReader(`{"value":"` + encodedHello + `"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -110,18 +107,17 @@ func TestDecode_HappyPath(t *testing.T) {
 	}
 	assertJSON(t, w)
 
-	var resp httpx.Response[Result] //empleando librería interna del proyecto para respuesta estandarizada
-	if err := json.NewDecoder(w.Body).Decode(&resp); 
-		err != nil {
+	var resp httpx.Response[Result]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.Data.Result != "Hello, world!" {
-		t.Errorf("result: got %q, want %q", resp.Data.Result, "Hello, world!")
+	if resp.Data.Result != decodedHello {
+		t.Errorf("result: got %q, want %q", resp.Data.Result, decodedHello)
 	}
 }
 
-/// TestDecode_MissingValue verifica que el endpoint rechaza el request
-// cuando no viene el campo obligatorio "value".
+// TestDecode_MissingValue verifies that the endpoint rejects a request
+// when the required "value" field is missing.
 func TestDecode_MissingValue(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
 		strings.NewReader(`{}`))
@@ -136,11 +132,12 @@ func TestDecode_MissingValue(t *testing.T) {
 	assertJSON(t, w)
 }
 
-// TestDecode_InvalidVariant verifica que el endpoint rechaza el request
-// cuando "variant" recibe un valor que no existe.
+// TestDecode_InvalidVariant verifies that the endpoint rejects a request
+// when "variant" contains a value other than "standard" or "url".
 func TestDecode_InvalidVariant(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
-		strings.NewReader(`{"value":"SGVsbG8=","variant":"invalid"}`))
+		strings.NewReader(`{"value":"` + encodedHello + `","variant":"invalid"}`))
+
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -152,10 +149,8 @@ func TestDecode_InvalidVariant(t *testing.T) {
 	assertJSON(t, w)
 }
 
-// TestDecode_ServiceError verifica el caso donde el request pasa la validación
-// (tiene "value", el "variant" vacío es válido), pero el servicio falla porque
-// el string no es base64 real. A diferencia de los casos anteriores, acá el
-// servicio SÍ se ejecuta y es él quien devuelve el error con código 422.
+// TestDecode_ServiceError verifies that the endpoint returns 422 when the
+// value passes validation but is not valid base64.
 func TestDecode_ServiceError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/base64/decode",
 		strings.NewReader(`{"value":"not-valid-base64!!!"}`))


### PR DESCRIPTION
Agrega transport_http_test.go al servicio base64 cubriendo:
- Happy path para encode y decode
- Missing required param (falta el campo value)
- Invalid param value (variant con valor inválido)
- Service error (value no es base64 válido)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for base64 encode/decode endpoints, including success paths, input validation failures, and service error scenarios.
* **Chores**
  * Recorded execution coverage details for the base64 service and its HTTP layer to improve test visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->