### PR TITLE
feat(finance): add batch mortgage calculation endpoint and docs

### DIFF
--- a/apps/api/services/finance/mortgage/service.go
+++ b/apps/api/services/finance/mortgage/service.go
@@ -6,6 +6,7 @@ import "math"
 // transport tests to inject a stub without requiring the concrete *Service.
 type Calculator interface {
 	Calculate(principal, annualRate float64, years int) Response
+	CalculateBatch(mortgages []Request) BatchResponse
 }
 
 // Service computes mortgage payments and amortization schedules.
@@ -63,4 +64,13 @@ func (s *Service) Calculate(principal, annualRate float64, years int) Response {
 
 func round2(v float64) float64 {
 	return math.Round(v*100) / 100
+}
+
+// CalculateBatch calculates multiple mortgages and returns the results in the same order as the input.
+func (s *Service) CalculateBatch(mortgages []Request) BatchResponse {
+	results := make([]Response, len(mortgages))
+	for i, m := range mortgages {
+		results[i] = s.Calculate(m.Principal, m.Rate, m.Years)
+	}
+	return BatchResponse{Results: results, Total: len(results)}
 }

--- a/apps/api/services/finance/mortgage/service_test.go
+++ b/apps/api/services/finance/mortgage/service_test.go
@@ -88,3 +88,29 @@ func TestCalculate_ScheduleMonthNumbers(t *testing.T) {
 		}
 	}
 }
+
+func TestService_CalculateBatch(t *testing.T) {
+	svc := NewService()
+	mortgages := []Request{
+		{100000, 5.0, 1},
+		{100000, 5.6, 3},
+		{100000, 5.5, 5},
+	}
+	result := svc.CalculateBatch(mortgages)
+
+	if result.Total != 3 {
+		t.Errorf("expected 3, got %v", result.Total)
+	}
+
+	if result.Results[0].MonthlyPayment != 8560.75 {
+		t.Errorf("expected MonthlyPayment = 8560.75, got %v", result.Results[0].MonthlyPayment)
+	}
+
+	if result.Results[1].MonthlyPayment != 3024.1 {
+		t.Errorf("expected MonthlyPayment = 3024.1, got %v", result.Results[1].MonthlyPayment)
+	}
+
+	if result.Results[2].MonthlyPayment != 1910.12 {
+		t.Errorf("expected MonthlyPayment = 1910.12, got %v", result.Results[2].MonthlyPayment)
+	}
+}

--- a/apps/api/services/finance/mortgage/transport_http.go
+++ b/apps/api/services/finance/mortgage/transport_http.go
@@ -1,6 +1,7 @@
 package mortgage
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -28,4 +29,7 @@ func registerMortgageRoutes(r chi.Router, c Calculator) {
 
 		httpx.JSON(w, http.StatusOK, c.Calculate(req.Principal, req.Rate, req.Years))
 	})
+	r.Post("/mortgage/batch", httpx.HandleBatch(func(ctx context.Context, req BatchRequest) (BatchResponse, int, error) {
+		return c.CalculateBatch(req.Mortgages), len(req.Mortgages), nil
+	}))
 }

--- a/apps/api/services/finance/mortgage/transport_http_test.go
+++ b/apps/api/services/finance/mortgage/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -13,7 +14,8 @@ import (
 
 // stubCalculator implements Calculator for transport tests.
 type stubCalculator struct {
-	result Response
+	result  Response
+	results BatchResponse
 }
 
 func (s *stubCalculator) Calculate(principal, annualRate float64, years int) Response {
@@ -21,6 +23,11 @@ func (s *stubCalculator) Calculate(principal, annualRate float64, years int) Res
 	r.Principal = principal
 	r.Rate = annualRate
 	r.Years = years
+	return r
+}
+
+func (s *stubCalculator) CalculateBatch(mortgages []Request) BatchResponse {
+	r := s.results
 	return r
 }
 
@@ -163,5 +170,110 @@ func TestMortgage_MetadataTimestampSet(t *testing.T) {
 	resp := decodeResponse(t, w)
 	if resp.Metadata.Timestamp == "" {
 		t.Error("expected metadata.timestamp to be set")
+	}
+}
+
+func TestMortgage_BatchCalculate_HappyPath(t *testing.T) {
+	svc := &stubCalculator{results: BatchResponse{
+		Results: []Response{{MonthlyPayment: 1896.20}, {MonthlyPayment: 1896.20}},
+		Total:   2,
+	}}
+
+	r := setupRouter(svc)
+
+	body := `{"mortgages":[{"principal":150000,"rate":6.5,"years":2},{"principal":250000,"rate":6.5,"years":5}]}`
+	req := httptest.NewRequest(http.MethodPost, "/mortgage/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp httpx.Response[BatchResponse]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Data.Total != 2 {
+		t.Errorf("expected total 2, got %v", resp.Data.Total)
+	}
+
+	if len(resp.Data.Results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(resp.Data.Results))
+	}
+
+}
+
+func TestMortgage_BatchCalculate_EmptyBody(t *testing.T) {
+	svc := &stubCalculator{}
+
+	r := setupRouter(svc)
+
+	body := `{"mortgages": []}`
+	req := httptest.NewRequest(http.MethodPost, "/mortgage/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMortgage_BatchCalculate_missingBody(t *testing.T) {
+	svc := &stubCalculator{}
+
+	r := setupRouter(svc)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/mortgage/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMortgage_BatchCalculate_ExccedsLimit(t *testing.T) {
+	svc := &stubCalculator{}
+
+	r := setupRouter(svc)
+
+	mortgages := make([]Request, 51)
+
+	for i := range mortgages {
+		mortgages[i] = Request{Principal: 150000, Rate: 6.5, Years: 10}
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"mortgages": mortgages,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mortgage/batch", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMortgage_BatchCalculate_SetsUsageCountHeader(t *testing.T) {
+	svc := &stubCalculator{}
+
+	r := setupRouter(svc)
+
+	body := `{"mortgages":[{"principal":150000,"rate":6.5,"years":2},{"principal":250000,"rate":6.5,"years":5}]}`
+	req := httptest.NewRequest(http.MethodPost, "/mortgage/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	if got := w.Header().Get("X-Usage-Count"); got != "2" {
+		t.Errorf("Expected X-Usage-Count: 2, got %q", got)
 	}
 }

--- a/apps/api/services/finance/mortgage/type.go
+++ b/apps/api/services/finance/mortgage/type.go
@@ -27,4 +27,16 @@ type Response struct {
 	Schedule       []ScheduleEntry `json:"schedule"`
 }
 
-func (Response) IsData() {}
+// BatchRequest is the body for validating miltiple mortgages at once.
+type BatchRequest struct {
+	Mortgages []Request `json:"mortgages" validate:"required,min=1,max=50,dive"`
+}
+
+// BatchResponse is the response payload for POST /v1/finance/mortgage/batch.
+type BatchResponse struct {
+	Results []Response `json:"results"`
+	Total   int        `json:"total"`
+}
+
+func (Response) IsData()      {}
+func (BatchResponse) IsData() {}

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -130,7 +130,7 @@ apis:
     categories:
       - finance
     description: Calculate monthly mortgage payments and full amortization schedules. Pass principal, annual interest rate, and loan term in years.
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: false
     documentation_url: /apis/mortgage

--- a/apps/dashboard/config/api_docs/mortgage.yml
+++ b/apps/dashboard/config/api_docs/mortgage.yml
@@ -182,7 +182,7 @@ endpoints:
             "principal": 250000,
             "rate": 5.2,
             "years": 30
-          },
+          }
         ] 
       }
     response_example: |
@@ -210,7 +210,7 @@ endpoints:
                   "principal": 895.54,
                   "interest": 807.68,
                   "balance": 148213.74
-                },
+                }
               ]
             },
             {
@@ -234,7 +234,7 @@ endpoints:
                   "principal": 290.7,
                   "interest": 1082.08,
                   "balance": 249419.86
-                },
+                }
               ]
             }
           ],

--- a/apps/dashboard/config/api_docs/mortgage.yml
+++ b/apps/dashboard/config/api_docs/mortgage.yml
@@ -159,6 +159,153 @@ endpoints:
         data = JSON.parse(response.body)['data']
         puts data['monthly_payment']  # 1896.2
         puts data['total_interest']   # 382632.0
+  - name: Batch Calculate Mortgages
+    method: POST
+    path: /v1/finance/mortgage/batch
+    description: Calculate up to 50 mortgages in a single request. Results are returned in the same order as the input.
+    parameters:
+      - name: mortgages
+        type: array
+        required: true
+        location: body
+        description: "Array of mortgages to calculate (min: 1, max: 50)."
+        example: "[{\"principal\":150000,\"rate\":6.5,\"years\":10},{\"principal\":250000,\"rate\":5.2,\"years\":30}]"
+    request_example: |
+      {
+        "mortgages": [
+          {
+            "principal": 150000,
+            "rate": 6.5,
+            "years": 10
+          },
+          {
+            "principal": 250000,
+            "rate": 5.2,
+            "years": 30
+          },
+        ] 
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "principal": 150000,
+              "rate": 6.5,
+              "years": 10,
+              "monthly_payment": 1703.22,
+              "total_payment": 204386.36,
+              "total_interest": 54386.36,
+              "schedule": [
+                {
+                  "month": 1,
+                  "payment": 1703.22,
+                  "principal": 890.72,
+                  "interest": 812.5,
+                  "balance": 149109.28
+                },
+                {
+                  "month": 2,
+                  "payment": 1703.22,
+                  "principal": 895.54,
+                  "interest": 807.68,
+                  "balance": 148213.74
+                },
+              ]
+            },
+            {
+              "principal": 250000,
+              "rate": 5.2,
+              "years": 30,
+              "monthly_payment": 1372.78,
+              "total_payment": 494199.79,
+              "total_interest": 244199.79,
+              "schedule": [
+                {
+                  "month": 1,
+                  "payment": 1372.78,
+                  "principal": 289.44,
+                  "interest": 1083.33,
+                  "balance": 249710.56
+                },
+                {
+                  "month": 2,
+                  "payment": 1372.78,
+                  "principal": 290.7,
+                  "interest": 1082.08,
+                  "balance": 249419.86
+                },
+              ]
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-05-10T19:20:02Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: >-
+          Mortgage calculation result for each mortgage request in the same order
+          as the input. Each item has the same fields as the single mortgage
+          endpoint.
+      - name: total
+        type: integer
+        description: Number of results returned. Matches the length of the input array.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The mortgages array is missing, empty, or contains more than 50 items.
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/finance/mortgage/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"mortgages":[{"principal": 150000,"rate": 6.5,"years": 10},{"principal": 250000,"rate": 5.2,"years": 30}]}'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/finance/mortgage/batch"
+        headers = {
+            "requiems-api-key": "YOUR_API_KEY",
+            "Content-Type": "application/json"
+        }
+        payload = {"mortgages":[{"principal": 150000,"rate": 6.5,"years": 10},{"principal": 250000,"rate": 5.2,"years": 30}]}
+
+        response = requests.post(url, headers=headers, json=payload)
+        print(response.json())
+      javascript: |
+        const response = await fetch(
+          'https://api.requiems.xyz/v1/finance/mortgage/batch',
+          {
+            method: 'POST',
+            headers: {
+              'requiems-api-key': 'YOUR_API_KEY',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ mortgages: [{"principal": 150000,"rate": 6.5,"years": 10},{"principal": 250000,"rate": 5.2,"years": 30}] })
+          }
+        );
+
+        const { data } = await response.json();
+        console.log(data);
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/finance/mortgage/batch')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = { mortgages: [{"principal": 150000,"rate": 6.5,"years": 10},{"principal": 250000,"rate": 5.2,"years": 30}] }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        puts JSON.pretty_generate(JSON.parse(response.body))
 faq:
   - question: What formula is used?
     answer: >-


### PR DESCRIPTION
- Add BatchRequest and BatchResponse types for multi-mortgage calculations
- Implement CalculateBatch on Service, preserving input order in results
- Register POST /v1/finance/mortgage/batch route using httpx.HandleBatch
- Add IsData() to BatchResponse to satisfy the data interface
- Add tests covering happy path, empty body, missing body, limit exceeded (>50), and X-Usage-Count header
- Document POST /v1/finance/mortgage/batch with parameters, request/response examples, error codes, and code samples (curl, Python, JavaScript, Ruby)
- Update endpoints_count to 2 in mortgage API metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch mortgage calculation endpoint supporting up to 50 mortgages per request
  * Mortgage API now accepts multiple calculations in a single call with consolidated results
  * Updated API documentation with batch endpoint examples and specifications

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/611)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->