### PR TITLE
Email validate batch

### DIFF
--- a/apps/api/services/entertainment/advice/service.go
+++ b/apps/api/services/entertainment/advice/service.go
@@ -1,40 +1,40 @@
-package advice
+	package advice
 
-import (
-	"context"
-	"fmt"
-	"time"
+	import (
+		"context"
+		"fmt"
+		"time"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-)
+		"github.com/jackc/pgx/v5"
+		"github.com/jackc/pgx/v5/pgxpool"
+	)
 
-type querier interface {
-	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
-}
-
-type Service struct {
-	db querier
-}
-
-func NewService(db *pgxpool.Pool) *Service {
-	return &Service{db: db}
-}
-
-func (s *Service) Random(ctx context.Context) (Advice, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	row := s.db.QueryRow(ctx, `
-SELECT id, text
-FROM advice
-ORDER BY random()
-LIMIT 1;
-`)
-
-	var a Advice
-	if err := row.Scan(&a.ID, &a.Text); err != nil {
-		return Advice{}, fmt.Errorf("scan advice: %w", err)
+	type querier interface {
+		QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 	}
-	return a, nil
-}
+
+	type Service struct {
+		db querier
+	}
+
+	func NewService(db *pgxpool.Pool) *Service {
+		return &Service{db: db}
+	}
+
+	func (s *Service) Random(ctx context.Context) (Advice, error) {
+		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		row := s.db.QueryRow(ctx, `
+	SELECT id, text
+	FROM advice
+	ORDER BY random()
+	LIMIT 1;
+	`)
+
+		var a Advice
+		if err := row.Scan(&a.ID, &a.Text); err != nil {
+			return Advice{}, fmt.Errorf("scan advice: %w", err)
+		}
+		return a, nil
+	}

--- a/apps/api/services/entertainment/advice/service.go
+++ b/apps/api/services/entertainment/advice/service.go
@@ -1,40 +1,40 @@
-	package advice
+package advice
 
-	import (
-		"context"
-		"fmt"
-		"time"
+import (
+	"context"
+	"fmt"
+	"time"
 
-		"github.com/jackc/pgx/v5"
-		"github.com/jackc/pgx/v5/pgxpool"
-	)
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
 
-	type querier interface {
-		QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
-	}
+type querier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
 
-	type Service struct {
-		db querier
-	}
+type Service struct {
+	db querier
+}
 
-	func NewService(db *pgxpool.Pool) *Service {
-		return &Service{db: db}
-	}
+func NewService(db *pgxpool.Pool) *Service {
+	return &Service{db: db}
+}
 
-	func (s *Service) Random(ctx context.Context) (Advice, error) {
-		ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-		defer cancel()
+func (s *Service) Random(ctx context.Context) (Advice, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 
-		row := s.db.QueryRow(ctx, `
+	row := s.db.QueryRow(ctx, `
 	SELECT id, text
 	FROM advice
 	ORDER BY random()
 	LIMIT 1;
 	`)
 
-		var a Advice
-		if err := row.Scan(&a.ID, &a.Text); err != nil {
-			return Advice{}, fmt.Errorf("scan advice: %w", err)
-		}
-		return a, nil
+	var a Advice
+	if err := row.Scan(&a.ID, &a.Text); err != nil {
+		return Advice{}, fmt.Errorf("scan advice: %w", err)
 	}
+	return a, nil
+}

--- a/apps/api/services/validation/email/service.go
+++ b/apps/api/services/validation/email/service.go
@@ -107,6 +107,32 @@ func (s *Service) ValidateEmail(ctx context.Context, email string) Validation {
 	}
 }
 
+// ValidateEmailBatch processes multiple emails using the same validation logic.
+// Each item is processed independently.
+func (s *Service) ValidateEmailBatch(ctx context.Context, emails []string) BatchResponse {
+	results := make([]BatchItem, 0, len(emails))
+
+	for _, email := range emails {
+		res := s.ValidateEmail(ctx, email)
+
+		results = append(results, BatchItem{
+			Email:       res.Email,
+			Valid:       res.Valid,
+			SyntaxValid: res.SyntaxValid,
+			MXValid:     res.MxValid,
+			Disposable:  res.Disposable,
+			Normalized:  res.Normalized,
+			Domain:      res.Domain,
+			Suggestion:  res.Suggestion,
+		})
+	}
+
+	return BatchResponse{
+		Results: results,
+		Total:   len(results),
+	}
+}
+
 // isValidSyntax reports whether email is a syntactically valid RFC 5322 plain
 // addr-spec. Display-name formats such as "Name <user@example.com>" and
 // angle-addr forms such as "<user@example.com>" are rejected.

--- a/apps/api/services/validation/email/service.go
+++ b/apps/api/services/validation/email/service.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/agnivade/levenshtein"
 	normalizer "github.com/bobadilla-tech/go-email-normalizer"
@@ -110,22 +112,38 @@ func (s *Service) ValidateEmail(ctx context.Context, email string) Validation {
 // ValidateEmailBatch processes multiple emails using the same validation logic.
 // Each item is processed independently.
 func (s *Service) ValidateEmailBatch(ctx context.Context, emails []string) BatchResponse {
-	results := make([]BatchItem, 0, len(emails))
 
-	for _, email := range emails {
-		res := s.ValidateEmail(ctx, email)
+	const maxWorkers = 8
+	const perItemTimeout = 2 * time.Second
 
-		results = append(results, BatchItem{
-			Email:       res.Email,
-			Valid:       res.Valid,
-			SyntaxValid: res.SyntaxValid,
-			MXValid:     res.MxValid,
-			Disposable:  res.Disposable,
-			Normalized:  res.Normalized,
-			Domain:      res.Domain,
-			Suggestion:  res.Suggestion,
-		})
+	results := make([]BatchItem, len(emails))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
+
+	for i, email := range emails {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, email string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			itemCtx, cancel := context.WithTimeout(ctx, perItemTimeout)
+			defer cancel()
+
+			res := s.ValidateEmail(itemCtx, email)
+			results[i] = BatchItem{
+				Email:       res.Email,
+				Valid:       res.Valid,
+				SyntaxValid: res.SyntaxValid,
+				MXValid:     res.MxValid,
+				Disposable:  res.Disposable,
+				Normalized:  res.Normalized,
+				Domain:      res.Domain,
+				Suggestion:  res.Suggestion,
+			}
+		}(i, email)
 	}
+	wg.Wait()
 
 	return BatchResponse{
 		Results: results,

--- a/apps/api/services/validation/email/service_test.go
+++ b/apps/api/services/validation/email/service_test.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"testing"
+	"requiems-api/platform/httpx"
 )
 
 func newTestService() *Service {
@@ -167,5 +168,53 @@ func TestValidateEmail_GmailPlusNormalized(t *testing.T) {
 	}
 	if *result.Normalized == "User.Name+tag@gmail.com" {
 		t.Error("expected email to be normalized (Gmail strips dots and plus-tags)")
+	}
+}
+
+// ---Batch
+
+
+
+// ---- ValidateEmailBatch -----------------------------------------------------
+
+func TestBatchRequest_Valid_OneEmail(t *testing.T) {
+	req := BatchRequest{Emails: []string{"user@gmail.com"}}
+
+	if err := httpx.Validate.Struct(&req); err != nil {
+		t.Errorf("expected no error for single valid email, got %v", err)
+	}
+}
+
+func TestBatchRequest_Valid_MaxEmails(t *testing.T) {
+	emails := make([]string, 50)
+	for i := range emails {
+		emails[i] = "user@gmail.com"
+	}
+
+	req := BatchRequest{Emails: emails}
+
+	if err := httpx.Validate.Struct(&req); err != nil {
+		t.Errorf("expected no error for 50 emails, got %v", err)
+	}
+}
+
+func TestBatchRequest_Empty_Fails(t *testing.T) {
+	req := BatchRequest{Emails: []string{}}
+
+	if err := httpx.Validate.Struct(&req); err == nil {
+		t.Error("expected error for empty emails array")
+	}
+}
+
+func TestBatchRequest_OverLimit_Fails(t *testing.T) {
+	emails := make([]string, 51)
+	for i := range emails {
+		emails[i] = "user@gmail.com"
+	}
+
+	req := BatchRequest{Emails: emails}
+
+	if err := httpx.Validate.Struct(&req); err == nil {
+		t.Error("expected error for >50 emails")
 	}
 }

--- a/apps/api/services/validation/email/service_test.go
+++ b/apps/api/services/validation/email/service_test.go
@@ -2,8 +2,8 @@ package email
 
 import (
 	"context"
-	"testing"
 	"requiems-api/platform/httpx"
+	"testing"
 )
 
 func newTestService() *Service {
@@ -172,8 +172,6 @@ func TestValidateEmail_GmailPlusNormalized(t *testing.T) {
 }
 
 // ---Batch
-
-
 
 // ---- ValidateEmailBatch -----------------------------------------------------
 

--- a/apps/api/services/validation/email/transport_http.go
+++ b/apps/api/services/validation/email/transport_http.go
@@ -15,4 +15,8 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/email", httpx.Handle(func(ctx context.Context, req Request) (Validation, error) {
 		return svc.ValidateEmail(ctx, req.Email), nil
 	}))
+
+	r.Post("/email/batch", httpx.Handle(func(ctx context.Context, req BatchRequest) (BatchResponse, error) {
+		return svc.ValidateEmailBatch(ctx, req.Emails), nil
+	}))
 }

--- a/apps/api/services/validation/email/transport_http_test.go
+++ b/apps/api/services/validation/email/transport_http_test.go
@@ -18,6 +18,8 @@ func setupRouter() chi.Router {
 	return r
 }
 
+// ---- helpers ----
+
 func postValidate(body string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPost, "/email", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -26,6 +28,25 @@ func postValidate(body string) *httptest.ResponseRecorder {
 	return w
 }
 
+func postBatch(body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/email/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	setupRouter().ServeHTTP(w, req)
+	return w
+}
+
+func decodeBatchResponse(t *testing.T, w *httptest.ResponseRecorder) httpx.Response[BatchResponse] {
+	t.Helper()
+	var resp httpx.Response[BatchResponse]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode batch response: %v", err)
+	}
+	return resp
+}
+
+
+// ---- single endpoint tests (unchanged) ----
 func TestValidate_MissingEmail(t *testing.T) {
 	w := postValidate(`{}`)
 
@@ -135,5 +156,164 @@ func TestValidate_SuggestionNullForKnownDomain(t *testing.T) {
 
 	if string(data["suggestion"]) != "null" {
 		t.Errorf("expected suggestion=null for gmail.com, got %s", data["suggestion"])
+	}
+}
+
+// ---- batch endpoint tests ----
+
+func TestBatch_HappyPath_Returns200(t *testing.T) {
+	w := postBatch(`{"emails":["user@gmail.com","user@yahoo.com"]}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := decodeBatchResponse(t, w)
+
+	if resp.Data.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Data.Total)
+	}
+
+	if len(resp.Data.Results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(resp.Data.Results))
+	}
+
+	for i, item := range resp.Data.Results {
+		if !item.SyntaxValid {
+			t.Errorf("results[%d].SyntaxValid = false, want true", i)
+		}
+		if item.Email == nil {
+			t.Errorf("results[%d].Email = nil, want non-nil", i)
+		}
+	}
+}
+
+func TestBatch_InvalidSyntax_InBand(t *testing.T) {
+	w := postBatch(`{"emails":["notanemail"]}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	item := decodeBatchResponse(t, w).Data.Results[0]
+
+	if item.Valid {
+		t.Error("Valid = true, want false")
+	}
+	if item.SyntaxValid {
+		t.Error("SyntaxValid = true, want false")
+	}
+	if item.Email != nil {
+		t.Error("Email != nil, want nil")
+	}
+}
+
+func TestBatch_OrderPreserved(t *testing.T) {
+	w := postBatch(`{"emails":["a@gmail.com","b@gmail.com","c@gmail.com"]}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	results := decodeBatchResponse(t, w).Data.Results
+
+	expected := []string{"a@gmail.com", "b@gmail.com", "c@gmail.com"}
+
+	for i := range results {
+		if results[i].Email == nil {
+			t.Fatalf("results[%d].Email is nil", i)
+		}
+		if *results[i].Email != expected[i] {
+			t.Errorf("results[%d] = %s, want %s", i, *results[i].Email, expected[i])
+		}
+	}
+}
+
+func TestBatch_EmptyArray(t *testing.T) {
+	w := postBatch(`{"emails":[]}`)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatch_MissingEmailsField(t *testing.T) {
+	w := postBatch(`{}`)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatch_OverLimit(t *testing.T) {
+	emails := make([]string, 51)
+	for i := range emails {
+		emails[i] = `"user@gmail.com"`
+	}
+
+	body := `{"emails":[` + strings.Join(emails, ",") + `]}`
+	w := postBatch(body)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+func TestBatch_Mixed_RealWorldScenario(t *testing.T) {
+	w := postBatch(`{
+		"emails":[
+			"user@gmail.com",
+			"user@gmial.com",
+			"notanemail",
+			"user@yahoo.com"
+		]
+	}`)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	resp := decodeBatchResponse(t, w)
+
+	if resp.Data.Total != 4 {
+		t.Fatalf("expected 4 results, got %d", resp.Data.Total)
+	}
+
+	results := resp.Data.Results
+
+	if !results[0].SyntaxValid {
+		t.Error("gmail should be valid syntax")
+	}
+
+	if results[1].Suggestion == nil {
+		t.Error("expected suggestion for gmial.com")
+	}
+
+	if results[2].SyntaxValid {
+		t.Error("expected invalid syntax for notanemail")
+	}
+
+	if !results[3].SyntaxValid {
+		t.Error("yahoo should be valid syntax")
+	}
+}
+func TestBatch_DuplicateEmails(t *testing.T) {
+	w := postBatch(`{
+		"emails":[
+			"user@gmail.com",
+			"user@gmail.com",
+			"user@gmail.com"
+		]
+	}`)
+
+	resp := decodeBatchResponse(t, w)
+
+	if resp.Data.Total != 3 {
+		t.Errorf("expected 3 results, got %d", resp.Data.Total)
+	}
+
+	for _, r := range resp.Data.Results {
+		if r.Email == nil {
+			t.Error("expected email not nil for duplicates")
+		}
 	}
 }

--- a/apps/api/services/validation/email/transport_http_test.go
+++ b/apps/api/services/validation/email/transport_http_test.go
@@ -45,7 +45,6 @@ func decodeBatchResponse(t *testing.T, w *httptest.ResponseRecorder) httpx.Respo
 	return resp
 }
 
-
 // ---- single endpoint tests (unchanged) ----
 func TestValidate_MissingEmail(t *testing.T) {
 	w := postValidate(`{}`)

--- a/apps/api/services/validation/email/type.go
+++ b/apps/api/services/validation/email/type.go
@@ -44,5 +44,3 @@ type BatchResponse struct {
 }
 
 func (BatchResponse) IsData() {}
-
-

--- a/apps/api/services/validation/email/type.go
+++ b/apps/api/services/validation/email/type.go
@@ -18,3 +18,31 @@ type Validation struct {
 }
 
 func (Validation) IsData() {}
+
+// BatchRequest is the body for validating multiple emails at once.
+type BatchRequest struct {
+	Emails []string `json:"emails" validate:"required,min=1,max=50,dive,required"`
+}
+
+// BatchItem holds the result for a single email in a batch request.
+// Each email is always processed — invalid ones return valid: false.
+type BatchItem struct {
+	Email       *string `json:"email"`
+	Valid       bool    `json:"valid"`
+	SyntaxValid bool    `json:"syntax_valid"`
+	MXValid     bool    `json:"mx_valid"`
+	Disposable  bool    `json:"disposable"`
+	Normalized  *string `json:"normalized,omitempty"`
+	Domain      *string `json:"domain,omitempty"`
+	Suggestion  *string `json:"suggestion,omitempty"`
+}
+
+// BatchResponse is the response payload for POST /v1/validation/email/batch.
+type BatchResponse struct {
+	Results []BatchItem `json:"results"`
+	Total   int         `json:"total"`
+}
+
+func (BatchResponse) IsData() {}
+
+

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -178,7 +178,7 @@ apis:
     categories:
       - validation
     description: Full email validation in one call. Syntax check, MX record lookup, disposable domain detection, normalization, and typo suggestions. Includes everything from the Disposable Domain Checker and Email Normalizer in a single request.
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: true
     documentation_url: /apis/email-validate

--- a/apps/dashboard/config/api_docs/email-validate.yml
+++ b/apps/dashboard/config/api_docs/email-validate.yml
@@ -243,16 +243,17 @@ endpoints:
     errors:
       - code: validation_failed
         status: 422
-        description: Invalid request body (empty array, more than 50 emails, or invalid format)
+        description: Valid JSON body that fails field validation (empty array or more than 50 emails).
 
       - code: bad_request
         status: 400
-        description: Invalid JSON or malformed request body
+        description: Invalid JSON, malformed request body, or unexpected field types.
 
       - code: internal_error
         status: 500
         description: Unexpected server error
 
+    
     code_examples:
       curl: |
         curl -X POST https://api.requiems.xyz/v1/validation/email/batch \

--- a/apps/dashboard/config/api_docs/email-validate.yml
+++ b/apps/dashboard/config/api_docs/email-validate.yml
@@ -17,6 +17,7 @@ overview:
     - Disposable domain detection (90,000+ domains)
     - Email normalization (lowercase, plus-tag removal, alias resolution)
     - Typo suggestion for common provider domains (gmail.com, yahoo.com, outlook.com, and more)
+    - Batch endpoint for validating up to 50 emails per request
 endpoints:
   - name: Validate Email
     method: POST
@@ -144,6 +145,175 @@ endpoints:
         data = JSON.parse(response.body)['data']
         puts data['valid']       # false
         puts data['suggestion']  # gmail.com
+
+  - name: Validate Emails (Batch)
+    method: POST
+    path: /v1/validation/email/batch
+    description: >-
+      Validates up to 50 email addresses in a single request. Each email is processed independently and returns a full
+      validation breakdown (syntax, MX record, disposable check, normalization, and typo suggestion).
+      Invalid emails do not fail the request. Billing: 1 credit per email.
+
+    parameters:
+      - name: emails
+        type: array
+        required: true
+        location: body
+        description: Array of email addresses to validate. Min: 1, Max: 50.
+        example: '["user@gmail.com", "user@gmial.com"]'
+
+    request_example: |
+      {
+        "emails": ["user@gmail.com", "user@gmial.com"]
+      }
+
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "email": "user@gmail.com",
+              "valid": true,
+              "syntax_valid": true,
+              "mx_valid": true,
+              "disposable": false,
+              "normalized": "user@gmail.com",
+              "domain": "gmail.com",
+              "suggestion": null
+            },
+            {
+              "email": "user@gmial.com",
+              "valid": false,
+              "syntax_valid": true,
+              "mx_valid": false,
+              "disposable": false,
+              "normalized": "user@gmial.com",
+              "domain": "gmial.com",
+              "suggestion": "gmail.com"
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-01-01T00:00:00Z"
+        }
+      }
+
+    response_fields:
+      - name: results
+        type: array
+        description: List of validation results for each email, preserving input order
+
+      - name: results[].email
+        type: string|null
+        description: Original email input (null if invalid syntax)
+
+      - name: results[].valid
+        type: boolean
+        description: Overall validity (syntax + MX record)
+
+      - name: results[].syntax_valid
+        type: boolean
+        description: Whether the email is syntactically valid (RFC 5322)
+
+      - name: results[].mx_valid
+        type: boolean
+        description: Whether the domain has valid MX records
+
+      - name: results[].disposable
+        type: boolean
+        description: Whether the email comes from a disposable domain
+
+      - name: results[].normalized
+        type: string|null
+        description: Canonical normalized email (lowercase, alias handling, etc.)
+
+      - name: results[].domain
+        type: string|null
+        description: Extracted domain from email address
+
+      - name: results[].suggestion
+        type: string|null
+        description: Suggested correction for common domain typos
+
+      - name: total
+        type: integer
+        description: Number of emails processed in the batch
+
+    errors:
+      - code: validation_failed
+        status: 422
+        description: Invalid request body (empty array, more than 50 emails, or invalid format)
+
+      - code: bad_request
+        status: 400
+        description: Invalid JSON or malformed request body
+
+      - code: internal_error
+        status: 500
+        description: Unexpected server error
+
+    code_examples:
+      curl: |
+        curl -X POST https://api.requiems.xyz/v1/validation/email/batch \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"emails": ["user@gmail.com", "user@gmial.com"]}'
+
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/validation/email/batch"
+        headers = {
+            "requiems-api-key": "YOUR_API_KEY",
+            "Content-Type": "application/json"
+        }
+        payload = {"emails": ["user@gmail.com", "user@gmial.com"]}
+
+        response = requests.post(url, headers=headers, json=payload)
+        data = response.json()["data"]
+
+        for r in data["results"]:
+            print(r["email"], r["valid"])
+
+      javascript: |
+        const response = await fetch('https://api.requiems.xyz/v1/validation/email/batch', {
+          method: 'POST',
+          headers: {
+            'requiems-api-key': 'YOUR_API_KEY',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            emails: ['user@gmail.com', 'user@gmial.com']
+          })
+        });
+
+        const { data } = await response.json();
+
+        data.results.forEach(r => {
+          console.log(r.email, r.valid);
+        });
+
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/validation/email/batch')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = { emails: ['user@gmail.com', 'user@gmial.com'] }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        data = JSON.parse(response.body)['data']
+
+        data['results'].each do |r|
+          puts "#{r['email']} #{r['valid']}"
+        end
+        
 faq:
   - question: What does valid mean exactly?
     answer: >-

--- a/docs/apis/validation/email-validate.md
+++ b/docs/apis/validation/email-validate.md
@@ -24,6 +24,7 @@ provider domains.
 
 ## Request
 
+### Single Email
 ```json
 {
   "email": "user@gmial.com"
@@ -34,6 +35,29 @@ provider domains.
 `422 Unprocessable
 Entity`. Syntax errors do not return a 4xx — they return
 `200 OK` with `syntax_valid: false` and `valid: false`.
+
+
+### Batch (multiple emails)
+
+Accepts up to **50 emails** per request. Results are returned in the same
+order as the input array. All emails are processed, and validation results
+are returned for each item regardless of validity.
+
+Each email in the request counts as **1 credit** (`X-Usage-Count` is set to
+the number of emails in the request).
+
+`POST /v1/validation/email/batch`
+
+```json
+  { "emails": [ "user@gmail.com", "user@gmial.com", "bad-email" ] }
+```
+
+**Validation:** `emails` is required. A missing or empty array returns
+`422 Unprocessable Entity`. Requests with more than 50 items also return
+`422 Unprocessable Entity`. Each item must be a string. Syntax errors are
+handled per item and do not return a 4xx — the API returns `200 OK` with
+`syntax_valid: false` and `valid: false` for each invalid email.
+
 
 ## Response Envelope
 
@@ -85,6 +109,51 @@ Response:
     "suggestion": null
   },
   "metadata": { "timestamp": "2026-01-01T00:00:00Z" }
+}
+```
+
+Batch Response:
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "email": "user@gmail.com",
+        "valid": true,
+        "syntax_valid": true,
+        "mx_valid": true,
+        "disposable": false,
+        "normalized": "user@gmail.com",
+        "domain": "gmail.com",
+        "suggestion": null
+      },
+      {
+        "email": "user@gmial.com",
+        "valid": false,
+        "syntax_valid": true,
+        "mx_valid": false,
+        "disposable": false,
+        "normalized": "user@gmial.com",
+        "domain": "gmial.com",
+        "suggestion": "gmail.com"
+      },
+      {
+        "email": null,
+        "valid": false,
+        "syntax_valid": false,
+        "mx_valid": false,
+        "disposable": false,
+        "normalized": null,
+        "domain": null,
+        "suggestion": null
+      }
+    ],
+    "total": 3
+  },
+  "metadata": {
+    "timestamp": "2026-01-01T00:00:00Z"
+  }
 }
 ```
 


### PR DESCRIPTION
Adds a batch email validation endpoint to the Email Validator API.

- Added `/v1/validation/email/batch` endpoint
- Supports up to 50 emails per request
- Updated API documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch email validation endpoint supporting 1–50 emails per request; preserves single-email validation behavior
  * Returns per-email results: syntax validity, MX check, disposability, normalized email, domain, and typo suggestions
  * Invalid emails are reported in-band without failing the entire request

* **Documentation**
  * Added API docs, examples, and overview for the batch endpoint; updated API catalog

* **Tests**
  * Added server- and validation-level tests covering limits, ordering, mixed inputs, and per-item responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->