### PR TITLE
feat(mx): add batch MX lookup endpoint

### DIFF
--- a/apps/api/services/networking/mx/service.go
+++ b/apps/api/services/networking/mx/service.go
@@ -39,3 +39,25 @@ func (s *Service) Lookup(ctx context.Context, domain string) (LookupResponse, er
 		Records: sorted,
 	}, nil
 }
+
+func (s *Service) LookupBatch(ctx context.Context, domains []string) []BatchLookupItem {
+	results := make([]BatchLookupItem, len(domains))
+
+	for i, d := range domains {
+
+		result, err := s.Lookup(ctx, d)
+
+		if err != nil {
+			results[i] = BatchLookupItem{Domain: d, Found: false, Error: err.Error()}
+			continue
+		}
+
+		results[i] = BatchLookupItem{
+			Domain: d,
+			Found:  true,
+			Data:   result,
+		}
+	}
+
+	return results
+}

--- a/apps/api/services/networking/mx/service_test.go
+++ b/apps/api/services/networking/mx/service_test.go
@@ -1,0 +1,40 @@
+package mx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_LookupBatch(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	domains := []string{
+		"yahoo.com", "not-exist-ailxz.com", "icloud.com",
+	}
+
+	results := svc.LookupBatch(context.Background(), domains)
+
+	require.Equal(t, 3, len(results))
+	require.True(t, results[0].Found)
+	require.False(t, results[1].Found)
+	require.True(t, results[2].Found)
+}
+
+func TestService_LookupBatch_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	results := svc.LookupBatch(ctx, []string{"gmail.com", "outlook.com"})
+
+	// all should fail because context is cancelled
+	for _, item := range results {
+		require.False(t, item.Found)
+		require.NotEmpty(t, item.Error)
+	}
+}

--- a/apps/api/services/networking/mx/transport_http.go
+++ b/apps/api/services/networking/mx/transport_http.go
@@ -1,6 +1,7 @@
 package mx
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"regexp"
@@ -34,6 +35,12 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, result)
 	})
+
+	r.Post("/mx/batch", httpx.HandleBatch(
+		func(ctx context.Context, req BatchRequest) (httpx.BatchResponse[BatchLookupItem], error) {
+			return httpx.BatchResponse[BatchLookupItem]{Results: svc.LookupBatch(ctx, req.Domains)}, nil
+		},
+	))
 }
 
 // isDNSNotFound reports whether the error is a DNS "no such host" / NXDOMAIN error.

--- a/apps/api/services/networking/mx/transport_http_test.go
+++ b/apps/api/services/networking/mx/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -95,4 +96,80 @@ func TestMXLookup_HappyPath(t *testing.T) {
 	for i, rec := range resp.Data.Records {
 		assert.NotEmpty(t, rec.Host, "record[%d] has empty host", i)
 	}
+}
+
+func TestMXLookup_BatchLookup_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"domains":["gmail.com","outlook.com","yahoo.com"]}`
+	req := httptest.NewRequest(http.MethodPost, "/mx/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[httpx.BatchResponse[BatchLookupItem]]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 3)
+
+	for _, item := range resp.Data.Results {
+		assert.True(t, item.Found)
+		assert.NotEmpty(t, item.Data.Domain)
+		assert.Empty(t, item.Error)
+	}
+}
+
+func TestMxLookup_BatchLookup_EmptyBody(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"domains":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/mx/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var resp httpx.Response[httpx.BatchResponse[BatchLookupItem]]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMxLookup_BatchLookup_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	domains := make([]string, 51)
+
+	for i := range domains {
+		domains[i] = "gmail.com"
+	}
+
+	body, _ := json.Marshal(BatchRequest{
+		Domains: domains,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mx/batch", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestMxLookup_BatchLookup_setUsageCountHeader(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"domains":["gmail.com","outlook.com","yahoo.com"]}`
+	req := httptest.NewRequest(http.MethodPost, "/mx/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	require.Equal(t, "3", w.Header().Get("X-Usage-Count"))
 }

--- a/apps/api/services/networking/mx/type.go
+++ b/apps/api/services/networking/mx/type.go
@@ -12,4 +12,19 @@ type LookupResponse struct {
 	Records []Record `json:"records"`
 }
 
+//	BatchRequest is the body for validating multiple domains at once.
+type BatchRequest struct {
+	Domains []string `json:"domains" validate:"required,min=1,max=50,dive,required,fqdn"`
+}
+
+// BatchLookupItem represents the result of a single domain lookup
+// within a batch request. It contains the domain name, whether it
+// was found, any error encountered, and the associated lookup data.
+type BatchLookupItem struct {
+	Domain string         `json:"domain"`
+	Found  bool           `json:"found"`
+	Error  string         `json:"error,omitempty"`
+	Data   LookupResponse `json:"data,omitempty"`
+}
+
 func (LookupResponse) IsData() {}

--- a/apps/api/services/networking/mx/type.go
+++ b/apps/api/services/networking/mx/type.go
@@ -12,7 +12,7 @@ type LookupResponse struct {
 	Records []Record `json:"records"`
 }
 
-//	BatchRequest is the body for validating multiple domains at once.
+// BatchRequest is the body for validating multiple domains at once.
 type BatchRequest struct {
 	Domains []string `json:"domains" validate:"required,min=1,max=50,dive,required,fqdn"`
 }

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -299,7 +299,7 @@ apis:
     categories:
       - networking
     description: Look up MX (Mail Exchange) records for any domain. Returns all mail server hostnames with their priorities, sorted from highest to lowest priority.
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: false
     documentation_url: /apis/mx-lookup

--- a/apps/dashboard/config/api_docs/mx-lookup.yml
+++ b/apps/dashboard/config/api_docs/mx-lookup.yml
@@ -225,8 +225,9 @@ endpoints:
         response = requests.post(url, headers=headers, json=payload)
         for result in response.json()["data"]["results"]:
           print(result["domain"], result["found"])
-          for record in result["data"]["records"]:
-              print(f"  {record['host']} (priority: {record['priority']})")
+          if result["found"]:
+              for record in result["data"]["records"]:
+                print(f"  {record['host']} (priority: {record['priority']})")
       javascript: |
         const response = await fetch('https://api.requiems.xyz/v1/networking/mx/batch',
           {
@@ -242,9 +243,11 @@ endpoints:
         const { data } = await response.json();
         data.results.forEach(r => {
           console.log(r.domain, r.found);
-          r.data.records.forEach(record => {
-           console.log(record.host, record.priority);
-          });
+          if (r.found) {
+            r.data.records.forEach(record => {
+              console.log(record.host, record.priority);
+            });
+          }
         });
       ruby: |
         require 'net/http'
@@ -262,8 +265,10 @@ endpoints:
 
         JSON.parse(response.body)['data']['results'].each do |r|
           puts "#{r['domain']}: #{r['found']}"
-          r['data']['records'].each do |record|
-            puts "  #{record['host']} (priority: #{record['priority']})"
+          if r['found']
+            r['data']['records'].each do |record|
+              puts "  #{record['host']} (priority: #{record['priority']})"
+            end
           end
         end
 faq:

--- a/apps/dashboard/config/api_docs/mx-lookup.yml
+++ b/apps/dashboard/config/api_docs/mx-lookup.yml
@@ -105,6 +105,167 @@ endpoints:
 
         data = JSON.parse(response.body)['data']
         data['records'].each { |r| puts "#{r['priority']} #{r['host']}" }
+  - name: Batch MX Lookup 
+    method: POST
+    path: /v1/networking/mx/batch
+    description: >-
+      Retrieve MX records for up to 50 domains in a single request. Results for each domain are sorted by priority
+      ascending (lowest numeric value has the highest mail delivery priority per RFC 5321).
+    parameters:
+      - name: domains
+        type: array
+        required: true
+        location: body
+        description: "Array of domains to lookup (min: 1, max: 50)."
+        example: "[\"outlook.com\", \"yahoo.com\"]"
+    request_example: |
+      {
+        "domains": ["outlook.com", "yahoo.com"]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "domain": "outlook.com",
+              "found": true,
+              "data": {
+                "domain": "outlook.com",
+                "records": [
+                  {
+                    "host": "outlook-com.olc.protection.outlook.com.",
+                    "priority": 5
+                  }
+                ]
+                }
+              },
+              {
+                "domain": "yahoo.com",
+                "found": true,
+                "data": {
+                  "domain": "yahoo.com",
+                  "records": [
+                    {
+                      "host": "mta5.am0.yahoodns.net.",
+                      "priority": 1
+                    },
+                    {
+                      "host": "mta7.am0.yahoodns.net.",
+                      "priority": 1
+                    },
+                    {
+                      "host": "mta6.am0.yahoodns.net.",
+                      "priority": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-05-13T21:34:51Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: MX lookup results for each input domain, in the same order as the input.
+      - name: results[].domain
+        type: string
+        description: The domain name that was queried.
+      - name: results[].found
+        type: boolean
+        description: Whether MX records were found for the domain.
+      - name: results[].error
+        type: string
+        description: Error message if the lookup failed. Empty if found is true.
+      - name: results[].data
+        type: object
+        description: MX lookup data. Present only when found is true.
+      - name: results[].data.domain
+        type: string
+        description: The domain name associated with the MX records.
+      - name: results[].data.records
+        type: array
+        description: List of MX records sorted by priority ascending (lower value means higher priority).
+      - name: results[].data.records[].host
+        type: string
+        description: Hostname of the mail server.
+      - name: results[].data.records[].priority
+        type: number
+        description: Priority of the mail server. Lower value means higher priority.
+      - name: total
+        type: number
+        description: Total number of results returned.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The domains array is missing, empty, or contains more than 50 items.
+      - code: internal_error
+        status: 500
+        description: DNS lookup failed due to an unexpected server error.
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/networking/mx/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"domains":["outlook.com", "yahoo.com"]}'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/networking/mx/batch"
+        headers = {
+            "requiems-api-key": "YOUR_API_KEY",
+            "Content-Type": "application/json"
+        }
+        payload = {"domains": ["outlook.com", "yahoo.com"]}
+
+        response = requests.post(url, headers=headers, json=payload)
+        for result in response.json()["data"]["results"]:
+          print(result["domain"], result["found"])
+          for record in result["data"]["records"]:
+              print(f"  {record['host']} (priority: {record['priority']})")
+      javascript: |
+        const response = await fetch('https://api.requiems.xyz/v1/networking/mx/batch',
+          {
+            method: 'POST',
+            headers: {
+              'requiems-api-key': 'YOUR_API_KEY',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ domains: ['outlook.com', 'yahoo.com'] })
+          }
+        );
+
+        const { data } = await response.json();
+        data.results.forEach(r => {
+          console.log(r.domain, r.found);
+          r.data.records.forEach(record => {
+           console.log(record.host, record.priority);
+          });
+        });
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/networking/mx/batch')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = { domains: ['outlook.com', 'yahoo.com'] }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        JSON.parse(response.body)['data']['results'].each do |r|
+          puts "#{r['domain']}: #{r['found']}"
+          r['data']['records'].each do |record|
+            puts "  #{record['host']} (priority: #{record['priority']})"
+          end
+        end
 faq:
   - question: What does priority mean in MX records?
     answer: >-


### PR DESCRIPTION
- Add POST /mx/batch endpoint accepting up to 50 domains per request
- Add LookupBatch service method that processes each domain independently,
  continuing on error instead of failing the entire batch
- Add BatchRequest struct with validation: required, min=1, max=50, fqdn per domain
- Add BatchLookupItem struct with domain, found, error, and MX records data
- Add service unit tests:
  - LookupBatch happy path with mixed found/not-found domains
  - LookupBatch with cancelled context
- Add HTTP integration tests:
  - Happy path with 3 domains returns 200 and correct total
  - Empty domains array returns 422
  - Exceeds 50 domain limit returns 422
  - X-Usage-Count header returns correct domain count
- Add endpoint documentation with request/response fields and error codes
- Add code examples for curl, python, javascript and ruby
- Update endpoints_count to 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch MX lookup endpoint supporting up to 50 domains per request.
  * New `/mx/batch` endpoint returns per-domain results including found status and MX records.

* **Documentation**
  * Updated API documentation and catalog with batch lookup endpoint details and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/618)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->