### PR TITLE
Feat/unit conversion batch api

### DIFF
--- a/apps/api/services/technology/units/service.go
+++ b/apps/api/services/technology/units/service.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -225,3 +226,36 @@ func formatFactor(f float64) string {
 
 	return s[:i+1]
 }
+
+// ConvertBatch processes multiple unit conversion operations and returns a result for each one.
+// Each operation is converted independently — if one fails, the rest continue processing.
+// The returned slice preserves the same order as the input operations.
+func (s *Service) ConvertBatch(ctx context.Context, operations []BatchItem) []BatchResponse {
+	results := make([]BatchResponse, len(operations))
+
+	for i, op := range operations {
+		result, err := s.Convert(op.From, op.To, *op.Value)
+		if err != nil {
+			results[i] = BatchResponse{
+				From:    op.From,
+				To:      op.To,
+				Success: false,
+				Error:   err.Error(),
+			}
+			continue
+		}
+
+		results[i] = BatchResponse{
+			From:    op.From,
+			To:      op.To,
+			Success: true,
+			Data:    result,
+		}
+
+	}
+
+	return results
+}
+
+// Ptr returns a pointer to the given float64 value.
+func Ptr(v float64) *float64 { return &v }

--- a/apps/api/services/technology/units/service.go
+++ b/apps/api/services/technology/units/service.go
@@ -234,6 +234,16 @@ func (s *Service) ConvertBatch(ctx context.Context, operations []BatchItem) []Ba
 	results := make([]BatchResponse, len(operations))
 
 	for i, op := range operations {
+		if op.Value == nil {
+			results[i] = BatchResponse{
+				From:    op.From,
+				To:      op.To,
+				Success: false,
+				Error:   "value is required",
+			}
+			continue
+		}
+
 		result, err := s.Convert(op.From, op.To, *op.Value)
 		if err != nil {
 			results[i] = BatchResponse{

--- a/apps/api/services/technology/units/service_test.go
+++ b/apps/api/services/technology/units/service_test.go
@@ -250,8 +250,6 @@ func TestService_ConvertBatch(t *testing.T) {
 	require.False(t, results[2].Success)
 }
 
-// perserved Order
-
 func TestService_ConvertBatch_PreservedOrder(t *testing.T) {
 	t.Parallel()
 	svc := NewService()

--- a/apps/api/services/technology/units/service_test.go
+++ b/apps/api/services/technology/units/service_test.go
@@ -283,3 +283,22 @@ func TestService_ConvertBatch_PreservedOrder(t *testing.T) {
 	require.Equal(t, "c", results[2].From)
 	require.Equal(t, "g", results[2].To)
 }
+
+func TestService_ConvertBatch_NilValue(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	operations := []BatchItem{
+		{
+			From:  "miles",
+			To:    "km",
+			Value: nil, // malformed — missing value
+		},
+	}
+
+	results := svc.ConvertBatch(context.Background(), operations)
+
+	require.Len(t, results, 1)
+	assert.False(t, results[0].Success)
+	assert.Equal(t, "value is required", results[0].Error)
+}

--- a/apps/api/services/technology/units/service_test.go
+++ b/apps/api/services/technology/units/service_test.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -217,4 +218,70 @@ func TestTypes_IsData(t *testing.T) {
 	t.Parallel()
 	Result{}.IsData()
 	Results{}.IsData()
+}
+
+func TestService_ConvertBatch(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	operations := []BatchItem{
+		{
+			From:  "miles",
+			To:    "km",
+			Value: Ptr(10),
+		},
+		{
+			From:  "kg",
+			To:    "lb",
+			Value: Ptr(5),
+		},
+		{
+			From:  "c",
+			To:    "g",
+			Value: Ptr(25),
+		},
+	}
+
+	results := svc.ConvertBatch(context.Background(), operations)
+
+	require.Equal(t, 3, len(results))
+	require.True(t, results[0].Success)
+	require.True(t, results[1].Success)
+	require.False(t, results[2].Success)
+}
+
+// perserved Order
+
+func TestService_ConvertBatch_PreservedOrder(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	operations := []BatchItem{
+		{
+			From:  "miles",
+			To:    "km",
+			Value: Ptr(10),
+		},
+		{
+			From:  "kg",
+			To:    "lb",
+			Value: Ptr(5),
+		},
+		{
+			From:  "c",
+			To:    "g",
+			Value: Ptr(25),
+		},
+	}
+
+	results := svc.ConvertBatch(context.Background(), operations)
+
+	require.Equal(t, "miles", results[0].From)
+	require.Equal(t, "km", results[0].To)
+
+	require.Equal(t, "kg", results[1].From)
+	require.Equal(t, "lb", results[1].To)
+
+	require.Equal(t, "c", results[2].From)
+	require.Equal(t, "g", results[2].To)
 }

--- a/apps/api/services/technology/units/transport_http.go
+++ b/apps/api/services/technology/units/transport_http.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -38,4 +39,10 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, result)
 	})
+
+	r.Post("/convert/batch", httpx.HandleBatch(
+		func(ctx context.Context, req BatchRequest) (httpx.BatchResponse[BatchResponse], error) {
+			return httpx.BatchResponse[BatchResponse]{Results: svc.ConvertBatch(ctx, req.Operations)}, nil
+		}),
+	)
 }

--- a/apps/api/services/technology/units/transport_http_test.go
+++ b/apps/api/services/technology/units/transport_http_test.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"requiems-api/platform/httpx"
 	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
 )
 
 func setupRouter() chi.Router {

--- a/apps/api/services/technology/units/transport_http_test.go
+++ b/apps/api/services/technology/units/transport_http_test.go
@@ -1,0 +1,100 @@
+package units
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"requiems-api/platform/httpx"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRouter() chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService())
+	return r
+}
+
+func TestUnits_BatchConvert_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"operations":[{"from": "miles", "to": "km", "value": 10}]}`
+	req := httptest.NewRequest(http.MethodPost, "/convert/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[httpx.BatchResponse[BatchResponse]]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	require.Equal(t, 1, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 1)
+
+	assert.True(t, resp.Data.Results[0].Success)
+	assert.Empty(t, resp.Data.Results[0].Error)
+
+	assert.InDelta(
+		t,
+		16.0934,
+		resp.Data.Results[0].Data.Result,
+		0.001,
+	)
+}
+
+// Test EmptyBody
+func TestUnits_BatchConvert_EmptyOperations(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"operations":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/convert/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestUnits_BatchConvert_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	operations := make([]BatchItem, 51)
+
+	for i := range operations {
+		operations[i] = BatchItem{From: "miles", To: "km", Value: Ptr(10)}
+	}
+
+	body, _ := json.Marshal(BatchRequest{
+		Operations: operations,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/convert/batch", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestUnits_BatchConvert_SetUsageCountHeader(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	body := `{"operations":[{"from": "miles", "to": "km", "value": 10}]}`
+	req := httptest.NewRequest(http.MethodPost, "/convert/batch", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	require.Equal(t, "1", w.Header().Get("X-Usage-Count"))
+}

--- a/apps/api/services/technology/units/type.go
+++ b/apps/api/services/technology/units/type.go
@@ -21,3 +21,24 @@ type Results struct {
 }
 
 func (Results) IsData() {}
+
+// BatchItem represents a single unit conversion operation.
+type BatchItem struct {
+	From  string   `json:"from" validate:"required"`
+	To    string   `json:"to"  validate:"required"`
+	Value *float64 `json:"value" validate:"required"`
+}
+
+// BatchRequest represents a request containing multiple conversion operations.
+type BatchRequest struct {
+	Operations []BatchItem `json:"operations" validate:"required,min=1,max=50,dive"`
+}
+
+// BatchResponse represents the result of a single batch conversion operation.
+type BatchResponse struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+	Data    Result `json:"data"`
+}

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -703,7 +703,7 @@ apis:
     categories:
       - technology
     description: Convert between units of measurement — length, weight, volume, temperature, area, and speed
-    endpoints_count: 2
+    endpoints_count: 3
     status: live
     popular: false
     documentation_url: /apis/unit-conversion

--- a/apps/dashboard/config/api_docs/unit-conversion.yml
+++ b/apps/dashboard/config/api_docs/unit-conversion.yml
@@ -297,7 +297,7 @@ endpoints:
         type: string
         description: Formula or conversion factor used to calculate the result.
       - name: total
-        type: number
+        type: integer
         description: Total number of conversion results returned.
     errors:
       - code: validation_failed

--- a/apps/dashboard/config/api_docs/unit-conversion.yml
+++ b/apps/dashboard/config/api_docs/unit-conversion.yml
@@ -200,6 +200,245 @@ endpoints:
 
         units = JSON.parse(response.body)['data']
         puts "Temperature units: #{units['temperature'].join(', ')}"
+  - name: Batch Convert Units
+    method: POST
+    path: /v1/technology/convert/batch
+    description: convert up to 50 unit conversion operations in a single request.
+    parameters:
+      - name: operations
+        type: array
+        required: true
+        location: body
+        description: "Array of operations to convert (min: 1, max: 50)."
+        example: "[{\"from\":\"kg\",\"to\":\"lb\",\"value\":10},{\"from\":\"c\",\"to\":\"f\",\"value\":5}]"
+    request_example: |
+      {
+        "operations": [
+          {
+            "from": "kg",
+            "to": "lb",
+            "value": 10
+          },
+          {
+            "from": "c",
+            "to": "f",
+            "value": 5
+          }
+       ]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "from": "kg",
+              "to": "lb",
+              "success": true,
+              "data": {
+                "from": "kg",
+                "to": "lb",
+                "input": 10,
+                "result": 22.046244,
+                "formula": "kg × 2.204624"
+              }
+            },
+            {
+              "from": "c",
+              "to": "f",
+              "success": true,
+              "data": {
+                "from": "c",
+                "to": "f",
+                "input": 5,
+                "result": 41,
+                "formula": "°C × 9/5 + 32"
+              }
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-05-15T21:52:05Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: List of unit conversion results returned in the same order as the input operations.
+      - name: results[].from
+        type: string
+        description: Source unit used for the conversion.
+      - name: results[].to
+        type: string
+        description: Target unit used for the conversion.
+      - name: results[].success
+        type: boolean
+        description: Indicates whether the conversion operation was successful.
+      - name: results[].error
+        type: string
+        description: Error message if the conversion failed. Empty when success is true.
+      - name: results[].data
+        type: object
+        description: Conversion result details. Contains empty values when the conversion fails.
+      - name: results[].data.from
+        type: string
+        description: Source unit.
+      - name: results[].data.to
+        type: string
+        description: Target unit.
+      - name: results[].data.input
+        type: number
+        description: Original numeric value provided for conversion.
+      - name: results[].data.result
+        type: number
+        description: Converted numeric result.
+      - name: results[].data.formula
+        type: string
+        description: Formula or conversion factor used to calculate the result.
+      - name: total
+        type: number
+        description: Total number of conversion results returned.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The operations array is missing, empty, or contains more than 50 items.
+      - code: bad_request
+        status: 400
+        description: Invalid JSON, malformed request body, or unexpected field types.
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/technology/convert/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "operations": [
+              {
+                "from": "kg",
+                "to": "lb",
+                "value": 10
+              },
+              {
+                "from": "c",
+                "to": "f",
+                "value": 5
+              }
+            ]
+          }'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/technology/convert/batch"
+
+        headers = {
+          "requiems-api-key": "YOUR_API_KEY",
+          "Content-Type": "application/json"
+        }
+
+        payload = {
+          "operations": [
+            {
+              "from": "kg",
+              "to": "lb",
+              "value": 10
+            },
+            {
+              "from": "c",
+              "to": "f",
+              "value": 5
+            }
+          ]
+        }
+
+        response = requests.post(url, headers=headers, json=payload)
+
+        for item in response.json()["data"]["results"]:
+          print(item["from"], "->", item["to"])
+
+          if item["success"]:
+            print("Result:", item["data"]["result"])
+            print("Formula:", item["data"]["formula"])
+          else:
+            print("Error:", item["error"])
+
+      javascript: |
+        const response = await fetch(
+          'https://api.requiems.xyz/v1/technology/convert/batch',
+          {
+            method: 'POST',
+            headers: {
+              'requiems-api-key': 'YOUR_API_KEY',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              operations: [
+                {
+                  from: 'kg',
+                  to: 'lb',
+                  value: 10
+                },
+                {
+                  from: 'c',
+                  to: 'f',
+                  value: 5
+                }
+              ]
+            })
+          }
+        );
+
+        const { data } = await response.json();
+
+        data.results.forEach(item => {
+          console.log(item.from, '->', item.to);
+
+          if (item.success) {
+            console.log('Result:', item.data.result);
+            console.log('Formula:', item.data.formula);
+          } else {
+            console.log('Error:', item.error);
+          }
+        });
+
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/technology/convert/batch')
+
+        request = Net::HTTP::Post.new(uri)
+
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+
+        request.body = {
+          operations: [
+            {
+              from: 'kg',
+              to: 'lb',
+              value: 10
+            },
+            {
+              from: 'c',
+              to: 'f',
+              value: 5
+            }
+          ]
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        JSON.parse(response.body)['data']['results'].each do |item|
+          puts "#{item['from']} -> #{item['to']}"
+
+          if item['success']
+            puts "Result: #{item['data']['result']}"
+            puts "Formula: #{item['data']['formula']}"
+          else
+            puts "Error: #{item['error']}"
+          end
+        end
 supported_units:
   length:
     - key: mm

--- a/apps/dashboard/config/api_docs/unit-conversion.yml
+++ b/apps/dashboard/config/api_docs/unit-conversion.yml
@@ -210,7 +210,8 @@ endpoints:
         required: true
         location: body
         description: "Array of operations to convert (min: 1, max: 50)."
-        example: "[{\"from\":\"kg\",\"to\":\"lb\",\"value\":10},{\"from\":\"c\",\"to\":\"f\",\"value\":5}]"
+        example: |
+          [{"from": "kg", "to": "lb", "value": 10}, {"from": "c", "to": "f", "value": 5}]
     request_example: |
       {
         "operations": [


### PR DESCRIPTION
Endpoint:
- Add BatchItem, BatchRequest, BatchResponse types
- Add ConvertBatch service method with per-operation error handling
- Add POST /convert/batch endpoint via httpx.HandleBatch
- Use *float64 for Value to distinguish absent field from zero

Tests:
- Add service tests for batch conversion and preserved order
- Add transport tests for happy path, empty operations, limit exceeded
- Add transport test for X-Usage-Count response header

Docs:
- Add documentation for POST /convert/batch
- update endpoints_count from 2 to 3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch unit conversion (POST /v1/technology/convert/batch) supporting up to 50 operations, returning per-item results with success/error flags, conversion data, and overall total
  * Response includes a usage-count header

* **Bug Fixes / Validation**
  * Empty or oversized operation lists return validation errors (422)
  * Items missing a value are marked unsuccessful with an error ("value is required")

* **Documentation**
  * Added API docs with multi-language examples

* **Tests**
  * Added coverage for batch endpoint behaviors and validations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->