### PR TITLE
add Batch word

### DIFF
--- a/apps/api/services/text/words/service.go
+++ b/apps/api/services/text/words/service.go
@@ -98,3 +98,52 @@ func (s *Service) Define(word string) (DictionaryEntry, error) {
 		Synonyms:    synonyms,
 	}, nil
 }
+
+type BatchRequest struct {
+	Items []string `json:"items" validate:"required,min=1,max=50,dive,required"`
+}
+
+type BatchItem struct {
+	Word  string           `json:"word"`
+	Found bool             `json:"found"`
+	Entry *DictionaryEntry `json:"entry,omitempty"`
+	Error string           `json:"error,omitempty"`
+}
+
+type BatchResponse struct {
+	Results []BatchItem `json:"results"`
+	Total   int         `json:"total"`
+}
+
+func (BatchResponse) IsData() {}
+
+// -------------------- BATCH --------------------
+
+func (s *Service) BatchDefine(ctx context.Context, req BatchRequest) (BatchResponse, error) {
+	results := make([]BatchItem, len(req.Items))
+
+	for i, raw := range req.Items {
+		word := strings.ToLower(strings.TrimSpace(raw))
+
+		entry, err := s.Define(word)
+		if err != nil {
+			results[i] = BatchItem{
+				Word:  word,
+				Found: false,
+				Error: err.Error(),
+			}
+			continue
+		}
+
+		results[i] = BatchItem{
+			Word:  word,
+			Found: true,
+			Entry: &entry,
+		}
+	}
+
+	return BatchResponse{
+		Results: results,
+		Total:   len(results),
+	}, nil
+}

--- a/apps/api/services/text/words/service.go
+++ b/apps/api/services/text/words/service.go
@@ -10,31 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-type Word struct {
-	ID           int    `json:"id"`
-	Word         string `json:"word"`
-	Definition   string `json:"definition"`
-	PartOfSpeech string `json:"part_of_speech,omitempty"`
-}
-
-func (Word) IsData() {}
-
-// Definition represents a single definition entry for a word.
-type Definition struct {
-	PartOfSpeech string `json:"partOfSpeech"`
-	Definition   string `json:"definition"`
-	Example      string `json:"example,omitempty"`
-}
-
-// DictionaryEntry is the response payload for the dictionary endpoint.
-type DictionaryEntry struct {
-	Word        string       `json:"word"`
-	Phonetic    string       `json:"phonetic,omitempty"`
-	Definitions []Definition `json:"definitions"`
-	Synonyms    []string     `json:"synonyms"`
-}
-
-func (DictionaryEntry) IsData() {}
 
 type querier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
@@ -99,25 +74,6 @@ func (s *Service) Define(word string) (DictionaryEntry, error) {
 	}, nil
 }
 
-type BatchRequest struct {
-	Items []string `json:"items" validate:"required,min=1,max=50,dive,required"`
-}
-
-type BatchItem struct {
-	Word  string           `json:"word"`
-	Found bool             `json:"found"`
-	Entry *DictionaryEntry `json:"entry,omitempty"`
-	Error string           `json:"error,omitempty"`
-}
-
-type BatchResponse struct {
-	Results []BatchItem `json:"results"`
-	Total   int         `json:"total"`
-}
-
-func (BatchResponse) IsData() {}
-
-// -------------------- BATCH --------------------
 
 func (s *Service) BatchDefine(ctx context.Context, req BatchRequest) (BatchResponse, error) {
 	results := make([]BatchItem, len(req.Items))

--- a/apps/api/services/text/words/service_test.go
+++ b/apps/api/services/text/words/service_test.go
@@ -97,3 +97,117 @@ func TestRandom_EmptyPartOfSpeechAllowed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", got.PartOfSpeech)
 }
+func TestBatchDefine_MixedWords(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	req := BatchRequest{
+		Items: []string{
+			"ephemeral",
+			"SERENDIPITY",
+			"zzyzx",
+		},
+	}
+
+	resp, err := svc.BatchDefine(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Total)
+	require.Len(t, resp.Results, 3)
+
+	assert.True(t, resp.Results[0].Found)
+	assert.Equal(t, "ephemeral", resp.Results[0].Word)
+
+	assert.True(t, resp.Results[1].Found)
+	assert.Equal(t, "serendipity", resp.Results[1].Word)
+
+	assert.False(t, resp.Results[2].Found)
+	assert.Nil(t, resp.Results[2].Entry)
+	assert.NotEmpty(t, resp.Results[2].Error)
+}
+
+func TestBatchDefine_AllValid(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	req := BatchRequest{
+		Items: []string{
+			"melancholy",
+			"resilience",
+			"eloquent",
+		},
+	}
+
+	resp, err := svc.BatchDefine(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Total)
+	require.Len(t, resp.Results, 3)
+
+	for i, r := range resp.Results {
+		assert.True(t, r.Found, "item %d should be found", i)
+		assert.NotNil(t, r.Entry)
+		assert.NotEmpty(t, r.Entry.Definitions)
+	}
+}
+
+func TestBatchDefine_AllInvalid(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	req := BatchRequest{
+		Items: []string{"xxx", "yyy", "zzz"},
+	}
+
+	resp, err := svc.BatchDefine(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Total)
+
+	for _, r := range resp.Results {
+		assert.False(t, r.Found)
+		assert.Nil(t, r.Entry)
+		assert.NotEmpty(t, r.Error)
+	}
+}
+
+func TestBatchDefine_TrimsAndNormalizes(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	req := BatchRequest{
+		Items: []string{
+			"  Ephemeral  ",
+			"  SERENDIPITY ",
+		},
+	}
+
+	resp, err := svc.BatchDefine(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.True(t, resp.Results[0].Found)
+	assert.Equal(t, "ephemeral", resp.Results[0].Word)
+
+	assert.True(t, resp.Results[1].Found)
+	assert.Equal(t, "serendipity", resp.Results[1].Word)
+}
+
+func TestBatchDefine_EmptyRequest(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	req := BatchRequest{
+		Items: []string{},
+	}
+
+	resp, err := svc.BatchDefine(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, resp.Total)
+	assert.Len(t, resp.Results, 0)
+}

--- a/apps/api/services/text/words/transport_http.go
+++ b/apps/api/services/text/words/transport_http.go
@@ -1,6 +1,7 @@
 package words
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -36,4 +37,15 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, entry)
 	})
+	r.Post("/words/batch", httpx.HandleBatch(
+		func(ctx context.Context, req BatchRequest) (BatchResponse, int, error) {
+
+			resp, err := svc.BatchDefine(ctx, req)
+			if err != nil {
+				return BatchResponse{}, http.StatusInternalServerError, err
+			}
+
+			return resp, http.StatusOK, nil
+		},
+	))
 }

--- a/apps/api/services/text/words/transport_http_test.go
+++ b/apps/api/services/text/words/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -97,4 +98,176 @@ func TestDictionary_MultipleDefinitions(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, len(resp.Data.Definitions) >= 2, "expected at least 2 definitions, got %d", len(resp.Data.Definitions))
+}
+
+func TestWordsBatch_ValidRequest(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	body := `{
+		"items": ["ephemeral", "serendipity", "melancholy"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Data.Total)
+	assert.Len(t, resp.Data.Results, 3)
+
+	for _, item := range resp.Data.Results {
+		assert.NotEmpty(t, item.Word)
+		assert.True(t, item.Found)
+		assert.NotNil(t, item.Entry)
+		assert.Empty(t, item.Error)
+	}
+}
+
+func TestWordsBatch_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	body := `{
+		"items": ["EPHEMERAL", "SeReNdiPiTy"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, resp.Data.Total)
+
+	for _, item := range resp.Data.Results {
+		assert.True(t, item.Found)
+		assert.NotNil(t, item.Entry)
+	}
+}
+
+func TestWordsBatch_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	body := `{
+		"items": ["ephemeral", "fakeword123", "serendipity"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Data.Total)
+	assert.Len(t, resp.Data.Results, 3)
+
+	assert.True(t, resp.Data.Results[0].Found)
+	assert.False(t, resp.Data.Results[1].Found)
+	assert.NotEmpty(t, resp.Data.Results[1].Error)
+	assert.True(t, resp.Data.Results[2].Found)
+}
+
+func TestWordsBatch_EmptyItems(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	body := `{"items":[]}`
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestWordsBatch_MissingBody(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestWordsBatch_UnknownWords(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	body := `{
+		"items": ["notaword1", "notaword2"]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	for _, item := range resp.Data.Results {
+		assert.False(t, item.Found)
+		assert.NotNil(t, item.Error)
+		assert.Nil(t, item.Entry)
+	}
+}
+func TestWordsBatch_TooManyItems(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter()
+
+	items := make([]string, 51)
+	for i := 0; i < 51; i++ {
+		items[i] = "ephemeral"
+	}
+
+	bodyBytes, _ := json.Marshal(BatchRequest{Items: items})
+
+	req := httptest.NewRequest(http.MethodPost, "/words/batch", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+
+	// opcional: solo validar que devuelve error HTTP correcto
+	assert.Contains(t, w.Body.String(), "error")
 }

--- a/apps/api/services/text/words/transport_http_test.go
+++ b/apps/api/services/text/words/transport_http_test.go
@@ -244,7 +244,7 @@ func TestWordsBatch_UnknownWords(t *testing.T) {
 
 	for _, item := range resp.Data.Results {
 		assert.False(t, item.Found)
-		assert.NotNil(t, item.Error)
+		assert.NotEmpty(t, item.Error)
 		assert.Nil(t, item.Entry)
 	}
 }

--- a/apps/api/services/text/words/type.go
+++ b/apps/api/services/text/words/type.go
@@ -1,0 +1,45 @@
+package words
+
+type Word struct {
+	ID           int    `json:"id"`
+	Word         string `json:"word"`
+	Definition   string `json:"definition"`
+	PartOfSpeech string `json:"part_of_speech,omitempty"`
+}
+
+func (Word) IsData() {}
+
+// Definition represents a single definition entry for a word.
+type Definition struct {
+	PartOfSpeech string `json:"partOfSpeech"`
+	Definition   string `json:"definition"`
+	Example      string `json:"example,omitempty"`
+}
+
+// DictionaryEntry is the response payload for the dictionary endpoint.
+type DictionaryEntry struct {
+	Word        string       `json:"word"`
+	Phonetic    string       `json:"phonetic,omitempty"`
+	Definitions []Definition `json:"definitions"`
+	Synonyms    []string     `json:"synonyms"`
+}
+
+func (DictionaryEntry) IsData() {}
+
+type BatchRequest struct {
+	Items []string `json:"items" validate:"required,min=1,max=50,dive,required"`
+}
+
+type BatchItem struct {
+	Word  string           `json:"word"`
+	Found bool             `json:"found"`
+	Entry *DictionaryEntry `json:"entry,omitempty"`
+	Error string           `json:"error,omitempty"`
+}
+
+type BatchResponse struct {
+	Results []BatchItem `json:"results"`
+	Total   int         `json:"total"`
+}
+
+func (BatchResponse) IsData() {}

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -544,7 +544,7 @@ apis:
     categories:
       - text
     description: Generate random words for testing, games, and creative projects
-    endpoints_count: 2
+    endpoints_count: 3
     status: live
     popular: false
     documentation_url: /apis/words

--- a/apps/dashboard/config/api_docs/words.yml
+++ b/apps/dashboard/config/api_docs/words.yml
@@ -86,7 +86,67 @@ endpoints:
         end
 
         data = JSON.parse(response.body)['data']
-        puts "#{data['word']} (#{data['part_of_speech']}): #{data['definition']}"
+         puts "#{data['word']} (#{data['part_of_speech']}): #{data['definition']}"
+  - name: Batch Define Words
+    method: POST
+    path: /v1/text/words/batch
+    description: >
+      Resolve multiple words in a single request. Returns dictionary entries when found,
+      or error information when a word is not in the dataset.
+    parameters:
+      - name: items
+        type: array
+        required: true
+        description: List of words to look up in batch (max 50 items recommended)
+        items:
+          type: string
+    request_example: |
+      {
+        "items": ["ephemeral", "serendipity", "melancholy"]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "word": "ephemeral",
+              "found": true,
+              "entry": {
+                "word": "ephemeral",
+                "phonetic": "/ɪˈfɛm(ə)rəl/",
+                "definitions": [
+                  {
+                    "partOfSpeech": "adjective",
+                    "definition": "lasting for a very short time",
+                    "example": "ephemeral pleasures"
+                  }
+                ],
+                "synonyms": ["transient", "fleeting", "momentary"]
+              }
+            },
+            {
+              "word": "fakeword",
+              "found": false,
+              "error": "word not found: fakeword"
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-01-01T00:00:00Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: List of batch lookup results
+      - name: total
+        type: integer
+        description: Total number of items processed
+    errors:
+      - code: 422
+        message: unprocessable_entity
+        description: Invalid or empty items array     
 faq:
   - question: What parts of speech are included?
     answer: >-
@@ -111,3 +171,7 @@ performance:
   avg_ms: 1015
   samples: 50
   measured_at: "2026-04-20"
+
+
+
+  

--- a/apps/dashboard/config/api_docs/words.yml
+++ b/apps/dashboard/config/api_docs/words.yml
@@ -97,7 +97,7 @@ endpoints:
       - name: items
         type: array
         required: true
-        description: List of words to look up in batch (max 50 items recommended)
+        description: List of words to look up in batch (max 50 items )
         items:
           type: string
     request_example: |
@@ -109,19 +109,18 @@ endpoints:
         "data": {
           "results": [
             {
-              "word": "ephemeral",
+              "word": "serendipity",
               "found": true,
               "entry": {
-                "word": "ephemeral",
-                "phonetic": "/ɪˈfɛm(ə)rəl/",
+                "word": "serendipity",
+                "phonetic": "/ˌserənˈdipədē/",
                 "definitions": [
                   {
-                    "partOfSpeech": "adjective",
-                    "definition": "lasting for a very short time",
-                    "example": "ephemeral pleasures"
+                    "partOfSpeech": "noun",
+                    "definition": "the occurrence of events by chance in a happy way"
                   }
                 ],
-                "synonyms": ["transient", "fleeting", "momentary"]
+                "synonyms": ["fluke", "chance", "fortuity"]
               }
             },
             {
@@ -130,7 +129,7 @@ endpoints:
               "error": "word not found: fakeword"
             }
           ],
-          "total": 2
+          "total": 3
         },
         "metadata": {
           "timestamp": "2026-01-01T00:00:00Z"


### PR DESCRIPTION
-added BatchRequest, BatchItem, and BatchResponse 
-registered POST /v1/text/words/batch endpoint-
-added batch endpoint tests covering happy path, invalid JSON, empty arrays, unknown words, and requests exceeding 50 items
-updated Words API documentation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch word definition endpoint: submit multiple words in one request and receive individual results for each word (found/not found with definitions or error details).

* **Documentation**
  * Updated API documentation with batch endpoint specification and usage examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/613)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->