### PR TITLE
feat(holidays): add batch endpoint POST /v1/places/holidays/batch

### DIFF
--- a/apps/api/services/places/holidays/service.go
+++ b/apps/api/services/places/holidays/service.go
@@ -34,3 +34,35 @@ func (s *Service) GetHolidays(country string, year int) (HolidayList, error) {
 		Total:    len(holidayList),
 	}, nil
 }
+
+// GetHolidaysBatch returns holidays for each (country, year) pair in the given
+// slice. Pairs with no data are returned with Found: false instead of failing
+// the entire request (partial failure pattern).
+func (s *Service) GetHolidaysBatch(queries []BatchQuery) BatchResponse {
+	results := make([]BatchItem, len(queries))
+
+	for i, q := range queries {
+		list, err := s.GetHolidays(q.Country, q.Year)
+		if err != nil {
+			results[i] = BatchItem{
+				Country: q.Country,
+				Year:    q.Year,
+				Found:   false,
+			}
+			continue
+		}
+
+		results[i] = BatchItem{
+			Country:  list.Country,
+			Year:     list.Year,
+			Found:    true,
+			Holidays: list.Holidays,
+			Total:    list.Total,
+		}
+	}
+
+	return BatchResponse{
+		Results: results,
+		Total:   len(results),
+	}
+}

--- a/apps/api/services/places/holidays/service_test.go
+++ b/apps/api/services/places/holidays/service_test.go
@@ -89,3 +89,74 @@ func TestService_GetHolidays_InvalidCountry(t *testing.T) {
 		t.Errorf("expected error message to contain 'no holidays found', got %q", err.Error())
 	}
 }
+
+// ---- batch service tests ----
+
+func TestService_GetHolidaysBatch_AllFound(t *testing.T) {
+	svc := NewService()
+
+	queries := []BatchQuery{
+		{Country: "US", Year: 2025},
+		{Country: "GB", Year: 2025},
+	}
+
+	resp := svc.GetHolidaysBatch(queries)
+
+	if resp.Total != 2 {
+		t.Errorf("expected total 2, got %d", resp.Total)
+	}
+	for _, item := range resp.Results {
+		if !item.Found {
+			t.Errorf("expected found=true for %s %d", item.Country, item.Year)
+		}
+		if len(item.Holidays) == 0 {
+			t.Errorf("expected non-empty holidays for %s %d", item.Country, item.Year)
+		}
+	}
+}
+
+func TestService_GetHolidaysBatch_PartialFailure(t *testing.T) {
+	svc := NewService()
+
+	queries := []BatchQuery{
+		{Country: "US", Year: 2025},
+		{Country: "AQ", Year: 2025}, // valid ISO code (Antarctica) but no holiday data — triggers found:false
+	}
+
+	resp := svc.GetHolidaysBatch(queries)
+
+	if resp.Total != 2 {
+		t.Errorf("expected total 2, got %d", resp.Total)
+	}
+	if !resp.Results[0].Found {
+		t.Error("expected Results[0] (US) to be found")
+	}
+	if resp.Results[1].Found {
+		t.Error("expected Results[1] (ZZ) to be not found")
+	}
+	if len(resp.Results[1].Holidays) != 0 {
+		t.Error("expected empty holidays slice for not-found item")
+	}
+}
+
+func TestService_GetHolidaysBatch_PreservesOrder(t *testing.T) {
+	svc := NewService()
+
+	queries := []BatchQuery{
+		{Country: "DE", Year: 2025},
+		{Country: "AR", Year: 2024},
+		{Country: "JP", Year: 2025},
+	}
+
+	resp := svc.GetHolidaysBatch(queries)
+
+	if resp.Results[0].Country != "DE" {
+		t.Errorf("expected Results[0] country DE, got %s", resp.Results[0].Country)
+	}
+	if resp.Results[1].Country != "AR" {
+		t.Errorf("expected Results[1] country AR, got %s", resp.Results[1].Country)
+	}
+	if resp.Results[2].Country != "JP" {
+		t.Errorf("expected Results[2] country JP, got %s", resp.Results[2].Country)
+	}
+}

--- a/apps/api/services/places/holidays/transport_http.go
+++ b/apps/api/services/places/holidays/transport_http.go
@@ -1,6 +1,7 @@
 package holidays
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -31,4 +32,12 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, resp)
 	})
+
+	// POST /holidays/batch — return holidays for up to 50 (country, year) pairs at once.
+	// Uses HandleBatch so the gateway charges one credit per query (X-Usage-Count).
+	r.Post("/holidays/batch", httpx.HandleBatch(
+		func(_ context.Context, req BatchRequest) (BatchResponse, int, error) {
+			return svc.GetHolidaysBatch(req.Queries), len(req.Queries), nil
+		},
+	))
 }

--- a/apps/api/services/places/holidays/transport_http_test.go
+++ b/apps/api/services/places/holidays/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -145,5 +146,107 @@ func TestHolidays_LowercaseCountry(t *testing.T) {
 
 	if resp.Data.Country != "US" {
 		t.Errorf("expected country 'US', got %q", resp.Data.Country)
+	}
+}
+
+// ---- batch endpoint tests ----
+
+func TestHolidaysBatch_ValidRequest(t *testing.T) {
+	r := setupRouter(t)
+
+	body := `{"queries":[{"country":"US","year":2025},{"country":"GB","year":2025}]}`
+	req := httptest.NewRequest(http.MethodPost, "/holidays/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp httpx.Response[BatchResponse]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode batch response: %v", err)
+	}
+
+	if resp.Data.Total != 2 {
+		t.Errorf("expected total 2, got %d", resp.Data.Total)
+	}
+	for _, item := range resp.Data.Results {
+		if !item.Found {
+			t.Errorf("expected found=true for %s %d", item.Country, item.Year)
+		}
+	}
+}
+
+func TestHolidaysBatch_SetsUsageCountHeader(t *testing.T) {
+	r := setupRouter(t)
+
+	body := `{"queries":[{"country":"US","year":2025},{"country":"DE","year":2025}]}`
+	req := httptest.NewRequest(http.MethodPost, "/holidays/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Usage-Count"); got != "2" {
+		t.Errorf("expected X-Usage-Count: 2, got %q", got)
+	}
+}
+
+func TestHolidaysBatch_PartialFailure(t *testing.T) {
+	r := setupRouter(t)
+
+	// AQ (Antarctica) is a valid ISO 3166-1 alpha-2 code but has no holiday data,
+	// so it passes input validation and triggers the found:false path in the service.
+	body := `{"queries":[{"country":"US","year":2025},{"country":"AQ","year":2025}]}`
+	req := httptest.NewRequest(http.MethodPost, "/holidays/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp httpx.Response[BatchResponse]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode batch response: %v", err)
+	}
+
+	if resp.Data.Results[0].Found != true {
+		t.Error("expected Results[0] (US) to be found")
+	}
+	if resp.Data.Results[1].Found != false {
+		t.Error("expected Results[1] (AQ) to be not found")
+	}
+}
+
+func TestHolidaysBatch_EmptyQueries(t *testing.T) {
+	r := setupRouter(t)
+
+	body := `{"queries":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/holidays/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status 422, got %d", w.Code)
+	}
+}
+
+func TestHolidaysBatch_MissingBody(t *testing.T) {
+	r := setupRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/holidays/batch", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status 422, got %d", w.Code)
 	}
 }

--- a/apps/api/services/places/holidays/type.go
+++ b/apps/api/services/places/holidays/type.go
@@ -20,3 +20,33 @@ type HolidayList struct {
 }
 
 func (HolidayList) IsData() {}
+
+// BatchQuery holds a single (country, year) pair within a batch request.
+type BatchQuery struct {
+	Country string `json:"country" validate:"required,iso3166_1_alpha2"`
+	Year    int    `json:"year" validate:"required,min=1"`
+}
+
+// BatchRequest is the body for POST /holidays/batch.
+// Up to 50 (country, year) pairs may be submitted in a single call.
+type BatchRequest struct {
+	Queries []BatchQuery `json:"queries" validate:"required,min=1,max=50,dive"`
+}
+
+// BatchItem holds the result for a single (country, year) pair in a batch response.
+// Found is false when no holidays exist for that combination.
+type BatchItem struct {
+	Country  string    `json:"country"`
+	Year     int       `json:"year"`
+	Found    bool      `json:"found"`
+	Holidays []Holiday `json:"holidays,omitempty"`
+	Total    int       `json:"total,omitempty"`
+}
+
+// BatchResponse is the response payload for POST /v1/places/holidays/batch.
+type BatchResponse struct {
+	Results []BatchItem `json:"results"`
+	Total   int         `json:"total"`
+}
+
+func (BatchResponse) IsData() {}

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -372,7 +372,7 @@ apis:
     categories:
       - places
     description: Get a list of holidays for a specific country and year
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: false
     documentation_url: /apis/holidays

--- a/apps/dashboard/config/api_docs/holidays.yml
+++ b/apps/dashboard/config/api_docs/holidays.yml
@@ -17,6 +17,7 @@ overview:
     - National and public holidays
     - Yearly calendar data
     - Fast response times
+    - Batch endpoint for up to 50 (country, year) pairs per request
 
 endpoints:
   - name: Get Holidays
@@ -88,6 +89,133 @@ endpoints:
         status: 404
         description: No holidays found for the specified country and year
 
+  - name: Batch Get Holidays
+    method: POST
+    path: /v1/places/holidays/batch
+    description: Returns holidays for up to 50 (country, year) pairs in a single request. Each pair is processed independently — if one combination has no data, it returns found:false without failing the entire batch.
+
+    parameters:
+      - name: queries
+        type: array
+        required: true
+        location: body
+        description: "Array of (country, year) pairs. Min: 1, Max: 50."
+        example: '[{"country":"US","year":2025},{"country":"AR","year":2024}]'
+
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "country": "US",
+              "year": 2025,
+              "found": true,
+              "holidays": [
+                { "date": "2025-01-01", "name": "New Year's Day" },
+                { "date": "2025-07-04", "name": "Independence Day" }
+              ],
+              "total": 11
+            },
+            {
+              "country": "AR",
+              "year": 2024,
+              "found": true,
+              "holidays": [
+                { "date": "2024-01-01", "name": "Año Nuevo" }
+              ],
+              "total": 19
+            },
+            {
+              "country": "ZZ",
+              "year": 2025,
+              "found": false
+            }
+          ],
+          "total": 3
+        },
+        "metadata": {
+          "timestamp": "2025-01-15T10:30:00Z"
+        }
+      }
+
+    response_fields:
+      - name: results
+        type: array
+        description: One result per query, in the same order as the request
+      - name: results[].country
+        type: string
+        description: ISO 3166-1 alpha-2 country code
+      - name: results[].year
+        type: integer
+        description: Year queried
+      - name: results[].found
+        type: boolean
+        description: false when no holidays exist for that country/year combination
+      - name: results[].holidays
+        type: array
+        description: List of holidays. Omitted when found is false.
+      - name: results[].total
+        type: integer
+        description: Number of holidays. Omitted when found is false.
+      - name: total
+        type: integer
+        description: Total number of results (equals the number of queries sent)
+
+    errors:
+      - code: bad_request
+        status: 400
+        description: Malformed request body
+      - code: validation_failed
+        status: 422
+        description: queries is missing, empty, exceeds 50 items, or contains invalid country codes or years
+
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/places/holidays/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"queries":[{"country":"US","year":2025},{"country":"AR","year":2024}]}'
+
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/places/holidays/batch"
+        headers = {"requiems-api-key": "YOUR_API_KEY"}
+        body = {
+            "queries": [
+                {"country": "US", "year": 2025},
+                {"country": "AR", "year": 2024},
+            ]
+        }
+
+        response = requests.post(url, headers=headers, json=body)
+        for result in response.json()["data"]["results"]:
+            if result["found"]:
+                print(f"{result['country']} {result['year']}: {result['total']} holidays")
+            else:
+                print(f"{result['country']} {result['year']}: not found")
+
+      javascript: |
+        const response = await fetch('https://api.requiems.xyz/v1/places/holidays/batch', {
+          method: 'POST',
+          headers: {
+            'requiems-api-key': 'YOUR_API_KEY',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            queries: [
+              { country: 'US', year: 2025 },
+              { country: 'AR', year: 2024 }
+            ]
+          })
+        });
+
+        const { data } = await response.json();
+        data.results.forEach(r => {
+          if (r.found) console.log(`${r.country} ${r.year}: ${r.total} holidays`);
+          else console.log(`${r.country} ${r.year}: not found`);
+        });
+
     code_examples:
       curl: |
         curl "https://api.requiems.xyz/v1/places/holidays?country=US&year=2025" \
@@ -136,5 +264,5 @@ faq:
   - question: What types of holidays are included?
     answer: The API returns national and public holidays for each country, including federal holidays, bank holidays, and widely observed holidays. Religious and regional holidays may vary by country.
 
-  - question: Can I get holidays for multiple years?
-    answer: Currently, holidays are returned for a single year per request. To get holidays across multiple years, make separate requests for each year.
+  - question: Can I get holidays for multiple countries or years at once?
+    answer: Yes. Use the batch endpoint (POST /v1/places/holidays/batch) to query up to 50 (country, year) combinations in a single request. Each pair is resolved independently, so a missing combination returns found:false without affecting the rest of the results.

--- a/apps/dashboard/config/api_docs/holidays.yml
+++ b/apps/dashboard/config/api_docs/holidays.yml
@@ -89,6 +89,47 @@ endpoints:
         status: 404
         description: No holidays found for the specified country and year
 
+    code_examples:
+      curl: |
+        curl "https://api.requiems.xyz/v1/places/holidays?country=US&year=2025" \
+          -H "requiems-api-key: YOUR_API_KEY"
+
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/places/holidays"
+        params = {"country": "US", "year": 2025}
+        headers = {"requiems-api-key": "YOUR_API_KEY"}
+
+        response = requests.get(url, headers=headers, params=params)
+        print(response.json())
+
+      javascript: |
+        const response = await fetch('https://api.requiems.xyz/v1/places/holidays?country=US&year=2025', {
+          headers: {
+            'requiems-api-key': 'YOUR_API_KEY'
+          }
+        });
+
+        const data = await response.json();
+        console.log(data.data.holidays);
+
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/places/holidays')
+        uri.query = URI.encode_www_form(country: 'US', year: 2025)
+        request = Net::HTTP::Get.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        data = JSON.parse(response.body)
+        puts data['data']['holidays']
+
   - name: Batch Get Holidays
     method: POST
     path: /v1/places/holidays/batch
@@ -126,7 +167,7 @@ endpoints:
               "total": 19
             },
             {
-              "country": "ZZ",
+              "country": "AQ",
               "year": 2025,
               "found": false
             }
@@ -215,47 +256,6 @@ endpoints:
           if (r.found) console.log(`${r.country} ${r.year}: ${r.total} holidays`);
           else console.log(`${r.country} ${r.year}: not found`);
         });
-
-    code_examples:
-      curl: |
-        curl "https://api.requiems.xyz/v1/places/holidays?country=US&year=2025" \
-          -H "requiems-api-key: YOUR_API_KEY"
-
-      python: |
-        import requests
-
-        url = "https://api.requiems.xyz/v1/places/holidays"
-        params = {"country": "US", "year": 2025}
-        headers = {"requiems-api-key": "YOUR_API_KEY"}
-
-        response = requests.get(url, headers=headers, params=params)
-        print(response.json())
-
-      javascript: |
-        const response = await fetch('https://api.requiems.xyz/v1/places/holidays?country=US&year=2025', {
-          headers: {
-            'requiems-api-key': 'YOUR_API_KEY'
-          }
-        });
-
-        const data = await response.json();
-        console.log(data.data.holidays);
-
-      ruby: |
-        require 'net/http'
-        require 'json'
-
-        uri = URI('https://api.requiems.xyz/v1/places/holidays')
-        uri.query = URI.encode_www_form(country: 'US', year: 2025)
-        request = Net::HTTP::Get.new(uri)
-        request['requiems-api-key'] = 'YOUR_API_KEY'
-
-        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-          http.request(request)
-        end
-
-        data = JSON.parse(response.body)
-        puts data['data']['holidays']
 
 faq:
   - question: Which countries are supported?


### PR DESCRIPTION
- Add BatchQuery, BatchRequest, BatchItem, BatchResponse types
- Implement GetHolidaysBatch in service (partial failure pattern)
- Register POST /holidays/batch route via httpx.HandleBatch
- Update api_catalog.yml endpoints_count to 2
- Update holidays.yml docs with batch endpoint, parameters and examples
- Add service and HTTP tests for batch (allFound, partialFailure, order, usage header)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a POST /v1/places/holidays/batch endpoint to request holidays for up to 50 country-year pairs in one call. Responses include per-item found/holidays info and an overall total.

* **Documentation**
  * Updated API docs and FAQ to describe the new batch capability and per-item resolution behavior.

* **Behavior**
  * Responses include a usage/count header and return validation errors (HTTP 422) for invalid or empty batch requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->