### PR TITLE
Refactor/remove http references from services

### DIFF
--- a/apps/api/cmd/seed-commodities/source.go
+++ b/apps/api/cmd/seed-commodities/source.go
@@ -144,7 +144,7 @@ type yahooChart struct {
 			Timestamps []int64 `json:"timestamp"`
 			Indicators struct {
 				Quote []struct {
-					Close []interface{} `json:"close"`
+					Close []any `json:"close"`
 				} `json:"quote"`
 			} `json:"indicators"`
 		} `json:"result"`
@@ -236,7 +236,7 @@ func parseFREDRow(record []string) (val float64, year int, ok bool) {
 }
 
 // parseYahooClose extracts a positive finite float64 from closes at index i.
-func parseYahooClose(closes []interface{}, i int) (float64, bool) {
+func parseYahooClose(closes []any, i int) (float64, bool) {
 	if i >= len(closes) || closes[i] == nil {
 		return 0, false
 	}

--- a/apps/api/cmd/seed-commodities/source_test.go
+++ b/apps/api/cmd/seed-commodities/source_test.go
@@ -43,7 +43,7 @@ func TestParseFREDRow(t *testing.T) {
 func TestParseYahooClose(t *testing.T) {
 	t.Parallel()
 
-	closes := []interface{}{
+	closes := []any{
 		float64(1234.56),
 		nil,
 		json.Number("99.99"),

--- a/apps/api/cmd/seed-exercises/source_test.go
+++ b/apps/api/cmd/seed-exercises/source_test.go
@@ -59,7 +59,7 @@ func TestLoadExercises_SkipsMissingIDOrName(t *testing.T) {
 func TestLoadExercises_NilSlicesNormalised(t *testing.T) {
 	t.Parallel()
 
-	exercises := []map[string]interface{}{
+	exercises := []map[string]any{
 		{"exerciseId": "ex004", "name": "Squat"}, // omit all slice fields
 	}
 

--- a/apps/api/cmd/seed-exercises/source_test.go
+++ b/apps/api/cmd/seed-exercises/source_test.go
@@ -13,7 +13,7 @@ import (
 func TestLoadExercises_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	exercises := []map[string]interface{}{
+	exercises := []map[string]any{
 		{
 			"exerciseId":       "ex001",
 			"name":             "Push-up",
@@ -43,7 +43,7 @@ func TestLoadExercises_HappyPath(t *testing.T) {
 func TestLoadExercises_SkipsMissingIDOrName(t *testing.T) {
 	t.Parallel()
 
-	exercises := []map[string]interface{}{
+	exercises := []map[string]any{
 		{"exerciseId": "", "name": "No ID Exercise"},               // missing ID
 		{"exerciseId": "ex002", "name": ""},                        // missing name
 		{"exerciseId": "ex003", "name": "Valid", "bodyParts": nil}, // valid — nil fields normalised
@@ -95,7 +95,7 @@ func TestLoadExercises_InvalidJSON(t *testing.T) {
 
 // writeExercisesJSON marshals exercises to exercises.json in a temp dir and
 // returns the dir path.
-func writeExercisesJSON(t *testing.T, exercises interface{}) string {
+func writeExercisesJSON(t *testing.T, exercises any) string {
 	t.Helper()
 
 	dir := t.TempDir()

--- a/apps/api/platform/httpx/errors.go
+++ b/apps/api/platform/httpx/errors.go
@@ -15,17 +15,3 @@ type ValidationFailure struct {
 
 func (e *ValidationFailure) Error() string { return "validation_failed" }
 
-// AppError is a typed error the service layer can return to signal a specific
-// HTTP status code and error code to the client. The Handle wrapper maps it
-// automatically.
-//
-// Example:
-//
-//	return nil, &httpx.AppError{Status: 404, Code: "not_found", Message: "resource not found"}
-type AppError struct {
-	Code    string
-	Message string
-	Status  int
-}
-
-func (e *AppError) Error() string { return e.Message }

--- a/apps/api/platform/httpx/errors.go
+++ b/apps/api/platform/httpx/errors.go
@@ -14,4 +14,3 @@ type ValidationFailure struct {
 }
 
 func (e *ValidationFailure) Error() string { return "validation_failed" }
-

--- a/apps/api/platform/httpx/handler.go
+++ b/apps/api/platform/httpx/handler.go
@@ -54,8 +54,7 @@ func Handle[Req any, Res Data](
 				Error(w, ae.Status, ae.Code, ae.Message)
 				return
 			}
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
@@ -93,8 +92,7 @@ func HandleBatch[Req any, Res Data](
 				Error(w, ae.Status, ae.Code, ae.Message)
 				return
 			}
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/platform/httpx/handler.go
+++ b/apps/api/platform/httpx/handler.go
@@ -54,10 +54,16 @@ func Handle[Req any, Res Data](
 				Error(w, ae.Status, ae.Code, ae.Message)
 				return
 			}
+			
 			if se, ok := errors.AsType[*svcerr.Error](err); ok {
+				if se.Kind == svcerr.KindUpstream {
+					sentry.CaptureException(err)
+				}
+
 				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
+
 			sentry.CaptureException(err)
 			Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
 			return
@@ -93,6 +99,9 @@ func HandleBatch[Req any, Res Data](
 				return
 			}
 			if se, ok := errors.AsType[*svcerr.Error](err); ok {
+				if se.Kind == svcerr.KindUpstream {
+					sentry.CaptureException(err)
+				}
 				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/platform/httpx/handler.go
+++ b/apps/api/platform/httpx/handler.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	sentry "github.com/getsentry/sentry-go"
+
+	"requiems-api/platform/svcerr"
 )
 
 // Handle wraps an endpoint function with automatic JSON binding, validation,
@@ -52,7 +54,11 @@ func Handle[Req any, Res Data](
 				Error(w, ae.Status, ae.Code, ae.Message)
 				return
 			}
-
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
+				return
+			}
 			sentry.CaptureException(err)
 			Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
 			return
@@ -85,6 +91,11 @@ func HandleBatch[Req any, Res Data](
 		if err != nil {
 			if ae, ok := errors.AsType[*AppError](err); ok {
 				Error(w, ae.Status, ae.Code, ae.Message)
+				return
+			}
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			sentry.CaptureException(err)

--- a/apps/api/platform/httpx/handler.go
+++ b/apps/api/platform/httpx/handler.go
@@ -19,7 +19,7 @@ import (
 //
 // Error mapping:
 //   - *ValidationFailure  → 422 with {"error":"validation_failed","fields":[...]}
-//   - *AppError           → AppError.Status with {"error":Code,"message":Message}
+//   - *svcerr.Error       → mapped HTTP status with {"error":Code,"message":Message}
 //   - any other error     → 500 with {"error":"internal_error"}
 //
 // Usage:
@@ -50,11 +50,6 @@ func Handle[Req any, Res Data](
 		res, err := fn(r.Context(), req)
 
 		if err != nil {
-			if ae, ok := errors.AsType[*AppError](err); ok {
-				Error(w, ae.Status, ae.Code, ae.Message)
-				return
-			}
-			
 			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				if se.Kind == svcerr.KindUpstream {
 					sentry.CaptureException(err)
@@ -94,10 +89,6 @@ func HandleBatch[Req any, Res Data](
 
 		res, count, err := fn(r.Context(), req)
 		if err != nil {
-			if ae, ok := errors.AsType[*AppError](err); ok {
-				Error(w, ae.Status, ae.Code, ae.Message)
-				return
-			}
 			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				if se.Kind == svcerr.KindUpstream {
 					sentry.CaptureException(err)

--- a/apps/api/platform/httpx/handler_test.go
+++ b/apps/api/platform/httpx/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // handleReq / handleRes are minimal request and response types used across
@@ -84,11 +85,11 @@ func TestHandle_ValidationFailure_Returns422(t *testing.T) {
 	assert.NotEmpty(t, resp.Fields)
 }
 
-func TestHandle_AppError_MapsStatus(t *testing.T) {
+func TestHandle_SvcError_MapsStatus(t *testing.T) {
 	t.Parallel()
 
 	h := httpx.Handle(func(_ context.Context, req handleReq) (handleRes, error) {
-		return handleRes{}, &httpx.AppError{Status: http.StatusTeapot, Code: "im_a_teapot", Message: "brew something"}
+		return handleRes{}, svcerr.NotFound("not_found", "resource not found")
 	})
 
 	body := strings.NewReader(`{"name":"x"}`)
@@ -96,12 +97,12 @@ func TestHandle_AppError_MapsStatus(t *testing.T) {
 	w := httptest.NewRecorder()
 	h(w, r)
 
-	assert.Equal(t, http.StatusTeapot, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	var resp httpx.ErrorResponse
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
-	assert.Equal(t, "im_a_teapot", resp.Error)
+	assert.Equal(t, "not_found", resp.Error)
 }
 
 func TestHandle_InternalError_Returns500(t *testing.T) {
@@ -155,11 +156,11 @@ func TestHandleBatch_ValidationFailure_Returns422(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
-func TestHandleBatch_AppError_MapsStatus(t *testing.T) {
+func TestHandleBatch_SvcError_MapsStatus(t *testing.T) {
 	t.Parallel()
 
 	h := httpx.HandleBatch(func(_ context.Context, req handleReq) (handleRes, int, error) {
-		return handleRes{}, 0, &httpx.AppError{Status: http.StatusBadGateway, Code: "bad_gateway", Message: "upstream down"}
+		return handleRes{}, 0, svcerr.Upstream("upstream_error", "upstream down")
 	})
 
 	body := strings.NewReader(`{"name":"x"}`)
@@ -167,7 +168,7 @@ func TestHandleBatch_AppError_MapsStatus(t *testing.T) {
 	w := httptest.NewRecorder()
 	h(w, r)
 
-	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
 func TestHandleBatch_InternalError_Returns500(t *testing.T) {

--- a/apps/api/platform/httpx/handler_test.go
+++ b/apps/api/platform/httpx/handler_test.go
@@ -185,3 +185,24 @@ func TestHandleBatch_InternalError_Returns500(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+func TestHandle_BodyTooLarge_Returns400(t *testing.T) {
+	t.Parallel()
+
+	h := httpx.Handle(func(_ context.Context, req handleReq) (handleRes, error) {
+		return handleRes{}, nil
+	})
+
+	big := strings.NewReader(`{"name":"` + strings.Repeat("x", 1<<20+1) + `"}`)
+	r := httptest.NewRequest(http.MethodPost, "/", big)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp httpx.ErrorResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Message, "too large")
+}

--- a/apps/api/platform/svcerr/svcerr.go
+++ b/apps/api/platform/svcerr/svcerr.go
@@ -1,5 +1,7 @@
 package svcerr
 
+import "net/http"
+
 // Kind classifies a service error so the HTTP layer can map it to a status code.
 type Kind int
 
@@ -10,7 +12,7 @@ const (
 	KindUpstream             // 503
 )
 
-// Error is a transport-agnostic service error. Services return this type;
+// A transport-agnostic service error. Services return this type;
 // the HTTP layer maps Kind to an HTTP status code.
 type Error struct {
 	Kind    Kind
@@ -20,19 +22,19 @@ type Error struct {
 
 func (e *Error) Error() string { return e.Message }
 
-// HTTPStatus returns the HTTP status code that corresponds to the error kind.
+// Returns the HTTP status code that corresponds to the error kind.
 func HTTPStatus(e *Error) int {
 	switch e.Kind {
 	case KindNotFound:
-		return 404
+		return http.StatusNotFound
 	case KindInvalid:
-		return 400
+		return http.StatusBadRequest
 	case KindUnknown:
-		return 422
+		return http.StatusUnprocessableEntity
 	case KindUpstream:
-		return 503
+		return http.StatusServiceUnavailable
 	}
-	return 500
+	return http.StatusInternalServerError
 }
 
 func NotFound(code, msg string) *Error { return &Error{Kind: KindNotFound, Code: code, Message: msg} }

--- a/apps/api/platform/svcerr/svcerr.go
+++ b/apps/api/platform/svcerr/svcerr.go
@@ -1,0 +1,41 @@
+package svcerr
+
+// Kind classifies a service error so the HTTP layer can map it to a status code.
+type Kind int
+
+const (
+	KindNotFound Kind = iota // 404
+	KindInvalid              // 400
+	KindUnknown              // 422
+	KindUpstream             // 503
+)
+
+// Error is a transport-agnostic service error. Services return this type;
+// the HTTP layer maps Kind to an HTTP status code.
+type Error struct {
+	Kind    Kind
+	Code    string
+	Message string
+}
+
+func (e *Error) Error() string { return e.Message }
+
+// HTTPStatus returns the HTTP status code that corresponds to the error kind.
+func HTTPStatus(e *Error) int {
+	switch e.Kind {
+	case KindNotFound:
+		return 404
+	case KindInvalid:
+		return 400
+	case KindUnknown:
+		return 422
+	case KindUpstream:
+		return 503
+	}
+	return 500
+}
+
+func NotFound(code, msg string) *Error { return &Error{Kind: KindNotFound, Code: code, Message: msg} }
+func Invalid(code, msg string) *Error  { return &Error{Kind: KindInvalid, Code: code, Message: msg} }
+func Unknown(code, msg string) *Error  { return &Error{Kind: KindUnknown, Code: code, Message: msg} }
+func Upstream(code, msg string) *Error { return &Error{Kind: KindUpstream, Code: code, Message: msg} }

--- a/apps/api/platform/svcerr/svcerr.go
+++ b/apps/api/platform/svcerr/svcerr.go
@@ -24,6 +24,9 @@ func (e *Error) Error() string { return e.Message }
 
 // Returns the HTTP status code that corresponds to the error kind.
 func HTTPStatus(e *Error) int {
+	if e == nil {
+		return http.StatusInternalServerError
+	}
 	switch e.Kind {
 	case KindNotFound:
 		return http.StatusNotFound

--- a/apps/api/platform/svcerr/svcerr_test.go
+++ b/apps/api/platform/svcerr/svcerr_test.go
@@ -1,0 +1,74 @@
+package svcerr
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPStatus_Nil(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, http.StatusInternalServerError, HTTPStatus(nil))
+}
+
+func TestHTTPStatus_AllKinds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		kind Kind
+		want int
+	}{
+		{KindNotFound, http.StatusNotFound},
+		{KindInvalid, http.StatusBadRequest},
+		{KindUnknown, http.StatusUnprocessableEntity},
+		{KindUpstream, http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		e := &Error{Kind: tc.kind}
+		assert.Equal(t, tc.want, HTTPStatus(e))
+	}
+}
+
+func TestHTTPStatus_UnknownKind(t *testing.T) {
+	t.Parallel()
+	e := &Error{Kind: Kind(999)}
+	assert.Equal(t, http.StatusInternalServerError, HTTPStatus(e))
+}
+
+func TestError_ErrorMethod(t *testing.T) {
+	t.Parallel()
+	e := &Error{Message: "something went wrong"}
+	assert.Equal(t, "something went wrong", e.Error())
+}
+
+func TestNotFound_Fields(t *testing.T) {
+	t.Parallel()
+	e := NotFound("not_found", "resource missing")
+	assert.Equal(t, KindNotFound, e.Kind)
+	assert.Equal(t, "not_found", e.Code)
+	assert.Equal(t, "resource missing", e.Message)
+}
+
+func TestInvalid_Fields(t *testing.T) {
+	t.Parallel()
+	e := Invalid("bad_input", "input is bad")
+	assert.Equal(t, KindInvalid, e.Kind)
+	assert.Equal(t, "bad_input", e.Code)
+	assert.Equal(t, "input is bad", e.Message)
+}
+
+func TestUnknown_Fields(t *testing.T) {
+	t.Parallel()
+	e := Unknown("unprocessable", "cannot process")
+	assert.Equal(t, KindUnknown, e.Kind)
+	assert.Equal(t, "unprocessable", e.Code)
+	assert.Equal(t, "cannot process", e.Message)
+}
+
+func TestUpstream_Fields(t *testing.T) {
+	t.Parallel()
+	e := Upstream("upstream_error", "service down")
+	assert.Equal(t, KindUpstream, e.Kind)
+	assert.Equal(t, "upstream_error", e.Code)
+	assert.Equal(t, "service down", e.Message)
+}

--- a/apps/api/services/entertainment/sudoku/service.go
+++ b/apps/api/services/entertainment/sudoku/service.go
@@ -1,6 +1,7 @@
 package sudoku
 
 import (
+	"fmt"
 	"math/rand/v2"
 )
 
@@ -38,10 +39,10 @@ func NewService() *Service {
 }
 
 // Generate returns a new Sudoku puzzle at the requested difficulty level.
-// The default difficulty is "medium".
-func (s *Service) Generate(difficulty string) Puzzle {
+// Returns an error if difficulty is not one of: easy, medium, hard.
+func (s *Service) Generate(difficulty string) (Puzzle, error) {
 	if _, ok := cellsToRemove[difficulty]; !ok {
-		difficulty = "medium"
+		return Puzzle{}, fmt.Errorf("invalid difficulty %q: must be one of easy, medium, hard", difficulty)
 	}
 
 	rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // Good enough for puzzle generation.
@@ -52,17 +53,21 @@ func (s *Service) Generate(difficulty string) Puzzle {
 		Difficulty: difficulty,
 		Puzzle:     puzzle,
 		Solution:   solution,
-	}
+	}, nil
 }
 
 // GenerateBatch generates multiple Sudoku puzzles from the given difficulty list.
-// Results are returned in the same order as the input slice.
-func (s *Service) GenerateBatch(difficulties []string) []Puzzle {
+// Returns an error if any difficulty value is invalid.
+func (s *Service) GenerateBatch(difficulties []string) ([]Puzzle, error) {
 	results := make([]Puzzle, len(difficulties))
 	for i, d := range difficulties {
-		results[i] = s.Generate(d)
+		p, err := s.Generate(d)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = p
 	}
-	return results
+	return results, nil
 }
 
 // shuffle produces a new valid solution by permuting the base grid.

--- a/apps/api/services/entertainment/sudoku/service_test.go
+++ b/apps/api/services/entertainment/sudoku/service_test.go
@@ -1,0 +1,34 @@
+package sudoku
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_InvalidDifficulty(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	p, err := svc.Generate("impossible")
+	require.Error(t, err)
+	assert.Equal(t, Puzzle{}, p)
+}
+
+func TestGenerateBatch_InvalidDifficultyPropagates(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	_, err := svc.GenerateBatch([]string{"easy", "impossible"})
+	require.Error(t, err)
+}
+
+func TestGenerateBatch_AllValid(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	results, err := svc.GenerateBatch([]string{"easy", "medium", "hard"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, "easy", results[0].Difficulty)
+	assert.Equal(t, "medium", results[1].Difficulty)
+	assert.Equal(t, "hard", results[2].Difficulty)
+}

--- a/apps/api/services/entertainment/sudoku/transport_http.go
+++ b/apps/api/services/entertainment/sudoku/transport_http.go
@@ -19,12 +19,20 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 			return
 		}
 
-		httpx.JSON(w, http.StatusOK, svc.Generate(req.Difficulty))
+		puzzle, err := svc.Generate(req.Difficulty)
+		if err != nil {
+			httpx.Error(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		httpx.JSON(w, http.StatusOK, puzzle)
 	})
 
 	r.Post("/sudoku/batch", httpx.HandleBatch(
 		func(_ context.Context, req BatchRequest) (BatchResponse, int, error) {
-			results := svc.GenerateBatch(req.Puzzles)
+			results, err := svc.GenerateBatch(req.Puzzles)
+			if err != nil {
+				return BatchResponse{}, 0, err
+			}
 			return BatchResponse{Results: results, Total: len(results)}, len(results), nil
 		},
 	))

--- a/apps/api/services/entertainment/sudoku/transport_http_test.go
+++ b/apps/api/services/entertainment/sudoku/transport_http_test.go
@@ -79,7 +79,8 @@ func TestSudoku_PuzzleHasEmptyCells(t *testing.T) {
 	for _, d := range []string{"easy", "medium", "hard"} {
 		t.Run(d, func(t *testing.T) {
 			t.Parallel()
-			p := svc.Generate(d)
+			p, err := svc.Generate(d)
+			require.NoError(t, err)
 
 			empty := 0
 			for r := range 9 {
@@ -99,7 +100,8 @@ func TestSudoku_PuzzleHasEmptyCells(t *testing.T) {
 func TestSudoku_SolutionIsComplete(t *testing.T) {
 	t.Parallel()
 	svc := NewService()
-	p := svc.Generate("hard")
+	p, err := svc.Generate("hard")
+	require.NoError(t, err)
 
 	for r := range 9 {
 		for c := range 9 {
@@ -111,7 +113,8 @@ func TestSudoku_SolutionIsComplete(t *testing.T) {
 func TestSudoku_SolutionIsValid(t *testing.T) {
 	t.Parallel()
 	svc := NewService()
-	p := svc.Generate("medium")
+	p, err := svc.Generate("medium")
+	require.NoError(t, err)
 
 	// Check each row contains 1-9.
 	for r := range 9 {
@@ -144,7 +147,8 @@ func TestSudoku_SolutionIsValid(t *testing.T) {
 func TestSudoku_PuzzleMatchesSolution(t *testing.T) {
 	t.Parallel()
 	svc := NewService()
-	p := svc.Generate("easy")
+	p, err := svc.Generate("easy")
+	require.NoError(t, err)
 
 	for r := range 9 {
 		for c := range 9 {

--- a/apps/api/services/finance/bin/service.go
+++ b/apps/api/services/finance/bin/service.go
@@ -103,8 +103,8 @@ func (s *Service) queryBINByPrefix6(ctx context.Context, prefix6 string) (Lookup
 	return r, err
 }
 
-// sanitizeBIN strips common separators, validates that the result is 6–8
-// decimal digits, and returns an *httpx.AppError for client-side failures.
+// sanitizeBIN strips common separators and validates that the result is 6–8
+// decimal digits.
 func sanitizeBIN(raw string) (string, error) {
 	cleaned := strings.Map(func(r rune) rune {
 		if r == '-' || r == ' ' {

--- a/apps/api/services/finance/bin/service.go
+++ b/apps/api/services/finance/bin/service.go
@@ -3,13 +3,12 @@ package bin
 import (
 	"context"
 	"errors"
-	"net/http"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // Service provides BIN lookup against the bin_data PostgreSQL table.
@@ -41,11 +40,7 @@ func (s *Service) Lookup(ctx context.Context, raw string) (LookupResponse, error
 	}
 
 	if errors.Is(err, pgx.ErrNoRows) {
-		return LookupResponse{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "BIN not found",
-		}
+		return LookupResponse{}, svcerr.NotFound("not_found", "BIN not found")
 	}
 	if err != nil {
 		return LookupResponse{}, err
@@ -119,20 +114,12 @@ func sanitizeBIN(raw string) (string, error) {
 	}, strings.TrimSpace(raw))
 
 	if len(cleaned) < 6 || len(cleaned) > 8 {
-		return "", &httpx.AppError{
-			Status:  http.StatusBadRequest,
-			Code:    "bad_request",
-			Message: "BIN must be between 6 and 8 digits",
-		}
+		return "", svcerr.Invalid("bad_request", "BIN must be between 6 and 8 digits")
 	}
 
 	for _, ch := range cleaned {
 		if ch < '0' || ch > '9' {
-			return "", &httpx.AppError{
-				Status:  http.StatusBadRequest,
-				Code:    "bad_request",
-				Message: "BIN must contain digits only",
-			}
+			return "", svcerr.Invalid("bad_request", "BIN must contain digits only")
 		}
 	}
 

--- a/apps/api/services/finance/bin/transport_http.go
+++ b/apps/api/services/finance/bin/transport_http.go
@@ -25,8 +25,7 @@ func registerBINRoutes(r chi.Router, l Looker) {
 
 		result, err := l.Lookup(r.Context(), rawBIN)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/bin/transport_http.go
+++ b/apps/api/services/finance/bin/transport_http.go
@@ -1,11 +1,13 @@
 package bin
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts BIN lookup handlers on the given router.
@@ -23,8 +25,9 @@ func registerBINRoutes(r chi.Router, l Looker) {
 
 		result, err := l.Lookup(r.Context(), rawBIN)
 		if err != nil {
-			if ae, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/apps/api/services/finance/bin/transport_http_test.go
+++ b/apps/api/services/finance/bin/transport_http_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubService implements Looker for transport tests. It returns a fixed result
@@ -96,11 +97,7 @@ func TestBINLookup_ResponseEnvelope(t *testing.T) {
 
 func TestBINLookup_UnknownBIN_Returns404(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusNotFound,
-		Code:    "not_found",
-		Message: "BIN not found",
-	}}
+	svc := &stubService{err: svcerr.NotFound("not_found", "BIN not found")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/bin/999999", http.NoBody)
@@ -112,11 +109,7 @@ func TestBINLookup_UnknownBIN_Returns404(t *testing.T) {
 
 func TestBINLookup_TooShort_Returns400(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusBadRequest,
-		Code:    "bad_request",
-		Message: "BIN must be between 6 and 8 digits",
-	}}
+	svc := &stubService{err: svcerr.Invalid("bad_request", "BIN must be between 6 and 8 digits")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/bin/4242", http.NoBody)
@@ -128,11 +121,7 @@ func TestBINLookup_TooShort_Returns400(t *testing.T) {
 
 func TestBINLookup_TooLong_Returns400(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusBadRequest,
-		Code:    "bad_request",
-		Message: "BIN must be between 6 and 8 digits",
-	}}
+	svc := &stubService{err: svcerr.Invalid("bad_request", "BIN must be between 6 and 8 digits")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/bin/424242424", http.NoBody)
@@ -144,11 +133,7 @@ func TestBINLookup_TooLong_Returns400(t *testing.T) {
 
 func TestBINLookup_NonDigits_Returns400(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusBadRequest,
-		Code:    "bad_request",
-		Message: "BIN must contain digits only",
-	}}
+	svc := &stubService{err: svcerr.Invalid("bad_request", "BIN must contain digits only")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/bin/abcdef", http.NoBody)

--- a/apps/api/services/finance/commodities/service.go
+++ b/apps/api/services/finance/commodities/service.go
@@ -3,12 +3,11 @@ package commodities
 import (
 	"context"
 	"math"
-	"net/http"
 	"strconv"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const historyDepth = 11 // 1 current + 10 historical years
@@ -58,11 +57,7 @@ func (s *Service) Get(ctx context.Context, slug string) (CommodityPrice, error) 
 	}
 
 	if len(results) == 0 {
-		return CommodityPrice{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "commodity not found",
-		}
+		return CommodityPrice{}, svcerr.NotFound("not_found", "commodity not found")
 	}
 
 	latest := results[0]

--- a/apps/api/services/finance/commodities/service_test.go
+++ b/apps/api/services/finance/commodities/service_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubGetter implements Getter for service-layer unit tests.
@@ -80,11 +80,7 @@ func TestStubGetter_ReturnsCommodity(t *testing.T) {
 
 func TestStubGetter_PropagatesError(t *testing.T) {
 	t.Parallel()
-	stub := &stubGetter{err: &httpx.AppError{
-		Status:  404,
-		Code:    "not_found",
-		Message: "commodity not found",
-	}}
+	stub := &stubGetter{err: svcerr.NotFound("not_found", "commodity not found")}
 
 	_, err := stub.Get(context.Background(), "unknown")
 	require.Error(t, err)

--- a/apps/api/services/finance/commodities/transport_http.go
+++ b/apps/api/services/finance/commodities/transport_http.go
@@ -1,11 +1,13 @@
 package commodities
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts commodity price handlers on the given router.
@@ -24,8 +26,9 @@ func registerCommodityRoutes(r chi.Router, g Getter) {
 
 		result, err := g.Get(r.Context(), slug)
 		if err != nil {
-			if ae, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/apps/api/services/finance/commodities/transport_http.go
+++ b/apps/api/services/finance/commodities/transport_http.go
@@ -26,8 +26,7 @@ func registerCommodityRoutes(r chi.Router, g Getter) {
 
 		result, err := g.Get(r.Context(), slug)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/commodities/transport_http_test.go
+++ b/apps/api/services/finance/commodities/transport_http_test.go
@@ -3,6 +3,7 @@ package commodities
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubGetterHTTP implements Getter for transport tests.
@@ -91,11 +93,7 @@ func TestCommodity_ResponseEnvelope(t *testing.T) {
 
 func TestCommodity_UnknownSlug_Returns404(t *testing.T) {
 	t.Parallel()
-	svc := &stubGetterHTTP{err: &httpx.AppError{
-		Status:  http.StatusNotFound,
-		Code:    "not_found",
-		Message: "commodity not found",
-	}}
+	svc := &stubGetterHTTP{err: svcerr.NotFound("not_found", "commodity not found")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/commodities/unobtainium", http.NoBody)
@@ -107,11 +105,7 @@ func TestCommodity_UnknownSlug_Returns404(t *testing.T) {
 
 func TestCommodity_InternalError_Returns500(t *testing.T) {
 	t.Parallel()
-	svc := &stubGetterHTTP{err: &httpx.AppError{
-		Status:  http.StatusInternalServerError,
-		Code:    "internal_error",
-		Message: "internal server error",
-	}}
+	svc := &stubGetterHTTP{err: errors.New("internal server error")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/commodities/gold", http.NoBody)

--- a/apps/api/services/finance/crypto/service.go
+++ b/apps/api/services/finance/crypto/service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const (
@@ -78,11 +78,7 @@ func newServiceWithClient(client *http.Client, baseURL string) *Service {
 func (s *Service) GetPrice(ctx context.Context, symbol string) (Price, error) {
 	coin, ok := coinMap[symbol]
 	if !ok {
-		return Price{}, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "unknown_symbol",
-			Message: fmt.Sprintf("unsupported symbol: %s", symbol),
-		}
+		return Price{}, svcerr.Unknown("unknown_symbol", fmt.Sprintf("unsupported symbol: %s", symbol))
 	}
 
 	if s.rdb != nil {
@@ -146,38 +142,22 @@ func (s *Service) fetchPrice(ctx context.Context, coinID, symbol, name string) (
 
 	resp, err := s.httpClient.Do(req) //nolint:gosec // URL is built from a hardcoded base, not user input
 	if err != nil {
-		return Price{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "crypto price service unavailable",
-		}
+		return Price{}, svcerr.Upstream("upstream_error", "crypto price service unavailable")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return Price{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "crypto price service unavailable",
-		}
+		return Price{}, svcerr.Upstream("upstream_error", "crypto price service unavailable")
 	}
 
 	var body coinGeckoResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return Price{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "crypto price service unavailable",
-		}
+		return Price{}, svcerr.Upstream("upstream_error", "crypto price service unavailable")
 	}
 
 	data, ok := body[coinID]
 	if !ok {
-		return Price{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "crypto price service unavailable",
-		}
+		return Price{}, svcerr.Upstream("upstream_error", "crypto price service unavailable")
 	}
 
 	return Price{

--- a/apps/api/services/finance/crypto/service_test.go
+++ b/apps/api/services/finance/crypto/service_test.go
@@ -89,3 +89,23 @@ func TestGetPrice_NoRedis_CallsUpstream(t *testing.T) {
 
 	assert.Equal(t, 2, callCount, "expected 2 upstream calls (no Redis), got %d", callCount)
 }
+
+func TestGetPrice_CoinMissingFromResponse_Upstream(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a valid JSON body that doesn't include the requested coin ID.
+		body := coinGeckoResponse{}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	svc := newServiceWithClient(srv.Client(), srv.URL)
+	_, err := svc.GetPrice(context.Background(), "BTC")
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
+	assert.Equal(t, "upstream_error", se.Code)
+}

--- a/apps/api/services/finance/crypto/service_test.go
+++ b/apps/api/services/finance/crypto/service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func TestGetPrice_ValidSymbol(t *testing.T) {
@@ -45,10 +45,10 @@ func TestGetPrice_UnknownSymbol(t *testing.T) {
 	_, err := svc.GetPrice(context.Background(), "FAKE")
 	require.Error(t, err)
 
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "unknown_symbol", ae.Code)
-	assert.Equal(t, http.StatusUnprocessableEntity, ae.Status)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "unknown_symbol", se.Code)
+	assert.Equal(t, svcerr.KindUnknown, se.Kind)
 }
 
 func TestGetPrice_UpstreamError(t *testing.T) {
@@ -62,9 +62,9 @@ func TestGetPrice_UpstreamError(t *testing.T) {
 	_, err := svc.GetPrice(context.Background(), "BTC")
 	require.Error(t, err)
 
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "upstream_error", ae.Code)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "upstream_error", se.Code)
 }
 
 func TestGetPrice_NoRedis_CallsUpstream(t *testing.T) {

--- a/apps/api/services/finance/crypto/transport_http.go
+++ b/apps/api/services/finance/crypto/transport_http.go
@@ -27,8 +27,7 @@ func registerCryptoRoutes(r chi.Router, g Getter) {
 
 		price, err := g.GetPrice(r.Context(), symbol)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/crypto/transport_http.go
+++ b/apps/api/services/finance/crypto/transport_http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts crypto price handlers on the given router.
@@ -26,9 +27,9 @@ func registerCryptoRoutes(r chi.Router, g Getter) {
 
 		price, err := g.GetPrice(r.Context(), symbol)
 		if err != nil {
-			var ae *httpx.AppError
-			if errors.As(err, &ae) {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusServiceUnavailable, "upstream_error", "crypto price service unavailable")

--- a/apps/api/services/finance/exchange/service.go
+++ b/apps/api/services/finance/exchange/service.go
@@ -115,7 +115,7 @@ func (s *Service) fetchRate(ctx context.Context, from, to string) (float64, time
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return 0, time.Time{}, svcerr.Unknown("invalid_currency", fmt.Sprintf("unknown currency code: %s or %s", from, to))
+		return 0, time.Time{}, svcerr.Unknown("invalid_currency", fmt.Sprintf("unknown currency pair: %s/%s", from, to))
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/apps/api/services/finance/exchange/service.go
+++ b/apps/api/services/finance/exchange/service.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const (
@@ -110,46 +110,26 @@ func (s *Service) fetchRate(ctx context.Context, from, to string) (float64, time
 
 	resp, err := s.httpClient.Do(req) //nolint:gosec // URL is built from a fixed base URL and validated 3-char alpha currency codes
 	if err != nil {
-		return 0, time.Time{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "exchange rate service unavailable",
-		}
+		return 0, time.Time{}, svcerr.Upstream("upstream_error", "exchange rate service unavailable")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return 0, time.Time{}, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_currency",
-			Message: fmt.Sprintf("unknown currency code: %s or %s", from, to),
-		}
+		return 0, time.Time{}, svcerr.Unknown("invalid_currency", fmt.Sprintf("unknown currency code: %s or %s", from, to))
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, time.Time{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "exchange rate service unavailable",
-		}
+		return 0, time.Time{}, svcerr.Upstream("upstream_error", "exchange rate service unavailable")
 	}
 
 	var body frankfurterResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return 0, time.Time{}, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "exchange rate service unavailable",
-		}
+		return 0, time.Time{}, svcerr.Upstream("upstream_error", "exchange rate service unavailable")
 	}
 
 	rate, ok := body.Rates[to]
 	if !ok {
-		return 0, time.Time{}, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_currency",
-			Message: fmt.Sprintf("unknown currency code: %s", to),
-		}
+		return 0, time.Time{}, svcerr.Unknown("invalid_currency", fmt.Sprintf("unknown currency code: %s", to))
 	}
 
 	ts, err := time.Parse("2006-01-02", body.Date)

--- a/apps/api/services/finance/exchange/service_test.go
+++ b/apps/api/services/finance/exchange/service_test.go
@@ -130,3 +130,21 @@ func TestCacheKey_AlwaysUppercase(t *testing.T) {
 	assert.Equal(t, "exchange:USD:EUR", cacheKey("usd", "eur"), "cache key must be uppercase")
 	assert.Equal(t, "exchange:USD:EUR", cacheKey("USD", "EUR"), "cache key must be uppercase")
 }
+
+func TestGetRate_BadDateFallsBackToNow(t *testing.T) {
+	t.Parallel()
+	svc, cleanup := newTestService(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := frankfurterResponse{
+			Base:  "USD",
+			Date:  "not-a-date",
+			Rates: map[string]float64{"EUR": 0.91},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer cleanup()
+
+	_, ts, err := svc.GetRate(t.Context(), "USD", "EUR")
+	require.NoError(t, err)
+	assert.Equal(t, time.Now().UTC().Year(), ts.Year(), "bad date must fall back to current year")
+}

--- a/apps/api/services/finance/exchange/service_test.go
+++ b/apps/api/services/finance/exchange/service_test.go
@@ -87,6 +87,7 @@ func TestGetRate_APIReturns404_Returns422(t *testing.T) {
 	var se *svcerr.Error
 	require.ErrorAs(t, err, &se)
 	assert.Equal(t, "invalid_currency", se.Code)
+	assert.Equal(t, svcerr.KindUnknown, se.Kind)
 }
 
 func TestGetRate_APIReturns500_Returns503(t *testing.T) {

--- a/apps/api/services/finance/exchange/service_test.go
+++ b/apps/api/services/finance/exchange/service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // fakeFrankfurter returns a handler that serves a Frankfurter-shaped response.
@@ -67,10 +67,10 @@ func TestGetRate_InvalidTargetCurrency_Returns422(t *testing.T) {
 	_, _, err := svc.GetRate(t.Context(), "USD", "XYZ")
 	require.Error(t, err)
 
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "invalid_currency", ae.Code)
-	assert.Equal(t, http.StatusUnprocessableEntity, ae.Status)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "invalid_currency", se.Code)
+	assert.Equal(t, svcerr.KindUnknown, se.Kind)
 }
 
 func TestGetRate_APIReturns404_Returns422(t *testing.T) {
@@ -84,9 +84,9 @@ func TestGetRate_APIReturns404_Returns422(t *testing.T) {
 	_, _, err := svc.GetRate(t.Context(), "XYZ", "EUR")
 	require.Error(t, err)
 
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "invalid_currency", ae.Code)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "invalid_currency", se.Code)
 }
 
 func TestGetRate_APIReturns500_Returns503(t *testing.T) {
@@ -100,10 +100,10 @@ func TestGetRate_APIReturns500_Returns503(t *testing.T) {
 	_, _, err := svc.GetRate(t.Context(), "USD", "EUR")
 	require.Error(t, err)
 
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "upstream_error", ae.Code)
-	assert.Equal(t, http.StatusServiceUnavailable, ae.Status)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "upstream_error", se.Code)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
 }
 
 func TestParseCache_RoundTrip(t *testing.T) {

--- a/apps/api/services/finance/exchange/transport_http.go
+++ b/apps/api/services/finance/exchange/transport_http.go
@@ -34,8 +34,7 @@ func registerExchangeRoutes(r chi.Router, f Fetcher) {
 
 		rate, ts, err := f.GetRate(r.Context(), from, to)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
@@ -64,8 +63,7 @@ func registerExchangeRoutes(r chi.Router, f Fetcher) {
 
 		rate, ts, err := f.GetRate(r.Context(), from, to)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/exchange/transport_http.go
+++ b/apps/api/services/finance/exchange/transport_http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts exchange rate handlers on the given router.
@@ -33,9 +34,9 @@ func registerExchangeRoutes(r chi.Router, f Fetcher) {
 
 		rate, ts, err := f.GetRate(r.Context(), from, to)
 		if err != nil {
-			var ae *httpx.AppError
-			if errors.As(err, &ae) {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusServiceUnavailable, "upstream_error", "exchange rate service unavailable")
@@ -63,9 +64,9 @@ func registerExchangeRoutes(r chi.Router, f Fetcher) {
 
 		rate, ts, err := f.GetRate(r.Context(), from, to)
 		if err != nil {
-			var ae *httpx.AppError
-			if errors.As(err, &ae) {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusServiceUnavailable, "upstream_error", "exchange rate service unavailable")

--- a/apps/api/services/finance/exchange/transport_http_test.go
+++ b/apps/api/services/finance/exchange/transport_http_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 type stubFetcher struct {
@@ -118,8 +119,8 @@ func TestExchangeRate_InvalidCurrencyCode_Returns400(t *testing.T) {
 
 func TestExchangeRate_UnknownCurrency_Returns422(t *testing.T) {
 	t.Parallel()
-	appErr := &httpx.AppError{Status: http.StatusUnprocessableEntity, Code: "invalid_currency", Message: "unknown currency code: XYZ"}
-	r := setupRouter(errFetcher(appErr))
+	svcErr := svcerr.Unknown("invalid_currency", "unknown currency code: XYZ")
+	r := setupRouter(errFetcher(svcErr))
 
 	req := httptest.NewRequest(http.MethodGet, "/exchange-rate?from=XYZ&to=EUR", http.NoBody)
 	w := httptest.NewRecorder()
@@ -188,8 +189,8 @@ func TestConvert_ZeroAmount_Returns400(t *testing.T) {
 
 func TestConvert_UnknownCurrency_Returns422(t *testing.T) {
 	t.Parallel()
-	appErr := &httpx.AppError{Status: http.StatusUnprocessableEntity, Code: "invalid_currency", Message: "unknown currency code: XYZ"}
-	r := setupRouter(errFetcher(appErr))
+	svcErr := svcerr.Unknown("invalid_currency", "unknown currency code: XYZ")
+	r := setupRouter(errFetcher(svcErr))
 
 	req := httptest.NewRequest(http.MethodGet, "/convert?from=XYZ&to=EUR&amount=50", http.NoBody)
 	w := httptest.NewRecorder()

--- a/apps/api/services/finance/inflation/service.go
+++ b/apps/api/services/finance/inflation/service.go
@@ -2,13 +2,12 @@ package inflation
 
 import (
 	"context"
-	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const historyDepth = 11 // 1 current + 10 historical years
@@ -58,11 +57,7 @@ func (s *Service) GetInflation(ctx context.Context, rawCode string) (Response, e
 	}
 
 	if len(results) == 0 {
-		return Response{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "no inflation data found for country",
-		}
+		return Response{}, svcerr.NotFound("not_found", "no inflation data found for country")
 	}
 
 	latest := results[0]

--- a/apps/api/services/finance/inflation/transport_http.go
+++ b/apps/api/services/finance/inflation/transport_http.go
@@ -2,12 +2,14 @@ package inflation
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts inflation handlers on the given router.
@@ -37,8 +39,9 @@ func registerInflationRoutes(r chi.Router, g Getter) {
 
 		resp, err := g.GetInflation(r.Context(), req.Country)
 		if err != nil {
-			if ae, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/apps/api/services/finance/inflation/transport_http.go
+++ b/apps/api/services/finance/inflation/transport_http.go
@@ -39,8 +39,7 @@ func registerInflationRoutes(r chi.Router, g Getter) {
 
 		resp, err := g.GetInflation(r.Context(), req.Country)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/inflation/transport_http_test.go
+++ b/apps/api/services/finance/inflation/transport_http_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubGetter implements Getter for transport tests. It returns a fixed result
@@ -128,11 +129,7 @@ func TestInflation_ResponseEnvelope(t *testing.T) {
 
 func TestInflation_UnknownCountry_Returns404(t *testing.T) {
 	t.Parallel()
-	svc := &stubGetter{err: &httpx.AppError{
-		Status:  http.StatusNotFound,
-		Code:    "not_found",
-		Message: "no inflation data found for country",
-	}}
+	svc := &stubGetter{err: svcerr.NotFound("not_found", "no inflation data found for country")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/inflation?country=XK", http.NoBody)
@@ -224,11 +221,7 @@ func TestBatch_HappyPath_Returns200(t *testing.T) {
 func TestBatch_PartialFailure_NotFoundItemIsInBand(t *testing.T) {
 	t.Parallel()
 	// Stub returns error for every call — all items should be found: false, but status is still 200.
-	svc := &stubGetter{err: &httpx.AppError{
-		Status:  http.StatusNotFound,
-		Code:    "not_found",
-		Message: "no inflation data found for country",
-	}}
+	svc := &stubGetter{err: svcerr.NotFound("not_found", "no inflation data found for country")}
 	r := setupRouter(svc)
 
 	w := postBatch(r, `{"countries": ["US", "AR"]}`)

--- a/apps/api/services/finance/swift/service.go
+++ b/apps/api/services/finance/swift/service.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // Service provides SWIFT/BIC code lookup against the swift_codes PostgreSQL table.
@@ -34,11 +33,7 @@ func (s *Service) Lookup(ctx context.Context, raw string) (LookupResponse, error
 
 	result, err := s.querySwift(ctx, code)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return LookupResponse{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "SWIFT code not found",
-		}
+		return LookupResponse{}, svcerr.NotFound("not_found", "SWIFT code not found")
 	}
 	if err != nil {
 		return LookupResponse{}, err
@@ -144,48 +139,32 @@ func (s *Service) querySwift(ctx context.Context, code string) (LookupResponse, 
 
 // sanitizeSWIFT normalises the raw input and validates it against the SWIFT/BIC
 // format (ISO 9362). Returns the canonical 11-character code (appending "XXX"
-// for 8-character primary office codes) or an *httpx.AppError for client errors.
+// for 8-character primary office codes) or an error for invalid input.
 func sanitizeSWIFT(raw string) (string, error) {
 	code := strings.ToUpper(strings.TrimSpace(raw))
 
 	if len(code) != 8 && len(code) != 11 {
-		return "", &httpx.AppError{
-			Status:  http.StatusBadRequest,
-			Code:    "bad_request",
-			Message: "SWIFT code must be 8 or 11 characters",
-		}
+		return "", svcerr.Invalid("bad_request", "SWIFT code must be 8 or 11 characters")
 	}
 
 	// Positions 0–3: bank code — must be letters only.
 	for i := range 4 {
 		if code[i] < 'A' || code[i] > 'Z' {
-			return "", &httpx.AppError{
-				Status:  http.StatusBadRequest,
-				Code:    "bad_request",
-				Message: "bank code must be 4 letters (positions 1–4)",
-			}
+			return "", svcerr.Invalid("bad_request", "bank code must be 4 letters (positions 1–4)")
 		}
 	}
 
 	// Positions 4–5: country code — must be letters only.
 	for i := 4; i < 6; i++ {
 		if code[i] < 'A' || code[i] > 'Z' {
-			return "", &httpx.AppError{
-				Status:  http.StatusBadRequest,
-				Code:    "bad_request",
-				Message: "country code must be 2 letters (positions 5–6)",
-			}
+			return "", svcerr.Invalid("bad_request", "country code must be 2 letters (positions 5–6)")
 		}
 	}
 
 	// Positions 6–7: location code — alphanumeric.
 	for i := 6; i < 8; i++ {
 		if !isAlphanumeric(code[i]) {
-			return "", &httpx.AppError{
-				Status:  http.StatusBadRequest,
-				Code:    "bad_request",
-				Message: "location code must be alphanumeric (positions 7–8)",
-			}
+			return "", svcerr.Invalid("bad_request", "location code must be alphanumeric (positions 7–8)")
 		}
 	}
 
@@ -193,11 +172,7 @@ func sanitizeSWIFT(raw string) (string, error) {
 	if len(code) == 11 {
 		for i := 8; i < 11; i++ {
 			if !isAlphanumeric(code[i]) {
-				return "", &httpx.AppError{
-					Status:  http.StatusBadRequest,
-					Code:    "bad_request",
-					Message: "branch code must be alphanumeric (positions 9–11)",
-				}
+				return "", svcerr.Invalid("bad_request", "branch code must be alphanumeric (positions 9–11)")
 			}
 		}
 	}
@@ -217,20 +192,12 @@ func isAlphanumeric(b byte) bool {
 func sanitizeAlphaCode(raw string, expectedLen int, label string) (string, error) {
 	value := strings.ToUpper(strings.TrimSpace(raw))
 	if len(value) != expectedLen {
-		return "", &httpx.AppError{
-			Status:  http.StatusBadRequest,
-			Code:    "bad_request",
-			Message: fmt.Sprintf("%s must be %d letters", label, expectedLen),
-		}
+		return "", svcerr.Invalid("bad_request", fmt.Sprintf("%s must be %d letters", label, expectedLen))
 	}
 
 	for i := range expectedLen {
 		if value[i] < 'A' || value[i] > 'Z' {
-			return "", &httpx.AppError{
-				Status:  http.StatusBadRequest,
-				Code:    "bad_request",
-				Message: fmt.Sprintf("%s must contain letters only", label),
-			}
+			return "", svcerr.Invalid("bad_request", fmt.Sprintf("%s must contain letters only", label))
 		}
 	}
 

--- a/apps/api/services/finance/swift/service_integration_test.go
+++ b/apps/api/services/finance/swift/service_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func setupSwiftTestDB(t *testing.T) *pgxpool.Pool {
@@ -104,9 +104,9 @@ func TestServiceList_InvalidFilters(t *testing.T) {
 
 	_, err := svc.List(context.Background(), ListFilter{CountryCode: "D1"})
 	require.Error(t, err)
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, "bad_request", ae.Code)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, "bad_request", se.Code)
 
 	_, err = svc.List(context.Background(), ListFilter{BankCode: "TS1A"})
 	require.Error(t, err)

--- a/apps/api/services/finance/swift/service_test.go
+++ b/apps/api/services/finance/swift/service_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func TestSanitizeSWIFT_Valid8Char(t *testing.T) {
@@ -127,13 +127,13 @@ func TestSanitizeAlphaCode_InvalidChars(t *testing.T) {
 	assertAppError(t, err)
 }
 
-// assertAppError verifies that err is a 400 bad_request *httpx.AppError.
-// All sanitizeSWIFT validation errors return this exact status and code.
+// assertAppError verifies that err is a bad_request *svcerr.Error (KindInvalid).
+// All sanitizeSWIFT validation errors return this kind and code.
 func assertAppError(t *testing.T, err error) {
 	t.Helper()
 	require.Error(t, err)
-	var ae *httpx.AppError
-	require.ErrorAs(t, err, &ae)
-	assert.Equal(t, 400, ae.Status)
-	assert.Equal(t, "bad_request", ae.Code)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindInvalid, se.Kind)
+	assert.Equal(t, "bad_request", se.Code)
 }

--- a/apps/api/services/finance/swift/transport_http.go
+++ b/apps/api/services/finance/swift/transport_http.go
@@ -29,8 +29,7 @@ func registerSWIFTRoutes(r chi.Router, l Looker) {
 
 		result, err := l.List(r.Context(), filter)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
@@ -47,8 +46,7 @@ func registerSWIFTRoutes(r chi.Router, l Looker) {
 
 		result, err := l.Lookup(r.Context(), rawCode)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/finance/swift/transport_http.go
+++ b/apps/api/services/finance/swift/transport_http.go
@@ -1,11 +1,13 @@
 package swift
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts SWIFT/BIC lookup handlers on the given router.
@@ -27,8 +29,9 @@ func registerSWIFTRoutes(r chi.Router, l Looker) {
 
 		result, err := l.List(r.Context(), filter)
 		if err != nil {
-			if ae, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
@@ -44,8 +47,9 @@ func registerSWIFTRoutes(r chi.Router, l Looker) {
 
 		result, err := l.Lookup(r.Context(), rawCode)
 		if err != nil {
-			if ae, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, ae.Status, ae.Code, ae.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")

--- a/apps/api/services/finance/swift/transport_http_test.go
+++ b/apps/api/services/finance/swift/transport_http_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubService implements Looker for transport tests. It returns a fixed result
@@ -135,7 +136,7 @@ func TestSWIFT_List_InvalidOffset_Returns400(t *testing.T) {
 
 func TestSWIFT_List_ServiceAppError_Returns400(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{Status: http.StatusBadRequest, Code: "bad_request", Message: "invalid filter"}}
+	svc := &stubService{err: svcerr.Invalid("bad_request", "invalid filter")}
 	r := setupRouter(svc)
 
 	req := httptest.NewRequest(http.MethodGet, "/swift?country_code=D1", http.NoBody)
@@ -192,11 +193,7 @@ func TestSWIFT_MetadataTimestamp(t *testing.T) {
 
 func TestSWIFT_UnknownCode_Returns404(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusNotFound,
-		Code:    "not_found",
-		Message: "SWIFT code not found",
-	}}
+	svc := &stubService{err: svcerr.NotFound("not_found", "SWIFT code not found")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/swift/ZZZZZZZZXXX", http.NoBody)
@@ -208,11 +205,7 @@ func TestSWIFT_UnknownCode_Returns404(t *testing.T) {
 
 func TestSWIFT_BadFormat_Returns400(t *testing.T) {
 	t.Parallel()
-	svc := &stubService{err: &httpx.AppError{
-		Status:  http.StatusBadRequest,
-		Code:    "bad_request",
-		Message: "SWIFT code must be 8 or 11 characters",
-	}}
+	svc := &stubService{err: svcerr.Invalid("bad_request", "SWIFT code must be 8 or 11 characters")}
 
 	r := setupRouter(svc)
 	req := httptest.NewRequest(http.MethodGet, "/swift/INVALID", http.NoBody)

--- a/apps/api/services/health/exercises/service.go
+++ b/apps/api/services/health/exercises/service.go
@@ -3,13 +3,11 @@ package exercises
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/http"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // Service provides exercise lookups against the exercises PostgreSQL table.
@@ -88,17 +86,9 @@ func (s *Service) Get(ctx context.Context, id int) (Exercise, error) {
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return Exercise{}, &httpx.AppError{
-				Status:  http.StatusNotFound,
-				Code:    "not_found",
-				Message: "exercise not found",
-			}
+			return Exercise{}, svcerr.NotFound("not_found", "exercise not found")
 		}
-		return Exercise{}, &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "internal_error",
-			Message: fmt.Sprintf("failed to fetch exercise: %v", err),
-		}
+		return Exercise{}, err
 	}
 	return e, nil
 }
@@ -123,17 +113,9 @@ func (s *Service) Random(ctx context.Context, p ListParams) (Exercise, error) {
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return Exercise{}, &httpx.AppError{
-				Status:  http.StatusNotFound,
-				Code:    "not_found",
-				Message: "no exercises found matching the given filters",
-			}
+			return Exercise{}, svcerr.NotFound("not_found", "no exercises found matching the given filters")
 		}
-		return Exercise{}, &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "internal_error",
-			Message: fmt.Sprintf("failed to fetch random exercise: %v", err),
-		}
+		return Exercise{}, err
 	}
 	return e, nil
 }

--- a/apps/api/services/health/exercises/transport_http.go
+++ b/apps/api/services/health/exercises/transport_http.go
@@ -2,12 +2,14 @@ package exercises
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // exerciseQuerier is the interface consumed by HTTP handlers, allowing stub
@@ -58,8 +60,9 @@ func registerExerciseRoutes(r chi.Router, q exerciseQuerier) {
 
 		exercise, err := q.Random(r.Context(), params)
 		if err != nil {
-			if appErr, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch random exercise")
@@ -79,8 +82,9 @@ func registerExerciseRoutes(r chi.Router, q exerciseQuerier) {
 
 		exercise, err := q.Get(r.Context(), id)
 		if err != nil {
-			if appErr, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch exercise")

--- a/apps/api/services/health/exercises/transport_http.go
+++ b/apps/api/services/health/exercises/transport_http.go
@@ -60,8 +60,7 @@ func registerExerciseRoutes(r chi.Router, q exerciseQuerier) {
 
 		exercise, err := q.Random(r.Context(), params)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
@@ -82,8 +81,7 @@ func registerExerciseRoutes(r chi.Router, q exerciseQuerier) {
 
 		exercise, err := q.Get(r.Context(), id)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/health/exercises/transport_http_test.go
+++ b/apps/api/services/health/exercises/transport_http_test.go
@@ -275,9 +275,7 @@ func TestMetadata_ServiceError_Returns500(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			stub := &stubQuerier{err: &httpx.AppError{
-				Status: http.StatusInternalServerError, Code: "internal_error", Message: "db error",
-			}}
+			stub := &stubQuerier{err: errors.New("db error")}
 
 			r := setupTestRouter(stub)
 			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)

--- a/apps/api/services/health/exercises/transport_http_test.go
+++ b/apps/api/services/health/exercises/transport_http_test.go
@@ -3,6 +3,7 @@ package exercises
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // stubQuerier implements exerciseQuerier for HTTP handler tests.
@@ -108,9 +110,7 @@ func TestListExercises_ResponseEnvelope(t *testing.T) {
 
 func TestListExercises_ServiceError_Returns500(t *testing.T) {
 	t.Parallel()
-	stub := &stubQuerier{err: &httpx.AppError{
-		Status: http.StatusInternalServerError, Code: "internal_error", Message: "db down",
-	}}
+	stub := &stubQuerier{err: errors.New("db down")}
 
 	r := setupTestRouter(stub)
 	req := httptest.NewRequest(http.MethodGet, "/exercises", http.NoBody)
@@ -153,9 +153,7 @@ func TestRandomExercise_Returns200(t *testing.T) {
 
 func TestRandomExercise_NoMatch_Returns404(t *testing.T) {
 	t.Parallel()
-	stub := &stubQuerier{err: &httpx.AppError{
-		Status: http.StatusNotFound, Code: "not_found", Message: "no exercises found",
-	}}
+	stub := &stubQuerier{err: svcerr.NotFound("not_found", "no exercises found")}
 
 	r := setupTestRouter(stub)
 	req := httptest.NewRequest(http.MethodGet, "/exercises/random?body_part=unknown", http.NoBody)
@@ -210,9 +208,7 @@ func TestGetExercise_ZeroID_Returns400(t *testing.T) {
 
 func TestGetExercise_NotFound_Returns404(t *testing.T) {
 	t.Parallel()
-	stub := &stubQuerier{err: &httpx.AppError{
-		Status: http.StatusNotFound, Code: "not_found", Message: "exercise not found",
-	}}
+	stub := &stubQuerier{err: svcerr.NotFound("not_found", "exercise not found")}
 
 	r := setupTestRouter(stub)
 	req := httptest.NewRequest(http.MethodGet, "/exercises/9999", http.NoBody)

--- a/apps/api/services/networking/disposable/service.go
+++ b/apps/api/services/networking/disposable/service.go
@@ -64,10 +64,12 @@ func (s *Service) GetDomains(page, perPage int) (DomainsListResponse, error) {
 	allDomains := disposable.GetAllDomains()
 	total := len(allDomains)
 
-	start := (page - 1) * perPage
-	if start >= total {
+	maxPages := (total + perPage - 1) / perPage
+	if page > maxPages {
 		return DomainsListResponse{}, svcerr.NotFound("page_out_of_range", "page exceeds total number of available pages")
 	}
+
+	start := (page - 1) * perPage
 
 	end := start + perPage
 	if end > total {

--- a/apps/api/services/networking/disposable/service.go
+++ b/apps/api/services/networking/disposable/service.go
@@ -5,7 +5,7 @@ import (
 
 	disposable "github.com/bobadilla-tech/is-email-disposable"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 type Service struct{}
@@ -54,30 +54,22 @@ func (s *Service) CheckDomain(domain string) DomainCheckResponse {
 
 // GetDomains returns paginated list of disposable domains
 func (s *Service) GetDomains(page, perPage int) (DomainsListResponse, error) {
+	if page < 1 {
+		return DomainsListResponse{}, svcerr.Invalid("bad_request", "page must be at least 1")
+	}
+	if perPage < 1 || perPage > 1000 {
+		return DomainsListResponse{}, svcerr.Invalid("bad_request", "per_page must be between 1 and 1000")
+	}
+
 	allDomains := disposable.GetAllDomains()
 	total := len(allDomains)
 
-	// Default pagination values
-	if page < 1 {
-		page = 1
-	}
-	if perPage < 1 || perPage > 1000 {
-		perPage = 100
-	}
-
-	// Calculate pagination
 	start := (page - 1) * perPage
-	end := start + perPage
-
-	// Page is beyond the last page
 	if start >= total {
-		return DomainsListResponse{}, &httpx.AppError{
-			Status:  404,
-			Code:    "page_out_of_range",
-			Message: "page exceeds total number of available pages",
-		}
+		return DomainsListResponse{}, svcerr.NotFound("page_out_of_range", "page exceeds total number of available pages")
 	}
 
+	end := start + perPage
 	if end > total {
 		end = total
 	}

--- a/apps/api/services/networking/disposable/service_test.go
+++ b/apps/api/services/networking/disposable/service_test.go
@@ -1,0 +1,143 @@
+package disposable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/svcerr"
+)
+
+func TestCheckEmail_Disposable(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	res := svc.CheckEmail("test@mailinator.com")
+	assert.True(t, res.IsDisposable, "mailinator.com must be recognized as disposable")
+	assert.Equal(t, "test@mailinator.com", res.Email)
+	assert.Equal(t, "mailinator.com", res.Domain)
+}
+
+func TestCheckEmail_NotDisposable(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	res := svc.CheckEmail("user@gmail.com")
+	assert.False(t, res.IsDisposable)
+	assert.Equal(t, "gmail.com", res.Domain)
+}
+
+func TestCheckDomain_Disposable(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	res := svc.CheckDomain("mailinator.com")
+	assert.True(t, res.IsDisposable)
+	assert.Equal(t, "mailinator.com", res.Domain)
+}
+
+func TestCheckDomain_NotDisposable(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	res := svc.CheckDomain("gmail.com")
+	assert.False(t, res.IsDisposable)
+}
+
+func TestCheckBatch_CountMatchesInput(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	emails := []string{"a@mailinator.com", "b@gmail.com", "c@mailinator.com"}
+	res := svc.CheckBatch(emails)
+	assert.Equal(t, 3, res.Total)
+	assert.Len(t, res.Results, 3)
+	assert.True(t, res.Results[0].IsDisposable)
+	assert.False(t, res.Results[1].IsDisposable)
+	assert.True(t, res.Results[2].IsDisposable)
+}
+
+func TestGetStats_TotalNonZero(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	stats := svc.GetStats()
+	assert.Greater(t, stats.TotalDomains, 0, "disposable domain list must be non-empty")
+}
+
+func TestGetDomains_PageLessThanOne(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	_, err := svc.GetDomains(0, 10)
+	require.Error(t, err)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindInvalid, se.Kind)
+}
+
+func TestGetDomains_PerPageZero(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	_, err := svc.GetDomains(1, 0)
+	require.Error(t, err)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindInvalid, se.Kind)
+}
+
+func TestGetDomains_PerPageTooLarge(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	_, err := svc.GetDomains(1, 1001)
+	require.Error(t, err)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindInvalid, se.Kind)
+}
+
+func TestGetDomains_PageOutOfRange(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	_, err := svc.GetDomains(999999, 10)
+	require.Error(t, err)
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindNotFound, se.Kind)
+	assert.Equal(t, "page_out_of_range", se.Code)
+}
+
+func TestGetDomains_HappyPath(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	res, err := svc.GetDomains(1, 5)
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Page)
+	assert.Equal(t, 5, res.PerPage)
+	assert.Len(t, res.Domains, 5)
+	assert.Greater(t, res.Total, 0)
+	assert.True(t, res.HasMore, "page 1 of 5 should have more pages")
+}
+
+func TestGetDomains_LastPage(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	// Page large enough to be the last page.
+	first, err := svc.GetDomains(1, 1000)
+	require.NoError(t, err)
+	totalPages := (first.Total + 999) / 1000
+
+	last, err := svc.GetDomains(totalPages, 1000)
+	require.NoError(t, err)
+	assert.False(t, last.HasMore, "last page must not have more")
+}
+
+func TestExtractDomainFromEmail_Valid(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "example.com", ExtractDomainFromEmail("user@example.com"))
+}
+
+func TestExtractDomainFromEmail_NoAtSign(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", ExtractDomainFromEmail("notanemail"))
+}
+
+func TestExtractDomainFromEmail_MultipleAtSigns(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", ExtractDomainFromEmail("a@b@c"))
+}

--- a/apps/api/services/networking/disposable/transport_http.go
+++ b/apps/api/services/networking/disposable/transport_http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func RegisterRoutes(router chi.Router, svc *Service) {
@@ -50,8 +51,9 @@ func RegisterRoutes(router chi.Router, svc *Service) {
 		result, err := svc.GetDomains(q.Page, q.PerPage)
 
 		if err != nil {
-			if appErr, ok := errors.AsType[*httpx.AppError](err); ok {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "unexpected error")

--- a/apps/api/services/networking/disposable/transport_http.go
+++ b/apps/api/services/networking/disposable/transport_http.go
@@ -51,8 +51,7 @@ func RegisterRoutes(router chi.Router, svc *Service) {
 		result, err := svc.GetDomains(q.Page, q.PerPage)
 
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/places/geocode/service.go
+++ b/apps/api/services/places/geocode/service.go
@@ -64,7 +64,10 @@ func (s *Service) Geocode(ctx context.Context, address string) (GeocodeResponse,
 	}
 
 	var results []nominatimSearchResult
-	if err := json.Unmarshal(body, &results); err != nil || len(results) == 0 {
+	if err := json.Unmarshal(body, &results); err != nil {
+		return GeocodeResponse{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
+	}
+	if len(results) == 0 {
 		return GeocodeResponse{}, svcerr.NotFound("not_found", "no results found for the given address")
 	}
 
@@ -106,7 +109,10 @@ func (s *Service) ReverseGeocode(ctx context.Context, lat, lon float64) (Reverse
 	}
 
 	var result nominatimReverseResult
-	if err := json.Unmarshal(body, &result); err != nil || result.DisplayName == "" {
+	if err := json.Unmarshal(body, &result); err != nil {
+		return ReverseGeocodeResponse{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
+	}
+	if result.DisplayName == "" {
 		return ReverseGeocodeResponse{}, svcerr.NotFound("not_found", "no results found for the given coordinates")
 	}
 

--- a/apps/api/services/places/geocode/service.go
+++ b/apps/api/services/places/geocode/service.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const (
@@ -65,11 +65,7 @@ func (s *Service) Geocode(ctx context.Context, address string) (GeocodeResponse,
 
 	var results []nominatimSearchResult
 	if err := json.Unmarshal(body, &results); err != nil || len(results) == 0 {
-		return GeocodeResponse{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "no results found for the given address",
-		}
+		return GeocodeResponse{}, svcerr.NotFound("not_found", "no results found for the given address")
 	}
 
 	first := results[0]
@@ -111,11 +107,7 @@ func (s *Service) ReverseGeocode(ctx context.Context, lat, lon float64) (Reverse
 
 	var result nominatimReverseResult
 	if err := json.Unmarshal(body, &result); err != nil || result.DisplayName == "" {
-		return ReverseGeocodeResponse{}, &httpx.AppError{
-			Status:  http.StatusNotFound,
-			Code:    "not_found",
-			Message: "no results found for the given coordinates",
-		}
+		return ReverseGeocodeResponse{}, svcerr.NotFound("not_found", "no results found for the given coordinates")
 	}
 
 	resp := ReverseGeocodeResponse{
@@ -139,29 +131,17 @@ func (s *Service) doRequest(ctx context.Context, apiURL string) ([]byte, error) 
 
 	resp, err := s.httpClient.Do(req) //nolint:gosec // URL is built from a trusted base URL + encoded user input
 	if err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "geocoding service unavailable",
-		}
+		return nil, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "geocoding service unavailable",
-		}
+		return nil, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 	}
 
 	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusServiceUnavailable,
-			Code:    "upstream_error",
-			Message: "geocoding service unavailable",
-		}
+		return nil, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 	}
 
 	return buf, nil

--- a/apps/api/services/places/geocode/service_test.go
+++ b/apps/api/services/places/geocode/service_test.go
@@ -1,0 +1,204 @@
+package geocode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/svcerr"
+)
+
+func fakeSearchServer(results []nominatimSearchResult) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(results)
+	}))
+}
+
+func fakeReverseServer(result nominatimReverseResult) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	}))
+}
+
+func newTestService(srv *httptest.Server) *Service {
+	return NewService(srv.URL, srv.Client(), nil)
+}
+
+// --- Geocode ---
+
+func TestGeocodeService_HappyPath(t *testing.T) {
+	t.Parallel()
+	srv := fakeSearchServer([]nominatimSearchResult{
+		{
+			Lat:         "48.8566",
+			Lon:         "2.3522",
+			DisplayName: "Paris, France",
+			Address: nominatimAddress{
+				City:        "Paris",
+				CountryCode: "fr",
+			},
+		},
+	})
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	res, err := svc.Geocode(t.Context(), "Paris, France")
+	require.NoError(t, err)
+
+	assert.InDelta(t, 48.8566, res.Lat, 0.001)
+	assert.InDelta(t, 2.3522, res.Lon, 0.001)
+	assert.Equal(t, "Paris, France", res.Address)
+	assert.Equal(t, "Paris", res.City)
+	assert.Equal(t, "FR", res.Country)
+}
+
+func TestGeocodeService_EmptyResults_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := fakeSearchServer([]nominatimSearchResult{})
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.Geocode(t.Context(), "Nonexistent Place XYZ")
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindNotFound, se.Kind)
+	assert.Equal(t, "not_found", se.Code)
+}
+
+func TestGeocodeService_NonOKStatus_Upstream(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.Geocode(t.Context(), "anywhere")
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
+}
+
+func TestGeocodeService_InvalidJSON_Upstream(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not-json"))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.Geocode(t.Context(), "anywhere")
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
+}
+
+// --- ReverseGeocode ---
+
+func TestReverseGeocodeService_HappyPath(t *testing.T) {
+	t.Parallel()
+	srv := fakeReverseServer(nominatimReverseResult{
+		DisplayName: "Eiffel Tower, Paris, France",
+		Address: nominatimAddress{
+			City:        "Paris",
+			CountryCode: "fr",
+		},
+	})
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	res, err := svc.ReverseGeocode(t.Context(), 48.8584, 2.2945)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Eiffel Tower, Paris, France", res.Address)
+	assert.Equal(t, "Paris", res.City)
+	assert.Equal(t, "FR", res.Country)
+	assert.InDelta(t, 48.8584, res.Lat, 0.001)
+	assert.InDelta(t, 2.2945, res.Lon, 0.001)
+}
+
+func TestReverseGeocodeService_EmptyDisplayName_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := fakeReverseServer(nominatimReverseResult{DisplayName: ""})
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.ReverseGeocode(t.Context(), 0, 0)
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindNotFound, se.Kind)
+}
+
+func TestReverseGeocodeService_NonOKStatus_Upstream(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.ReverseGeocode(t.Context(), 0, 0)
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
+}
+
+func TestReverseGeocodeService_InvalidJSON_Upstream(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{bad json"))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(srv)
+	_, err := svc.ReverseGeocode(t.Context(), 0, 0)
+	require.Error(t, err)
+
+	var se *svcerr.Error
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, svcerr.KindUpstream, se.Kind)
+}
+
+// --- resolveCity ---
+
+func TestResolveCity_City(t *testing.T) {
+	t.Parallel()
+	a := nominatimAddress{City: "Paris", Town: "Suburb", Village: "Village", County: "County"}
+	assert.Equal(t, "Paris", a.resolveCity())
+}
+
+func TestResolveCity_Town(t *testing.T) {
+	t.Parallel()
+	a := nominatimAddress{Town: "Suburb", Village: "Village", County: "County"}
+	assert.Equal(t, "Suburb", a.resolveCity())
+}
+
+func TestResolveCity_Village(t *testing.T) {
+	t.Parallel()
+	a := nominatimAddress{Village: "Village", County: "County"}
+	assert.Equal(t, "Village", a.resolveCity())
+}
+
+func TestResolveCity_County(t *testing.T) {
+	t.Parallel()
+	a := nominatimAddress{County: "County"}
+	assert.Equal(t, "County", a.resolveCity())
+}

--- a/apps/api/services/places/geocode/transport_http.go
+++ b/apps/api/services/places/geocode/transport_http.go
@@ -1,11 +1,13 @@
 package geocode
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func RegisterRoutes(r chi.Router, svc *Service) {
@@ -22,8 +24,9 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.Geocode(r.Context(), q.Address)
 		if err != nil {
-			if appErr, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "geocoding failed")
@@ -47,8 +50,9 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.ReverseGeocode(r.Context(), q.Lat, q.Lon)
 		if err != nil {
-			if appErr, ok := err.(*httpx.AppError); ok {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "reverse geocoding failed")

--- a/apps/api/services/places/geocode/transport_http.go
+++ b/apps/api/services/places/geocode/transport_http.go
@@ -24,8 +24,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.Geocode(r.Context(), q.Address)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
@@ -50,8 +49,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.ReverseGeocode(r.Context(), q.Lat, q.Lon)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/technology/base64/service.go
+++ b/apps/api/services/technology/base64/service.go
@@ -2,9 +2,8 @@ package base64 //nolint:revive // package name matches the service domain it imp
 
 import (
 	"encoding/base64"
-	"net/http"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // Service provides Base64 encode and decode operations.
@@ -38,11 +37,7 @@ func (s *Service) Decode(value, variant string) (Result, error) {
 	}
 
 	if err != nil {
-		return Result{}, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_base64",
-			Message: "value is not valid base64",
-		}
+		return Result{}, svcerr.Unknown("invalid_base64", "value is not valid base64")
 	}
 
 	return Result{Result: string(decoded)}, nil

--- a/apps/api/services/technology/base64/service_test.go
+++ b/apps/api/services/technology/base64/service_test.go
@@ -1,14 +1,12 @@
 package base64 //nolint:revive // package name matches the service it tests; renaming would obscure intent
 
 import (
-	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func TestService_Encode(t *testing.T) {
@@ -120,9 +118,9 @@ func TestService_Decode(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				var appErr *httpx.AppError
-				require.True(t, errors.As(err, &appErr), "expected *httpx.AppError, got %T", err)
-				assert.Equal(t, http.StatusUnprocessableEntity, appErr.Status)
+				var se *svcerr.Error
+				require.ErrorAs(t, err, &se, "expected *svcerr.Error, got %T", err)
+				assert.Equal(t, svcerr.KindUnknown, se.Kind)
 				return
 			}
 

--- a/apps/api/services/technology/color/service.go
+++ b/apps/api/services/technology/color/service.go
@@ -3,11 +3,10 @@ package color //nolint:revive // package name matches the service domain it impl
 import (
 	"fmt"
 	"math"
-	"net/http"
 	"strconv"
 	"strings"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // Service provides color format conversion operations.
@@ -80,11 +79,7 @@ func parse(format, value string) (rgb, error) {
 }
 
 func invalidColor(value string) error {
-	return &httpx.AppError{
-		Status:  http.StatusUnprocessableEntity,
-		Code:    "invalid_color",
-		Message: fmt.Sprintf("cannot parse color value %q", value),
-	}
+	return svcerr.Unknown("invalid_color", fmt.Sprintf("cannot parse color value %q", value))
 }
 
 // parseHex parses a "#rrggbb" or "#rgb" hex color string.

--- a/apps/api/services/technology/color/service.go
+++ b/apps/api/services/technology/color/service.go
@@ -79,7 +79,7 @@ func parse(format, value string) (rgb, error) {
 }
 
 func invalidColor(value string) error {
-	return svcerr.Unknown("invalid_color", fmt.Sprintf("cannot parse color value %q", value))
+	return svcerr.Invalid("invalid_color", fmt.Sprintf("cannot parse color value %q", value))
 }
 
 // parseHex parses a "#rrggbb" or "#rgb" hex color string.

--- a/apps/api/services/technology/color/service_test.go
+++ b/apps/api/services/technology/color/service_test.go
@@ -1,14 +1,12 @@
 package color //nolint:revive // package name matches the service it tests; renaming would obscure intent
 
 import (
-	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 func TestService_Convert(t *testing.T) {
@@ -202,11 +200,11 @@ func TestService_Convert(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				var appErr *httpx.AppError
-				require.True(t, errors.As(err, &appErr), "expected *httpx.AppError, got %T", err)
-				assert.Equal(t, http.StatusUnprocessableEntity, appErr.Status)
+				var se *svcerr.Error
+				require.ErrorAs(t, err, &se, "expected *svcerr.Error, got %T", err)
+				assert.Equal(t, svcerr.KindUnknown, se.Kind)
 				if tt.wantErrCode != "" {
-					assert.Equal(t, tt.wantErrCode, appErr.Code)
+					assert.Equal(t, tt.wantErrCode, se.Code)
 				}
 				return
 			}

--- a/apps/api/services/technology/color/service_test.go
+++ b/apps/api/services/technology/color/service_test.go
@@ -202,7 +202,7 @@ func TestService_Convert(t *testing.T) {
 				require.Error(t, err)
 				var se *svcerr.Error
 				require.ErrorAs(t, err, &se, "expected *svcerr.Error, got %T", err)
-				assert.Equal(t, svcerr.KindUnknown, se.Kind)
+				assert.Equal(t, svcerr.KindInvalid, se.Kind)
 				if tt.wantErrCode != "" {
 					assert.Equal(t, tt.wantErrCode, se.Code)
 				}

--- a/apps/api/services/technology/color/transport_http.go
+++ b/apps/api/services/technology/color/transport_http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 // RegisterRoutes mounts the color conversion handler on the given router.
@@ -22,9 +23,9 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.Convert(req.From, req.To, req.Value)
 		if err != nil {
-			var appErr *httpx.AppError
-			if errors.As(err, &appErr) {
-				httpx.Error(w, appErr.Status, appErr.Code, appErr.Message)
+			var se *svcerr.Error
+			if errors.As(err, &se) {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}
 			httpx.Error(w, http.StatusInternalServerError, "internal_error", "failed to convert color")

--- a/apps/api/services/technology/color/transport_http.go
+++ b/apps/api/services/technology/color/transport_http.go
@@ -23,8 +23,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		result, err := svc.Convert(req.From, req.To, req.Value)
 		if err != nil {
-			var se *svcerr.Error
-			if errors.As(err, &se) {
+			if se, ok := errors.AsType[*svcerr.Error](err); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
 				return
 			}

--- a/apps/api/services/technology/color/transport_http_test.go
+++ b/apps/api/services/technology/color/transport_http_test.go
@@ -74,7 +74,7 @@ func TestColor_InvalidValue(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestColor_ServiceError(t *testing.T) {
@@ -90,7 +90,7 @@ func TestColor_ServiceError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Equal(t, http.StatusBadRequest, w.Code)
 	assert.True(t, strings.Contains(w.Header().Get("Content-Type"), "application/json"), "expected application/json, got %s", w.Header().Get("Content-Type"))
 
 	var resp httpx.ErrorResponse

--- a/apps/api/services/technology/format/service.go
+++ b/apps/api/services/technology/format/service.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	yaml "gopkg.in/yaml.v3"
 
-	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 const maxContentSize = 512 * 1024 // 512 KB
@@ -27,11 +26,7 @@ func NewService() *Service { return &Service{} }
 // Convert converts content from one format to another.
 func (s *Service) Convert(req Request) (Response, error) {
 	if len(req.Content) > maxContentSize {
-		return Response{}, &httpx.AppError{
-			Status:  http.StatusRequestEntityTooLarge,
-			Code:    "content_too_large",
-			Message: fmt.Sprintf("content exceeds maximum allowed size of %d bytes", maxContentSize),
-		}
+		return Response{}, svcerr.Invalid("content_too_large", fmt.Sprintf("content exceeds maximum allowed size of %d bytes", maxContentSize))
 	}
 
 	if req.From == req.To {
@@ -68,11 +63,7 @@ func parseInput(format, content string) (any, error) {
 	case "toml":
 		return parseTOML(content)
 	default:
-		return nil, &httpx.AppError{
-			Status:  http.StatusBadRequest,
-			Code:    "unsupported_format",
-			Message: fmt.Sprintf("unsupported input format: %s", format),
-		}
+		return nil, svcerr.Invalid("unsupported_format", fmt.Sprintf("unsupported input format: %s", format))
 	}
 }
 
@@ -90,11 +81,7 @@ func serializeOutput(format string, v any) (string, error) {
 	case "toml":
 		return toTOML(v)
 	default:
-		return "", &httpx.AppError{
-			Status:  http.StatusBadRequest,
-			Code:    "unsupported_format",
-			Message: fmt.Sprintf("unsupported output format: %s", format),
-		}
+		return "", svcerr.Invalid("unsupported_format", fmt.Sprintf("unsupported output format: %s", format))
 	}
 }
 
@@ -105,11 +92,7 @@ func parseJSON(content string) (any, error) {
 	dec.UseNumber()
 	var v any
 	if err := dec.Decode(&v); err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_json",
-			Message: fmt.Sprintf("invalid JSON: %s", err.Error()),
-		}
+		return nil, svcerr.Unknown("invalid_json", fmt.Sprintf("invalid JSON: %s", err.Error()))
 	}
 	return normalizeNumbers(v), nil
 }
@@ -117,11 +100,7 @@ func parseJSON(content string) (any, error) {
 func toJSON(v any) (string, error) {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return "", &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "conversion_error",
-			Message: "failed to serialize to JSON",
-		}
+		return "", fmt.Errorf("failed to serialize to JSON: %w", err)
 	}
 	return string(b), nil
 }
@@ -131,24 +110,16 @@ func toJSON(v any) (string, error) {
 func parseYAML(content string) (any, error) {
 	var v any
 	if err := yaml.Unmarshal([]byte(content), &v); err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_yaml",
-			Message: fmt.Sprintf("invalid YAML: %s", err.Error()),
-		}
+		return nil, svcerr.Unknown("invalid_yaml", fmt.Sprintf("invalid YAML: %s", err.Error()))
 	}
-	// yaml.v3 unmarshals maps as map[string]interface{}, which is what we want.
+	// yaml.v3 unmarshals maps as map[string]any, which is what we want.
 	return v, nil
 }
 
 func toYAML(v any) (string, error) {
 	b, err := yaml.Marshal(v)
 	if err != nil {
-		return "", &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "conversion_error",
-			Message: "failed to serialize to YAML",
-		}
+		return "", fmt.Errorf("failed to serialize to YAML: %w", err)
 	}
 	return string(b), nil
 }
@@ -161,11 +132,7 @@ func parseCSV(content string) (any, error) {
 	r := csv.NewReader(strings.NewReader(content))
 	records, err := r.ReadAll()
 	if err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_csv",
-			Message: fmt.Sprintf("invalid CSV: %s", err.Error()),
-		}
+		return nil, svcerr.Unknown("invalid_csv", fmt.Sprintf("invalid CSV: %s", err.Error()))
 	}
 	if len(records) == 0 {
 		return []any{}, nil
@@ -175,11 +142,7 @@ func parseCSV(content string) (any, error) {
 	rows := make([]any, 0, len(records)-1)
 	for rowIdx, record := range records[1:] {
 		if len(record) > len(headers) {
-			return nil, &httpx.AppError{
-				Status:  http.StatusUnprocessableEntity,
-				Code:    "invalid_csv",
-				Message: fmt.Sprintf("row %d has %d columns but header defines %d", rowIdx+2, len(record), len(headers)),
-			}
+			return nil, svcerr.Unknown("invalid_csv", fmt.Sprintf("row %d has %d columns but header defines %d", rowIdx+2, len(record), len(headers)))
 		}
 		row := make(map[string]any, len(headers))
 		for i, h := range headers {
@@ -199,11 +162,7 @@ func parseCSV(content string) (any, error) {
 func toCSV(v any) (string, error) {
 	rows, ok := v.([]any)
 	if !ok {
-		return "", &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "conversion_error",
-			Message: "CSV output requires a JSON array of objects",
-		}
+		return "", svcerr.Unknown("conversion_error", "CSV output requires a JSON array of objects")
 	}
 	if len(rows) == 0 {
 		return "", nil
@@ -211,11 +170,7 @@ func toCSV(v any) (string, error) {
 
 	firstRow, ok := rows[0].(map[string]any)
 	if !ok {
-		return "", &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "conversion_error",
-			Message: "CSV output requires a JSON array of objects",
-		}
+		return "", svcerr.Unknown("conversion_error", "CSV output requires a JSON array of objects")
 	}
 
 	// Collect headers from first row in deterministic order.
@@ -229,21 +184,13 @@ func toCSV(v any) (string, error) {
 	w := csv.NewWriter(&buf)
 
 	if err := w.Write(headers); err != nil {
-		return "", &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "conversion_error",
-			Message: "failed to write CSV headers",
-		}
+		return "", fmt.Errorf("failed to write CSV headers: %w", err)
 	}
 
 	for _, row := range rows {
 		m, ok := row.(map[string]any)
 		if !ok {
-			return "", &httpx.AppError{
-				Status:  http.StatusUnprocessableEntity,
-				Code:    "conversion_error",
-				Message: "CSV output requires all array elements to be objects",
-			}
+			return "", svcerr.Unknown("conversion_error", "CSV output requires all array elements to be objects")
 		}
 		record := make([]string, len(headers))
 		for i, h := range headers {
@@ -252,20 +199,12 @@ func toCSV(v any) (string, error) {
 			}
 		}
 		if err := w.Write(record); err != nil {
-			return "", &httpx.AppError{
-				Status:  http.StatusInternalServerError,
-				Code:    "conversion_error",
-				Message: "failed to write CSV row",
-			}
+			return "", fmt.Errorf("failed to write CSV row: %w", err)
 		}
 	}
 	w.Flush()
 	if err := w.Error(); err != nil {
-		return "", &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "conversion_error",
-			Message: "failed to flush CSV writer",
-		}
+		return "", fmt.Errorf("failed to flush CSV writer: %w", err)
 	}
 
 	return buf.String(), nil
@@ -278,11 +217,7 @@ func parseXML(content string) (any, error) {
 	dec := xml.NewDecoder(strings.NewReader(content))
 	result, err := xmlDecodeElement(dec)
 	if err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_xml",
-			Message: fmt.Sprintf("invalid XML: %s", err.Error()),
-		}
+		return nil, svcerr.Unknown("invalid_xml", fmt.Sprintf("invalid XML: %s", err.Error()))
 	}
 	return result, nil
 }
@@ -358,19 +293,16 @@ func toXML(v any) (string, error) {
 
 	root := xml.StartElement{Name: xml.Name{Local: "root"}}
 	if err := enc.EncodeToken(root); err != nil {
-		return "", conversionError()
+		return "", fmt.Errorf("failed to serialize to XML: %w", err)
 	}
 	if err := encodeXMLValue(enc, v); err != nil {
-		if ae, ok := err.(*httpx.AppError); ok {
-			return "", ae
-		}
-		return "", conversionError()
+		return "", fmt.Errorf("failed to serialize to XML: %w", err)
 	}
 	if err := enc.EncodeToken(root.End()); err != nil {
-		return "", conversionError()
+		return "", fmt.Errorf("failed to serialize to XML: %w", err)
 	}
 	if err := enc.Flush(); err != nil {
-		return "", conversionError()
+		return "", fmt.Errorf("failed to serialize to XML: %w", err)
 	}
 
 	return buf.String(), nil
@@ -439,24 +371,12 @@ func sanitizeXMLName(name string) string {
 	return b.String()
 }
 
-func conversionError() *httpx.AppError {
-	return &httpx.AppError{
-		Status:  http.StatusInternalServerError,
-		Code:    "conversion_error",
-		Message: "failed to serialize to XML",
-	}
-}
-
 // --- TOML ---
 
 func parseTOML(content string) (any, error) {
 	var v map[string]any
 	if _, err := toml.Decode(content, &v); err != nil {
-		return nil, &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "invalid_toml",
-			Message: fmt.Sprintf("invalid TOML: %s", err.Error()),
-		}
+		return nil, svcerr.Unknown("invalid_toml", fmt.Sprintf("invalid TOML: %s", err.Error()))
 	}
 	return v, nil
 }
@@ -464,20 +384,12 @@ func parseTOML(content string) (any, error) {
 func toTOML(v any) (string, error) {
 	m, ok := v.(map[string]any)
 	if !ok {
-		return "", &httpx.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    "conversion_error",
-			Message: "TOML output requires a JSON object (not an array or scalar)",
-		}
+		return "", svcerr.Unknown("conversion_error", "TOML output requires a JSON object (not an array or scalar)")
 	}
 	var buf strings.Builder
 	enc := toml.NewEncoder(&buf)
 	if err := enc.Encode(m); err != nil {
-		return "", &httpx.AppError{
-			Status:  http.StatusInternalServerError,
-			Code:    "conversion_error",
-			Message: "failed to serialize to TOML",
-		}
+		return "", fmt.Errorf("failed to serialize to TOML: %w", err)
 	}
 	return buf.String(), nil
 }

--- a/apps/api/services/technology/format/service_test.go
+++ b/apps/api/services/technology/format/service_test.go
@@ -1,6 +1,7 @@
 package convformat
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -190,4 +191,143 @@ func TestService_JSONToTOML_Array(t *testing.T) {
 	req := Request{From: "json", To: "toml", Content: `[1,2,3]`}
 	_, err := svc.Convert(req)
 	require.Error(t, err)
+}
+
+// --- Unsupported formats ---
+
+func TestService_UnsupportedInputFormat(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "msgpack", To: "json", Content: "data"}
+	_, err := svc.Convert(req)
+	require.Error(t, err)
+}
+
+func TestService_UnsupportedOutputFormat(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "json", To: "msgpack", Content: `{"x":1}`}
+	_, err := svc.Convert(req)
+	require.Error(t, err)
+}
+
+// --- CSV edge cases ---
+
+func TestService_CSVToJSON_EmptyContent(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "csv", To: "json", Content: ""}
+	resp, err := svc.Convert(req)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", strings.TrimSpace(resp.Result))
+}
+
+func TestService_CSV_RowWithFewerColumnsThanHeaders(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	// Go's csv.Reader enforces consistent field counts by default,
+	// so a row with fewer columns than the header returns an error.
+	req := Request{From: "csv", To: "json", Content: "a,b,c\n1,2\n"}
+	_, err := svc.Convert(req)
+	require.Error(t, err)
+}
+
+func TestService_CSV_RowWithMoreColumnsThanHeaders(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "csv", To: "json", Content: "a,b\n1,2,3\n"}
+	_, err := svc.Convert(req)
+	require.Error(t, err, "expected error when a row has more columns than headers")
+}
+
+func TestService_JSONToCSV_NonMapFirstRow(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "json", To: "csv", Content: `["string-not-a-map"]`}
+	_, err := svc.Convert(req)
+	require.Error(t, err)
+}
+
+func TestService_JSONToCSV_NonMapSubsequentRow(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{From: "json", To: "csv", Content: `[{"a":"1"},"bad"]`}
+	_, err := svc.Convert(req)
+	require.Error(t, err)
+}
+
+// --- XML edge cases ---
+
+func TestService_XML_DuplicateTags(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	req := Request{
+		From:    "xml",
+		To:      "json",
+		Content: `<root><item>A</item><item>B</item></root>`,
+	}
+	resp, err := svc.Convert(req)
+	require.NoError(t, err)
+	// Both items must appear in output.
+	assert.Contains(t, resp.Result, "A")
+	assert.Contains(t, resp.Result, "B")
+}
+
+// --- sanitizeXMLName ---
+
+func TestSanitizeXMLName_EmptyString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "_", sanitizeXMLName(""))
+}
+
+func TestSanitizeXMLName_StartsWithDigit(t *testing.T) {
+	t.Parallel()
+	// Leading digit is invalid in XML element names → replaced with _
+	result := sanitizeXMLName("1abc")
+	assert.Equal(t, "_abc", result)
+}
+
+func TestSanitizeXMLName_ValidName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "valid_Name", sanitizeXMLName("valid_Name"))
+}
+
+// --- normalizeNumbers ---
+
+func TestNormalizeNumbers_Float64(t *testing.T) {
+	t.Parallel()
+	result := normalizeNumbers(jsonNumber("1.5"))
+	assert.Equal(t, float64(1.5), result)
+}
+
+func TestNormalizeNumbers_Int64(t *testing.T) {
+	t.Parallel()
+	result := normalizeNumbers(jsonNumber("42"))
+	assert.Equal(t, int64(42), result)
+}
+
+func TestNormalizeNumbers_NestedMap(t *testing.T) {
+	t.Parallel()
+	input := map[string]any{"n": jsonNumber("3")}
+	result := normalizeNumbers(input)
+	m := result.(map[string]any)
+	assert.Equal(t, int64(3), m["n"])
+}
+
+func TestNormalizeNumbers_Slice(t *testing.T) {
+	t.Parallel()
+	input := []any{jsonNumber("7")}
+	result := normalizeNumbers(input)
+	s := result.([]any)
+	assert.Equal(t, int64(7), s[0])
+}
+
+func TestNormalizeNumbers_NonNumber(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "hello", normalizeNumbers("hello"))
+}
+
+// jsonNumber returns a json.Number value for use in normalizeNumbers tests.
+func jsonNumber(s string) any {
+	return json.Number(s)
 }

--- a/apps/api/services/text/normalize/transport_http.go
+++ b/apps/api/services/text/normalize/transport_http.go
@@ -2,9 +2,9 @@ package normalize
 
 import (
 	"context"
-	"net/http"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -18,7 +18,7 @@ func RegisterRoutes(router chi.Router, svc *Service) {
 		res, err := svc.Normalize(req.Email)
 		
 		if err != nil {
-			return EmailNormalization{}, &httpx.AppError{Status: http.StatusBadRequest, Code: "bad_request", Message: err.Error()}
+			return EmailNormalization{}, svcerr.Invalid("bad_request", err.Error())
 		}
 
 		return res, nil

--- a/apps/api/services/text/normalize/transport_http.go
+++ b/apps/api/services/text/normalize/transport_http.go
@@ -16,7 +16,7 @@ func RegisterRoutes(router chi.Router, svc *Service) {
 
 	router.Post("/normalize", httpx.Handle(func(_ context.Context, req EmailNormalizationRequest) (EmailNormalization, error) {
 		res, err := svc.Normalize(req.Email)
-		
+
 		if err != nil {
 			return EmailNormalization{}, svcerr.Invalid("bad_request", err.Error())
 		}

--- a/apps/api/services/text/normalize/transport_http.go
+++ b/apps/api/services/text/normalize/transport_http.go
@@ -16,6 +16,7 @@ func RegisterRoutes(router chi.Router, svc *Service) {
 
 	router.Post("/normalize", httpx.Handle(func(_ context.Context, req EmailNormalizationRequest) (EmailNormalization, error) {
 		res, err := svc.Normalize(req.Email)
+		
 		if err != nil {
 			return EmailNormalization{}, &httpx.AppError{Status: http.StatusBadRequest, Code: "bad_request", Message: err.Error()}
 		}

--- a/docs/core/adding-go-endpoints.md
+++ b/docs/core/adding-go-endpoints.md
@@ -4,8 +4,6 @@ This guide walks through every step required to ship a new endpoint: from
 writing the Go code to updating the dashboard catalog and API documentation.
 Follow it in order — the checklist at the end maps to each section.
 
----
-
 ## Architecture Refresher
 
 Before writing any code, understand where the Go backend sits in the request
@@ -30,6 +28,7 @@ apps/api/
 │   └── routes_v1.go      # Mounts all /v1 domain routers
 ├── platform/
 │   ├── httpx/            # JSON, Error, Handle, BindQuery helpers
+│   ├── svcerr/           # Transport-agnostic service errors (use in services)
 │   ├── config/           # Env config
 │   ├── db/               # PostgreSQL connection + migrations
 │   └── middleware/       # BackendSecretAuth
@@ -186,13 +185,43 @@ func (RiddleList) IsData() {}
 Services receive dependencies through their constructor. Keep this layer free of
 HTTP concerns.
 
+**Service Layer Rules — read these before writing a single line:**
+
+1. **Never import `net/http` or `requiems-api/platform/httpx` in a service.**
+   Services must not know about HTTP status codes. All error information is
+   communicated through `requiems-api/platform/svcerr`.
+
+2. **Return `*svcerr.Error` for expected failure cases** (not found, invalid
+   input, upstream unavailable). Return a plain `error` only for unexpected
+   infrastructure failures that should become `500`.
+
+3. **Never silently clamp or default invalid input.** If `difficulty` is not one
+   of `easy|medium|hard`, return `svcerr.Invalid(...)`. If `page > maxPages`,
+   return `svcerr.NotFound(...)`. Silent defaults hide bugs in callers.
+
+**`svcerr` constructor reference:**
+
+| Constructor                  | HTTP status | Use when                                   |
+| ---------------------------- | ----------- | ------------------------------------------ |
+| `svcerr.NotFound(code, msg)` | 404         | Resource does not exist                    |
+| `svcerr.Invalid(code, msg)`  | 400         | Bad input the caller can fix               |
+| `svcerr.Unknown(code, msg)`  | 422         | Unprocessable but structurally valid input |
+| `svcerr.Upstream(code, msg)` | 503         | Third-party service / DB unavailable       |
+
+`httpx.Handle` and `httpx.HandleBatch` map `*svcerr.Error` to the correct HTTP
+response automatically. `KindUpstream` errors are also forwarded to Sentry.
+
 ```go
 package riddle
 
 import (
     "context"
+    "errors"
 
+    "github.com/jackc/pgx/v5"
     "github.com/jackc/pgx/v5/pgxpool"
+
+    "requiems-api/platform/svcerr"
 )
 
 type Service struct {
@@ -203,17 +232,17 @@ func NewService(db *pgxpool.Pool) *Service {
     return &Service{db: db}
 }
 
-func (s *Service) Random(ctx context.Context, category string) (Riddle, error) {
+func (s *Service) GetByID(ctx context.Context, id int) (Riddle, error) {
     row := s.db.QueryRow(ctx, `
         SELECT id, question, answer, category
-        FROM riddles
-        WHERE category = $1
-        ORDER BY random()
-        LIMIT 1`, category)
+        FROM riddles WHERE id = $1`, id)
 
     var r Riddle
     if err := row.Scan(&r.ID, &r.Question, &r.Answer, &r.Category); err != nil {
-        return Riddle{}, err
+        if errors.Is(err, pgx.ErrNoRows) {
+            return Riddle{}, svcerr.NotFound("not_found", "riddle not found")
+        }
+        return Riddle{}, err // unexpected DB failure → 500
     }
     return r, nil
 }
@@ -232,19 +261,17 @@ func NewService() *Service { return &Service{} }
 
 Choose the right pattern based on the endpoint's input method.
 
----
-
 #### Pattern A: `httpx.Handle` — POST with JSON body (recommended for mutations)
 
 Use this when the request has a JSON body. The wrapper handles decoding,
-validation, and `AppError` unwrapping automatically.
+validation, and error mapping automatically. The service just returns errors —
+the handler does not need to inspect them.
 
 ```go
 package riddle
 
 import (
     "context"
-    "net/http"
 
     "github.com/go-chi/chi/v5"
     "requiems-api/platform/httpx"
@@ -265,8 +292,9 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 - Decodes JSON (strict mode — unknown fields are rejected)
 - Runs struct validation; returns `422 Unprocessable Entity` with field-level
   errors on failure
-- Returns `500 Internal Server Error` for unexpected errors
-- Unwraps `*httpx.AppError` and responds with the specified status/code
+- Unwraps `*svcerr.Error` and maps it to the appropriate HTTP status
+- Captures `KindUpstream` errors in Sentry before responding
+- Returns `500 Internal Server Error` for any other unhandled error
 
 ---
 
@@ -277,6 +305,17 @@ calling `BindQuery`. Always declare required fields and constraints using
 `validate` tags on the struct — do not add manual checks in the handler body.
 
 ```go
+package riddle
+
+import (
+    "errors"
+    "net/http"
+
+    "github.com/go-chi/chi/v5"
+    "requiems-api/platform/httpx"
+    "requiems-api/platform/svcerr"
+)
+
 func RegisterRoutes(r chi.Router, svc *Service) {
     r.Get("/riddles", func(w http.ResponseWriter, r *http.Request) {
         // Always set defaults before binding.
@@ -289,7 +328,11 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
         result, err := svc.List(r.Context(), req.Page, req.PerPage)
         if err != nil {
-            httpx.Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch riddles")
+            if se, ok := errors.AsType[*svcerr.Error](err); ok {
+                httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
+                return
+            }
+            httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
             return
         }
 
@@ -297,6 +340,11 @@ func RegisterRoutes(r chi.Router, svc *Service) {
     })
 }
 ```
+
+> **Never hardcode a status code based on a guess about what the service
+> returned.** Propagate the `*svcerr.Error` from the service — it carries the
+> correct status. Hardcoding `http.StatusInternalServerError` for all service
+> errors masks not-found and upstream failures behind a misleading 500.
 
 ---
 
@@ -315,7 +363,11 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
         riddle, err := svc.GetByID(r.Context(), id)
         if err != nil {
-            httpx.Error(w, http.StatusNotFound, "not_found", "riddle not found")
+            if se, ok := errors.AsType[*svcerr.Error](err); ok {
+                httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
+                return
+            }
+            httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
             return
         }
 
@@ -324,18 +376,28 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 }
 ```
 
+> The service returns `svcerr.NotFound(...)` when the riddle does not exist. The
+> handler propagates that decision rather than assuming a 404 — if the service
+> later returns a 422 for a malformed id, the handler still does the right thing
+> without any changes.
+
 ---
 
 **Error response reference:**
 
-| Situation                 | Status | Code (snake_case)                          |
-| ------------------------- | ------ | ------------------------------------------ |
-| Missing/invalid JSON body | 400    | `bad_request`                              |
-| Failed struct validation  | 422    | `validation_failed` (automatic via Handle) |
-| Resource not found        | 404    | `not_found`                                |
-| Caller not authorised     | 403    | `forbidden`                                |
-| Upstream/DB unavailable   | 503    | `service_unavailable`                      |
-| Unexpected failure        | 500    | `internal_error`                           |
+| Situation                    | Status | Code (snake_case)    | Source                 |
+| ---------------------------- | ------ | -------------------- | ---------------------- |
+| Missing/invalid JSON body    | 400    | `bad_request`        | `httpx` (automatic)    |
+| Failed struct validation     | 422    | `validation_failed`  | `httpx` (automatic)    |
+| Bad input the caller can fix | 400    | anything descriptive | `svcerr.Invalid(...)`  |
+| Resource not found           | 404    | anything descriptive | `svcerr.NotFound(...)` |
+| Valid input, unprocessable   | 422    | anything descriptive | `svcerr.Unknown(...)`  |
+| Third-party / DB unavailable | 503    | `upstream_error`     | `svcerr.Upstream(...)` |
+| Unexpected failure           | 500    | `internal_error`     | plain `error` from svc |
+
+`svcerr.Upstream` errors are captured in Sentry automatically by `httpx.Handle`
+and `httpx.HandleBatch`. `NotFound`, `Invalid`, and `Unknown` are not — they are
+expected outcomes, not bugs.
 
 ### 1d. `router.go` — Wire the Domain
 

--- a/docs/core/local-payment-testing.md
+++ b/docs/core/local-payment-testing.md
@@ -17,8 +17,8 @@ temporarily disable test mode locally, override with
 ### Step 1: Get your ngrok hostname
 
 Start your ngrok tunnel and note the public hostname (e.g.
-`unprized-unseditiously-marilynn.ngrok-free.dev`). Add it to
-`infra/docker/.env` (no protocol, no trailing slash):
+`unprized-unseditiously-marilynn.ngrok-free.dev`). Add it to `infra/docker/.env`
+(no protocol, no trailing slash):
 
 ```bash
 NGROK_HOST=your-hostname.ngrok-free.dev
@@ -31,8 +31,7 @@ host. Restart the Rails server after changing this value.
 
 1. Enable test mode in LemonSqueezy (toggle in the top bar)
 2. Go to Settings > Webhooks > Add webhook
-3. Set the URL to:
-   `https://<your NGROK_HOST>/webhooks/lemonsqueezy`
+3. Set the URL to: `https://<your NGROK_HOST>/webhooks/lemonsqueezy`
 4. Select all subscription events:
    - `subscription_created`
    - `subscription_updated`
@@ -77,7 +76,8 @@ If you have a reserved domain, pass it via `--domain`:
 ngrok http --domain=your-hostname.ngrok-free.dev 3000
 ```
 
-Confirm the tunnel is live: `https://<your NGROK_HOST>` → `http://localhost:3000`
+Confirm the tunnel is live: `https://<your NGROK_HOST>` →
+`http://localhost:3000`
 
 Test mode is already `true` by default — nothing to toggle.
 
@@ -138,8 +138,8 @@ The signing secret doesn't match.
 
 ### Webhook not being delivered
 
-1. Confirm ngrok is running:
-   `https://<your NGROK_HOST>/healthz` should return 200
+1. Confirm ngrok is running: `https://<your NGROK_HOST>/healthz` should return
+   200
 2. Check delivery attempts in LemonSqueezy > Settings > Webhooks > (your
    webhook) > Recent deliveries
 3. Make sure LemonSqueezy test mode is ON when triggering test checkouts


### PR DESCRIPTION
Services were importing `requiems-api/platform/httpx` and `net/http` to
return `*httpx.AppError` values containing raw HTTP status codes. This
coupled business logic to the transport layer — a service should not know
what HTTP status 503 means.

Two additional violations:
- `sudoku/service.go` and `disposable/service.go` silently clamped invalid
  input instead of returning explicit errors.
- Sentry never received upstream dependency failures because `*httpx.AppError`
  (and later `*svcerr.Error`) were handled before the `sentry.CaptureException`
  call in `httpx.Handle`/`HandleBatch`.

## Solution

### New `platform/svcerr` package

Transport-agnostic error type:

```go
type Kind int
const (
    KindNotFound Kind = iota // → 404
    KindInvalid              // → 400
    KindUnknown              // → 422
    KindUpstream             // → 503
)

type Error struct{ Kind Kind; Code string; Message string }

func NotFound(code, msg string) *Error
func Invalid(code, msg string) *Error
func Unknown(code, msg string) *Error
func Upstream(code, msg string) *Error
```

Services return `*svcerr.Error`. The HTTP layer maps `Kind` → status code.
No service ever imports `net/http` for error types.

### `platform/httpx` changes

- `httpx.Handle` / `HandleBatch` now auto-handle `*svcerr.Error` (mapped via
  `svcerr.HTTPStatus`) in addition to the existing `*ValidationFailure` path.
- `KindUpstream` errors are forwarded to Sentry before responding — upstream
  dependency failures now alert. Other kinds (not-found, invalid, unknown) are
  expected client errors and are not reported.
- `AppError` type deleted entirely. No callers remain.

### Service migrations (13 services)

`bin`, `crypto`, `exchange`, `inflation`, `swift`, `commodities`, `exercises`,
`geocode`, `disposable`, `base64`, `color`, `format`, `normalize`

Each service:
- Removes `httpx`/`net/http` imports used for error types
- Returns `svcerr.*` instead of `*httpx.AppError`
- Transport updated to use `errors.AsType[*svcerr.Error]` (stdlib generic,
  replaces two-line `var ae *AppError; errors.As(...)` pattern)

### Silent-clamp fixes

`sudoku/service.go`: `Generate(difficulty string)` now returns `(Puzzle, error)`
— invalid difficulty returns an error instead of silently defaulting to `"medium"`.

`disposable/service.go`: invalid `page`/`perPage` now return `svcerr.Invalid`
instead of being silently reset to defaults. Page-out-of-range uses an
overflow-safe `maxPages` check before computing `(page-1)*perPage`.

### Other correctness fixes

`geocode/service.go`: JSON decode failure was conflated with "no results" and
returned `svcerr.NotFound`. Now decode failure returns `svcerr.Upstream` and
empty results returns `svcerr.NotFound` separately.

`color/service.go`: Parse failures changed from `svcerr.Unknown` (422) to
`svcerr.Invalid` (400) — consistent with other validation errors across the
codebase.

`exchange/service.go`: Frankfurter 404 error message changed from
"unknown currency code: X or Y" (implies both wrong) to "unknown currency pair: X/Y".

`svcerr.HTTPStatus`: nil guard added — typed-nil `*svcerr.Error` no longer panics.

## Result

- 47 files changed, -219 net lines
- `grep -r '"requiems-api/platform/httpx"' services/ --include="service.go"` → 0 results
- `grep -r '"net/http"' services/ --include="service.go"` → 3 results (all legitimate HTTP client calls: exchange, crypto, geocode)
- All 60 test packages pass
