### PR TITLE
Feat/spell check batch

### DIFF
--- a/apps/api/app/routes_v1.go
+++ b/apps/api/app/routes_v1.go
@@ -75,7 +75,7 @@ func registerV1Routes(ctx context.Context, r chi.Router, pool *pgxpool.Pool, rdb
 
 	if serviceEnabled(cfg, "text") {
 		textRouter := chi.NewRouter()
-		text.RegisterRoutes(textRouter, pool)
+		text.RegisterRoutes(textRouter, pool, cfg)
 		r.Mount("/text", textRouter)
 	}
 

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/nyaruka/phonenumbers v1.7.4
 	github.com/pemistahl/lingua-go v1.4.0
 	github.com/ringsaturn/tzf v1.2.1
-	github.com/sajari/fuzzy v1.0.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.2

--- a/apps/api/platform/config/config.go
+++ b/apps/api/platform/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	EnabledServices    string // comma-separated list of services to mount; empty = all
 	Environment        string // "development" | "staging" | "production"
 	SentryDSN          string
+	LanguageToolURL    string // base URL for LanguageTool spell-check service
 }
 
 func Load() Config {
@@ -33,6 +34,7 @@ func Load() Config {
 		EnabledServices:    envOrDefault("ENABLED_SERVICES", ""),
 		Environment:        envOrDefault("ENVIRONMENT", "development"),
 		SentryDSN:          envOrDefault("SENTRY_DSN", "https://df9023edf98442d4887d1040de81b768@issues.bobadilla.tech/1"),
+		LanguageToolURL:    envOrDefault("LANGUAGETOOL_URL", "http://localhost:8010"),
 	}
 }
 

--- a/apps/api/services/text/router.go
+++ b/apps/api/services/text/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"requiems-api/platform/config"
 	"requiems-api/services/text/detectlanguage"
 	"requiems-api/services/text/lorem"
 	"requiems-api/services/text/normalize"
@@ -14,14 +15,14 @@ import (
 	"requiems-api/services/text/words"
 )
 
-func RegisterRoutes(r chi.Router, pool *pgxpool.Pool) {
+func RegisterRoutes(r chi.Router, pool *pgxpool.Pool, cfg config.Config) {
 	wordsSvc := words.NewService(pool)
 	words.RegisterRoutes(r, wordsSvc)
 
 	loremSvc := lorem.NewService()
 	lorem.RegisterRoutes(r, loremSvc)
 
-	spellcheckSvc := spellcheck.NewService()
+	spellcheckSvc := spellcheck.NewService(cfg.LanguageToolURL)
 	spellcheck.RegisterRoutes(r, spellcheckSvc)
 
 	thesaurusSvc := thesaurus.NewService()

--- a/apps/api/services/text/spellcheck/service.go
+++ b/apps/api/services/text/spellcheck/service.go
@@ -61,6 +61,10 @@ func (s *Service) Check(text string) (Result, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Result{}, fmt.Errorf("spellcheck: languagetool returned status %d", resp.StatusCode)
+	}
+
 	var ltResp ltResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ltResp); err != nil {
 		return Result{}, fmt.Errorf("spellcheck: failed to decode response: %w", err)
@@ -91,7 +95,7 @@ func buildResult(text string, matches []ltMatch) Result {
 	corrections := make([]Correction, 0, len(matches))
 
 	for _, m := range matches {
-		if len(m.Replacements) == 0 || m.Offset+m.Length > len(runes) {
+		if len(m.Replacements) == 0 || m.Offset < 0 || m.Length < 0 || m.Offset+m.Length > len(runes) {
 			continue
 		}
 		// Collect up to 3 suggestions so callers can present a picker.
@@ -115,7 +119,7 @@ func buildResult(text string, matches []ltMatch) Result {
 	copy(corrected, runes)
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
-		if len(m.Replacements) == 0 || m.Offset+m.Length > len(corrected) {
+		if len(m.Replacements) == 0 || m.Offset < 0 || m.Length < 0 || m.Offset+m.Length > len(corrected) {
 			continue
 		}
 		repl := []rune(m.Replacements[0].Value)

--- a/apps/api/services/text/spellcheck/service.go
+++ b/apps/api/services/text/spellcheck/service.go
@@ -72,19 +72,16 @@ func (s *Service) Check(text string) (Result, error) {
 // CheckBatch processes multiple texts and returns spell-check results for each.
 // It returns an error only if LanguageTool is unreachable; individual texts do
 // not produce per-item errors.
-func (s *Service) CheckBatch(texts []string) (BatchCheckResponse, error) {
+func (s *Service) CheckBatch(texts []string) ([]Result, error) {
 	results := make([]Result, 0, len(texts))
 	for _, text := range texts {
 		result, err := s.Check(text)
 		if err != nil {
-			return BatchCheckResponse{}, err
+			return nil, err
 		}
 		results = append(results, result)
 	}
-	return BatchCheckResponse{
-		Results: results,
-		Total:   len(results),
-	}, nil
+	return results, nil
 }
 
 // buildResult converts LanguageTool matches into our Result type.

--- a/apps/api/services/text/spellcheck/service.go
+++ b/apps/api/services/text/spellcheck/service.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -73,19 +74,36 @@ func (s *Service) Check(text string) (Result, error) {
 	return buildResult(text, ltResp.Matches), nil
 }
 
-// CheckBatch processes multiple texts and returns spell-check results for each.
-// It returns an error only if LanguageTool is unreachable; individual texts do
-// not produce per-item errors.
-func (s *Service) CheckBatch(texts []string) ([]Result, error) {
-	results := make([]Result, 0, len(texts))
-	for _, text := range texts {
-		result, err := s.Check(text)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, result)
+// CheckBatch processes multiple texts concurrently and returns spell-check
+// results for each. Up to 10 LanguageTool requests run in parallel to avoid
+// flooding the instance. Results are written to pre-allocated index slots so
+// input order is always preserved. If an individual text fails, its slot
+// receives a zero-value Result and the rest of the batch continues.
+func (s *Service) CheckBatch(texts []string) []Result {
+	const maxWorkers = 10
+
+	results := make([]Result, len(texts))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
+
+	for i, text := range texts {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, text string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			r, err := s.Check(text)
+			if err != nil {
+				results[i] = Result{}
+				return
+			}
+			results[i] = r
+		}(i, text)
 	}
-	return results, nil
+
+	wg.Wait()
+	return results
 }
 
 // buildResult converts LanguageTool matches into our Result type.

--- a/apps/api/services/text/spellcheck/service.go
+++ b/apps/api/services/text/spellcheck/service.go
@@ -1,189 +1,136 @@
 package spellcheck
 
 import (
-	"bufio"
-	"bytes"
-	_ "embed"
-	"errors"
+	"encoding/json"
 	"fmt"
-	"regexp"
+	"net/http"
+	"net/url"
 	"strings"
-	"unicode"
-
-	"github.com/sajari/fuzzy"
+	"time"
 )
 
-//go:embed data/words.txt
-var wordListData []byte
+const defaultLanguageToolURL = "http://localhost:8010"
 
-// wordRe matches sequences of ASCII letters (words).
-var wordRe = regexp.MustCompile(`[a-zA-Z]+`)
-
-// Correction describes a single spelling mistake and its suggested fix.
-type Correction struct {
-	Original  string `json:"original"`
-	Suggested string `json:"suggested"`
-	Position  int    `json:"position"`
+// ltResponse is the subset of the LanguageTool /v2/check response we need.
+type ltResponse struct {
+	Matches []ltMatch `json:"matches"`
 }
 
-// Result is the response payload for the spell check endpoint.
-type Result struct {
-	Corrected   string       `json:"corrected"`
-	Corrections []Correction `json:"corrections"`
+type ltMatch struct {
+	Offset       int             `json:"offset"`
+	Length       int             `json:"length"`
+	Replacements []ltReplacement `json:"replacements"`
 }
 
-// Service performs spell checking and correction.
+type ltReplacement struct {
+	Value string `json:"value"`
+}
+
+// Service calls LanguageTool for spell checking.
 type Service struct {
-	model   *fuzzy.Model
-	initErr error
+	client  *http.Client
+	baseURL string
 }
 
-// NewService returns a new spellcheck Service. If the embedded word list
-// cannot be loaded the service is still valid but Check will return an error.
-func NewService() *Service {
-	m := fuzzy.NewModel()
-	m.SetThreshold(1)
-
-	var words []string
-	scanner := bufio.NewScanner(bytes.NewReader(wordListData))
-	for scanner.Scan() {
-		if w := strings.TrimSpace(scanner.Text()); w != "" {
-			words = append(words, w)
-		}
+// NewService returns a new spellcheck Service backed by LanguageTool.
+// baseURL defaults to http://localhost:8010 if empty.
+func NewService(baseURL string) *Service {
+	if baseURL == "" {
+		baseURL = defaultLanguageToolURL
 	}
-	if err := scanner.Err(); err != nil {
-		return &Service{initErr: fmt.Errorf("spellcheck: word list unavailable: %w", err)}
+	return &Service{
+		client:  &http.Client{Timeout: 10 * time.Second},
+		baseURL: strings.TrimRight(baseURL, "/"),
 	}
-	m.Train(words)
-	return &Service{model: m}
 }
 
-// errUnavailable is returned by Check when the service failed to initialise.
-var errUnavailable = errors.New("spellcheck: service unavailable")
-
-// Check inspects text for spelling mistakes and returns the corrected text
-// together with a list of individual corrections. It returns an error if the
-// service failed to initialise.
+// Check inspects text for spelling mistakes using LanguageTool and returns
+// the corrected text together with a list of individual corrections.
 func (s *Service) Check(text string) (Result, error) {
-	if s.initErr != nil {
-		return Result{}, errUnavailable
+	form := url.Values{}
+	form.Set("text", text)
+	form.Set("language", "en-US")
+
+	resp, err := s.client.Post(
+		s.baseURL+"/v2/check",
+		"application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return Result{}, fmt.Errorf("spellcheck: languagetool unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var ltResp ltResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ltResp); err != nil {
+		return Result{}, fmt.Errorf("spellcheck: failed to decode response: %w", err)
 	}
 
-	var corrections []Correction
+	return buildResult(text, ltResp.Matches), nil
+}
 
-	// Find all word positions so that we can replace in one pass.
-	locs := wordRe.FindAllStringIndex(text, -1)
-
-	// Build the corrected string by walking through every word location.
-	var builder strings.Builder
-	prev := 0
-	for _, loc := range locs {
-		start, end := loc[0], loc[1]
-		word := text[start:end]
-		lower := strings.ToLower(word)
-
-		suggestion := bestSuggestion(lower, s.model)
-
-		// bestSuggestion returns the input unchanged when the word is already
-		// in the model's vocabulary.
-		if suggestion != lower && suggestion != "" {
-			display := matchCase(word, suggestion)
-
-			corrections = append(corrections, Correction{
-				Original:  word,
-				Suggested: display,
-				Position:  len([]rune(text[:start])),
-			})
-
-			// Copy verbatim text before this word, then the correction.
-			builder.WriteString(text[prev:start])
-			builder.WriteString(display)
-		} else {
-			builder.WriteString(text[prev:end])
+// CheckBatch processes multiple texts and returns spell-check results for each.
+// It returns an error only if LanguageTool is unreachable; individual texts do
+// not produce per-item errors.
+func (s *Service) CheckBatch(texts []string) (BatchCheckResponse, error) {
+	results := make([]Result, 0, len(texts))
+	for _, text := range texts {
+		result, err := s.Check(text)
+		if err != nil {
+			return BatchCheckResponse{}, err
 		}
-		prev = end
+		results = append(results, result)
 	}
-	// Append any trailing non-word characters.
-	builder.WriteString(text[prev:])
+	return BatchCheckResponse{
+		Results: results,
+		Total:   len(results),
+	}, nil
+}
+
+// buildResult converts LanguageTool matches into our Result type.
+// Replacements are applied in reverse order to keep offsets valid.
+func buildResult(text string, matches []ltMatch) Result {
+	runes := []rune(text)
+	corrections := make([]Correction, 0, len(matches))
+
+	for _, m := range matches {
+		if len(m.Replacements) == 0 || m.Offset+m.Length > len(runes) {
+			continue
+		}
+		// Collect up to 3 suggestions so callers can present a picker.
+		suggestions := make([]string, 0, 3)
+		for i, r := range m.Replacements {
+			if i >= 3 {
+				break
+			}
+			suggestions = append(suggestions, r.Value)
+		}
+		corrections = append(corrections, Correction{
+			Original:    string(runes[m.Offset : m.Offset+m.Length]),
+			Suggested:   m.Replacements[0].Value,
+			Suggestions: suggestions,
+			Position:    m.Offset,
+		})
+	}
+
+	// Apply replacements in reverse order to preserve offsets.
+	corrected := make([]rune, len(runes))
+	copy(corrected, runes)
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		if len(m.Replacements) == 0 || m.Offset+m.Length > len(corrected) {
+			continue
+		}
+		repl := []rune(m.Replacements[0].Value)
+		corrected = append(corrected[:m.Offset], append(repl, corrected[m.Offset+m.Length:]...)...)
+	}
 
 	if corrections == nil {
 		corrections = []Correction{}
 	}
 
 	return Result{
-		Corrected:   builder.String(),
+		Corrected:   string(corrected),
 		Corrections: corrections,
-	}, nil
-}
-
-// bestSuggestion picks the most likely correction from the model's exhaustive
-// potentials by preferring (in order): lowest Levenshtein distance, then same
-// first letter as the input, then highest corpus score.
-func bestSuggestion(input string, m *fuzzy.Model) string {
-	potentials := m.Potentials(input, true)
-	if len(potentials) == 0 {
-		return input
 	}
-
-	// Return the word unchanged when it is already in the vocabulary.
-	if p, ok := potentials[input]; ok && p.Leven == 0 {
-		return input
-	}
-
-	type candidate struct {
-		term  string
-		lev   int
-		score int
-	}
-
-	var best candidate
-	first := true
-	for _, p := range potentials {
-		if p.Leven == 0 {
-			// Exact match – the word is correct, no suggestion needed.
-			return input
-		}
-		bonus := 0
-		if p.Term != "" && input != "" && p.Term[0] == input[0] {
-			bonus = 100
-		}
-		effectiveScore := p.Score + bonus
-		if first || p.Leven < best.lev || (p.Leven == best.lev && effectiveScore > best.score) {
-			best = candidate{term: p.Term, lev: p.Leven, score: effectiveScore}
-			first = false
-		}
-	}
-
-	return best.term
-}
-
-// matchCase applies the capitalisation pattern of src to dst so that, for
-// example, "Ths" → "This" and "THs" → "THIS".
-func matchCase(src, dst string) string {
-	if src == "" || dst == "" {
-		return dst
-	}
-
-	srcRunes := []rune(src)
-	dstRunes := []rune(dst)
-
-	// All-uppercase source → uppercase suggestion.
-	allUpper := true
-	for _, r := range srcRunes {
-		if unicode.IsLetter(r) && !unicode.IsUpper(r) {
-			allUpper = false
-			break
-		}
-	}
-	if allUpper {
-		return strings.ToUpper(dst)
-	}
-
-	// First letter capitalised → capitalise first letter of suggestion.
-	if unicode.IsUpper(srcRunes[0]) {
-		dstRunes[0] = unicode.ToUpper(dstRunes[0])
-		return string(dstRunes)
-	}
-
-	return dst
 }

--- a/apps/api/services/text/spellcheck/service.go
+++ b/apps/api/services/text/spellcheck/service.go
@@ -92,6 +92,11 @@ func (s *Service) CheckBatch(texts []string) []Result {
 		go func(i int, text string) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			defer func() {
+				if rec := recover(); rec != nil {
+					results[i] = Result{}
+				}
+			}()
 
 			r, err := s.Check(text)
 			if err != nil {
@@ -106,6 +111,16 @@ func (s *Service) CheckBatch(texts []string) []Result {
 	return results
 }
 
+// isValidSpan reports whether m describes a non-empty, non-overflowing span
+// within a slice of runeCount runes.
+func isValidSpan(m ltMatch, runeCount int) bool {
+	return len(m.Replacements) > 0 &&
+		m.Offset >= 0 &&
+		m.Length >= 0 &&
+		m.Offset < runeCount &&
+		m.Length <= runeCount-m.Offset
+}
+
 // buildResult converts LanguageTool matches into our Result type.
 // Replacements are applied in reverse order to keep offsets valid.
 func buildResult(text string, matches []ltMatch) Result {
@@ -113,7 +128,7 @@ func buildResult(text string, matches []ltMatch) Result {
 	corrections := make([]Correction, 0, len(matches))
 
 	for _, m := range matches {
-		if len(m.Replacements) == 0 || m.Offset < 0 || m.Length < 0 || m.Offset+m.Length > len(runes) {
+		if !isValidSpan(m, len(runes)) {
 			continue
 		}
 		// Collect up to 3 suggestions so callers can present a picker.
@@ -137,7 +152,7 @@ func buildResult(text string, matches []ltMatch) Result {
 	copy(corrected, runes)
 	for i := len(matches) - 1; i >= 0; i-- {
 		m := matches[i]
-		if len(m.Replacements) == 0 || m.Offset < 0 || m.Length < 0 || m.Offset+m.Length > len(corrected) {
+		if !isValidSpan(m, len(corrected)) {
 			continue
 		}
 		repl := []rune(m.Replacements[0].Value)

--- a/apps/api/services/text/spellcheck/service_test.go
+++ b/apps/api/services/text/spellcheck/service_test.go
@@ -140,3 +140,31 @@ func TestService_Check_SuggestionsOnlyOne(t *testing.T) {
 	require.Len(t, result.Corrections, 1)
 	assert.Equal(t, []string{"test"}, result.Corrections[0].Suggestions)
 }
+
+func TestService_Check_LanguageToolNonOKStatus(t *testing.T) {
+	t.Parallel()
+	// Simulate LanguageTool returning a 500 — Check must propagate this as an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := NewService(srv.URL).Check("hello")
+	assert.Error(t, err)
+}
+
+func TestService_Check_NegativeOffsetIgnored(t *testing.T) {
+	t.Parallel()
+	// A match with a negative offset is malformed — it must be silently skipped,
+	// leaving the corrected text equal to the input.
+	srv := newMockLT(t, []ltMatch{
+		{Offset: -1, Length: 3, Replacements: []ltReplacement{{Value: "This"}}},
+	})
+	defer srv.Close()
+
+	result, err := NewService(srv.URL).Check("Ths is fine")
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Corrections)
+	assert.Equal(t, "Ths is fine", result.Corrected)
+}

--- a/apps/api/services/text/spellcheck/service_test.go
+++ b/apps/api/services/text/spellcheck/service_test.go
@@ -1,105 +1,133 @@
 package spellcheck
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// newMockLT starts a test HTTP server that returns the given matches,
+// simulating the LanguageTool /v2/check endpoint.
+func newMockLT(t *testing.T, matches []ltMatch) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ltResponse{Matches: matches})
+	}))
+}
+
 func TestService_Check_NoMistakes(t *testing.T) {
 	t.Parallel()
-	svc := NewService()
+	srv := newMockLT(t, []ltMatch{})
+	defer srv.Close()
 
-	result, err := svc.Check("This is a test")
+	result, err := NewService(srv.URL).Check("This is a test")
+
 	require.NoError(t, err)
-
 	assert.Equal(t, "This is a test", result.Corrected)
-	assert.Len(t, result.Corrections, 0)
+	assert.Empty(t, result.Corrections)
 }
 
 func TestService_Check_MisspelledWords(t *testing.T) {
 	t.Parallel()
-	svc := NewService()
+	srv := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 3, Replacements: []ltReplacement{{Value: "This"}}},
+		{Offset: 9, Length: 4, Replacements: []ltReplacement{{Value: "test"}}},
+	})
+	defer srv.Close()
 
-	result, err := svc.Check("Ths is a tset")
+	result, err := NewService(srv.URL).Check("Ths is a tset")
+
 	require.NoError(t, err)
-
-	assert.NotEmpty(t, result.Corrections)
-
-	foundThs := false
-	foundTset := false
-	for _, c := range result.Corrections {
-		if c.Original == "Ths" && c.Position == 0 && c.Suggested != "" {
-			foundThs = true
-		}
-		if c.Original == "tset" && c.Position == 9 && c.Suggested != "" {
-			foundTset = true
-		}
-	}
-
-	assert.True(t, foundThs, "expected correction for Ths at position 0; got %+v", result.Corrections)
-	assert.True(t, foundTset, "expected correction for tset at position 9; got %+v", result.Corrections)
-}
-
-func TestService_Check_EmptyText(t *testing.T) {
-	t.Parallel()
-	svc := NewService()
-
-	// Empty text is not a valid request (validate:"required" enforces that at
-	// the HTTP layer), but the service itself should return a safe empty result.
-	result, err := svc.Check("")
-	require.NoError(t, err)
-
-	assert.Equal(t, "", result.Corrected)
-	assert.Len(t, result.Corrections, 0)
+	require.Len(t, result.Corrections, 2)
+	assert.Equal(t, "Ths", result.Corrections[0].Original)
+	assert.Equal(t, "This", result.Corrections[0].Suggested)
+	assert.Equal(t, 0, result.Corrections[0].Position)
+	assert.Equal(t, "tset", result.Corrections[1].Original)
+	assert.Equal(t, "test", result.Corrections[1].Suggested)
+	assert.Equal(t, 9, result.Corrections[1].Position)
 }
 
 func TestService_Check_CorrectedTextReflectsFixes(t *testing.T) {
 	t.Parallel()
-	svc := NewService()
+	srv := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 3, Replacements: []ltReplacement{{Value: "This"}}},
+		{Offset: 9, Length: 4, Replacements: []ltReplacement{{Value: "test"}}},
+	})
+	defer srv.Close()
 
-	result, err := svc.Check("Ths is a tset")
+	result, err := NewService(srv.URL).Check("Ths is a tset")
+
 	require.NoError(t, err)
-
-	assert.False(t, result.Corrected == "Ths is a tset", "expected corrected text to differ from misspelled input")
+	assert.Equal(t, "This is a test", result.Corrected)
 }
 
 func TestService_Check_CorrectionsSliceNotNil(t *testing.T) {
 	t.Parallel()
-	svc := NewService()
+	srv := newMockLT(t, []ltMatch{})
+	defer srv.Close()
 
-	result, err := svc.Check("Hello world")
+	result, err := NewService(srv.URL).Check("Hello world")
+
 	require.NoError(t, err)
-
 	assert.NotNil(t, result.Corrections)
+}
+
+func TestService_Check_Unreachable(t *testing.T) {
+	t.Parallel()
+	// Nothing is listening on this port.
+	_, err := NewService("http://localhost:19999").Check("hello")
+	assert.Error(t, err)
 }
 
 func TestService_Check_PositionIsRuneOffset(t *testing.T) {
 	t.Parallel()
-	svc := NewService()
-	// "é" is a single rune but 2 UTF-8 bytes.
-	// "tset" starts at rune index 2 (é=1, space=1) but byte index 3.
-	result, err := svc.Check("é tset")
+	// "é" is one rune but two UTF-8 bytes. "tset" starts at rune index 2.
+	srv := newMockLT(t, []ltMatch{
+		{Offset: 2, Length: 4, Replacements: []ltReplacement{{Value: "test"}}},
+	})
+	defer srv.Close()
+
+	result, err := NewService(srv.URL).Check("é tset")
+
 	require.NoError(t, err)
-	require.NotEmpty(t, result.Corrections)
+	require.Len(t, result.Corrections, 1)
 	assert.Equal(t, 2, result.Corrections[0].Position)
 }
 
-func TestMatchCase_LowerInput(t *testing.T) {
+func TestService_Check_SuggestionsTopThree(t *testing.T) {
 	t.Parallel()
-	got := matchCase("abc", "suggested")
-	assert.Equal(t, "suggested", got)
+	// LanguageTool returns 4 replacements; we expect only the first 3.
+	srv := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 3, Replacements: []ltReplacement{
+			{Value: "This"}, {Value: "The"}, {Value: "Thus"}, {Value: "Those"},
+		}},
+	})
+	defer srv.Close()
+
+	result, err := NewService(srv.URL).Check("Ths is fine")
+
+	require.NoError(t, err)
+	require.Len(t, result.Corrections, 1)
+	assert.Equal(t, "This", result.Corrections[0].Suggested)
+	assert.Equal(t, []string{"This", "The", "Thus"}, result.Corrections[0].Suggestions)
 }
 
-func TestMatchCase_CapitalisedInput(t *testing.T) {
+func TestService_Check_SuggestionsOnlyOne(t *testing.T) {
 	t.Parallel()
-	got := matchCase("Abc", "suggested")
-	assert.Equal(t, "Suggested", got)
-}
+	// When LanguageTool returns a single replacement, Suggestions has length 1.
+	srv := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 4, Replacements: []ltReplacement{{Value: "test"}}},
+	})
+	defer srv.Close()
 
-func TestMatchCase_AllUpperInput(t *testing.T) {
-	t.Parallel()
-	got := matchCase("ABC", "suggested")
-	assert.Equal(t, "SUGGESTED", got)
+	result, err := NewService(srv.URL).Check("tset done")
+
+	require.NoError(t, err)
+	require.Len(t, result.Corrections, 1)
+	assert.Equal(t, []string{"test"}, result.Corrections[0].Suggestions)
 }

--- a/apps/api/services/text/spellcheck/service_test.go
+++ b/apps/api/services/text/spellcheck/service_test.go
@@ -12,9 +12,14 @@ import (
 
 // newMockLT starts a test HTTP server that returns the given matches,
 // simulating the LanguageTool /v2/check endpoint.
+// It asserts the HTTP contract: the caller must use POST /v2/check.
 func newMockLT(t *testing.T, matches []ltMatch) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/check" {
+			http.Error(w, "unexpected request: want POST /v2/check", http.StatusBadRequest)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(ltResponse{Matches: matches})
 	}))
@@ -79,8 +84,12 @@ func TestService_Check_CorrectionsSliceNotNil(t *testing.T) {
 
 func TestService_Check_Unreachable(t *testing.T) {
 	t.Parallel()
-	// Nothing is listening on this port.
-	_, err := NewService("http://localhost:19999").Check("hello")
+	// Start and immediately close a server to get a guaranteed-dead URL
+	// without relying on a fixed port that might be in use.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead.Close()
+
+	_, err := NewService(dead.URL).Check("hello")
 	assert.Error(t, err)
 }
 

--- a/apps/api/services/text/spellcheck/service_test.go
+++ b/apps/api/services/text/spellcheck/service_test.go
@@ -168,3 +168,32 @@ func TestService_Check_NegativeOffsetIgnored(t *testing.T) {
 	assert.Empty(t, result.Corrections)
 	assert.Equal(t, "Ths is fine", result.Corrected)
 }
+
+func TestService_CheckBatch_OrderPreserved(t *testing.T) {
+	t.Parallel()
+	// No matches — Corrected equals the input, so we can verify order by content.
+	srv := newMockLT(t, []ltMatch{})
+	defer srv.Close()
+
+	texts := []string{"first", "second", "third"}
+	results := NewService(srv.URL).CheckBatch(texts)
+
+	require.Len(t, results, 3)
+	for i, want := range texts {
+		assert.Equal(t, want, results[i].Corrected, "results[%d] out of order", i)
+	}
+}
+
+func TestService_CheckBatch_LTUnreachable(t *testing.T) {
+	t.Parallel()
+	// Dead server — each item gets a zero-value Result; the batch never errors out.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead.Close()
+
+	results := NewService(dead.URL).CheckBatch([]string{"hello", "world"})
+
+	require.Len(t, results, 2)
+	for i, r := range results {
+		assert.Equal(t, "", r.Corrected, "results[%d].Corrected should be zero-value", i)
+	}
+}

--- a/apps/api/services/text/spellcheck/transport_http.go
+++ b/apps/api/services/text/spellcheck/transport_http.go
@@ -23,10 +23,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 	r.Post("/spellcheck/batch", httpx.HandleBatch(
 		func(_ context.Context, req BatchCheckRequest) (BatchCheckResponse, error) {
-			results, err := svc.CheckBatch(req.Texts)
-			if err != nil {
-				return BatchCheckResponse{}, err
-			}
+			results := svc.CheckBatch(req.Texts)
 			return BatchCheckResponse{Results: results}, nil
 		},
 	))

--- a/apps/api/services/text/spellcheck/transport_http.go
+++ b/apps/api/services/text/spellcheck/transport_http.go
@@ -20,4 +20,11 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 			return svc.Check(req.Text)
 		},
 	))
+
+	r.Post("/spellcheck/batch", httpx.HandleBatch(
+		func(_ context.Context, req BatchCheckRequest) (BatchCheckResponse, int, error) {
+			res, err := svc.CheckBatch(req.Texts)
+			return res, len(req.Texts), err
+		},
+	))
 }

--- a/apps/api/services/text/spellcheck/transport_http.go
+++ b/apps/api/services/text/spellcheck/transport_http.go
@@ -22,9 +22,12 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	))
 
 	r.Post("/spellcheck/batch", httpx.HandleBatch(
-		func(_ context.Context, req BatchCheckRequest) (BatchCheckResponse, int, error) {
-			res, err := svc.CheckBatch(req.Texts)
-			return res, len(req.Texts), err
+		func(_ context.Context, req BatchCheckRequest) (BatchCheckResponse, error) {
+			results, err := svc.CheckBatch(req.Texts)
+			if err != nil {
+				return BatchCheckResponse{}, err
+			}
+			return BatchCheckResponse{Results: results}, nil
 		},
 	))
 }

--- a/apps/api/services/text/spellcheck/transport_http_test.go
+++ b/apps/api/services/text/spellcheck/transport_http_test.go
@@ -229,9 +229,11 @@ func TestSpellcheckBatch_MissingBody(t *testing.T) {
 
 func TestSpellcheckBatch_ServiceError(t *testing.T) {
 	t.Parallel()
-	// Point the service at a port where nothing is listening so every
-	// LanguageTool call fails, simulating an unreachable backend.
-	r := setupRouter("http://localhost:19999")
+	// Start and immediately close a server to get a guaranteed-dead URL
+	// without relying on a fixed port that might be in use.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead.Close()
+	r := setupRouter(dead.URL)
 
 	body := `{"texts":["Hello world","Clean text"]}`
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))

--- a/apps/api/services/text/spellcheck/transport_http_test.go
+++ b/apps/api/services/text/spellcheck/transport_http_test.go
@@ -227,10 +227,10 @@ func TestSpellcheckBatch_MissingBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestSpellcheckBatch_ServiceError(t *testing.T) {
+func TestSpellcheckBatch_LTUnreachableReturnsZeroResults(t *testing.T) {
 	t.Parallel()
-	// Start and immediately close a server to get a guaranteed-dead URL
-	// without relying on a fixed port that might be in use.
+	// When LanguageTool is unreachable, CheckBatch uses in-band errors:
+	// each failing item receives a zero-value Result and the batch returns 200.
 	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	dead.Close()
 	r := setupRouter(dead.URL)
@@ -241,5 +241,12 @@ func TestSpellcheckBatch_ServiceError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[BatchCheckResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 2)
+	// Each slot is a zero-value Result: Corrected is empty, Corrections is nil.
+	assert.Equal(t, "", resp.Data.Results[0].Corrected)
+	assert.Equal(t, "", resp.Data.Results[1].Corrected)
 }

--- a/apps/api/services/text/spellcheck/transport_http_test.go
+++ b/apps/api/services/text/spellcheck/transport_http_test.go
@@ -14,61 +14,73 @@ import (
 	"requiems-api/platform/httpx"
 )
 
-func setupRouter() chi.Router {
+func setupRouter(ltURL string) chi.Router {
 	r := chi.NewRouter()
-	RegisterRoutes(r, NewService())
+	RegisterRoutes(r, NewService(ltURL))
 	return r
 }
 
+// noopLT returns a mock LanguageTool server that always responds with no matches.
+// Use it for tests that only check validation errors (422, 400) where LanguageTool
+// is never actually reached.
+func noopLT(t *testing.T) *httptest.Server {
+	t.Helper()
+	return newMockLT(t, []ltMatch{})
+}
+
+// ── /spellcheck ──────────────────────────────────────────────────────────────
+
 func TestSpellcheck_CleanText(t *testing.T) {
 	t.Parallel()
-	r := setupRouter()
+	lt := newMockLT(t, []ltMatch{})
+	defer lt.Close()
+	r := setupRouter(lt.URL)
 
 	body := `{"text":"Hello world"}`
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var resp httpx.Response[Result]
-	err := json.NewDecoder(w.Body).Decode(&resp)
-	require.NoError(t, err)
-
-	assert.Len(t, resp.Data.Corrections, 0)
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp.Data.Corrections)
 }
 
 func TestSpellcheck_MisspelledText(t *testing.T) {
 	t.Parallel()
-	r := setupRouter()
+	lt := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 3, Replacements: []ltReplacement{{Value: "This"}}},
+		{Offset: 9, Length: 4, Replacements: []ltReplacement{{Value: "test"}}},
+	})
+	defer lt.Close()
+	r := setupRouter(lt.URL)
 
 	body := `{"text":"Ths is a tset"}`
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var resp httpx.Response[Result]
-	err := json.NewDecoder(w.Body).Decode(&resp)
-	require.NoError(t, err)
-
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	assert.NotEmpty(t, resp.Data.Corrections)
-	assert.False(t, resp.Data.Corrected == "Ths is a tset", "expected corrected text to differ from input")
+	assert.NotEqual(t, "Ths is a tset", resp.Data.Corrected)
 }
 
 func TestSpellcheck_MissingTextField(t *testing.T) {
 	t.Parallel()
-	r := setupRouter()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
 
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
@@ -76,12 +88,136 @@ func TestSpellcheck_MissingTextField(t *testing.T) {
 
 func TestSpellcheck_MissingBody(t *testing.T) {
 	t.Parallel()
-	r := setupRouter()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
 
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck", http.NoBody)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
 
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── /spellcheck/batch ────────────────────────────────────────────────────────
+
+func TestSpellcheckBatch_MixedTexts(t *testing.T) {
+	t.Parallel()
+	lt := newMockLT(t, []ltMatch{
+		{Offset: 0, Length: 3, Replacements: []ltReplacement{{Value: "This"}}},
+	})
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	body := `{"texts":["Hello world","Ths is a tset","Simple test"]}`
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchCheckResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 3)
+}
+
+func TestSpellcheckBatch_OrderPreserved(t *testing.T) {
+	t.Parallel()
+	lt := newMockLT(t, []ltMatch{})
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	// RFC requires results to stay in the same order as the input array.
+	body := `{"texts":["Hello world","Clean text","More clean text"]}`
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchCheckResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Data.Results, 3)
+}
+
+func TestSpellcheckBatch_UsageCountHeader(t *testing.T) {
+	t.Parallel()
+	lt := newMockLT(t, []ltMatch{})
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	body := `{"texts":["Hello world","Clean text","More text"]}`
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	// The gateway reads this header to charge per item instead of per request.
+	assert.Equal(t, "3", w.Header().Get("X-Usage-Count"))
+}
+
+func TestSpellcheckBatch_EmptyArray(t *testing.T) {
+	t.Parallel()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(`{"texts":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestSpellcheckBatch_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	// 51 texts — one over the maximum of 50.
+	texts := make([]string, 51)
+	for i := range texts {
+		texts[i] = `"hello world"`
+	}
+	body := `{"texts":[` + strings.Join(texts, ",") + `]}`
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestSpellcheckBatch_MissingTextsField(t *testing.T) {
+	t.Parallel()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestSpellcheckBatch_MissingBody(t *testing.T) {
+	t.Parallel()
+	lt := noopLT(t)
+	defer lt.Close()
+	r := setupRouter(lt.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", http.NoBody)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/apps/api/services/text/spellcheck/transport_http_test.go
+++ b/apps/api/services/text/spellcheck/transport_http_test.go
@@ -126,11 +126,12 @@ func TestSpellcheckBatch_MixedTexts(t *testing.T) {
 
 func TestSpellcheckBatch_OrderPreserved(t *testing.T) {
 	t.Parallel()
+	// No matches returned — so Corrected equals the original text for every
+	// item, letting us assert that each result maps to the right input position.
 	lt := newMockLT(t, []ltMatch{})
 	defer lt.Close()
 	r := setupRouter(lt.URL)
 
-	// RFC requires results to stay in the same order as the input array.
 	body := `{"texts":["Hello world","Clean text","More clean text"]}`
 	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -142,6 +143,9 @@ func TestSpellcheckBatch_OrderPreserved(t *testing.T) {
 	var resp httpx.Response[BatchCheckResponse]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	require.Len(t, resp.Data.Results, 3)
+	assert.Equal(t, "Hello world", resp.Data.Results[0].Corrected)
+	assert.Equal(t, "Clean text", resp.Data.Results[1].Corrected)
+	assert.Equal(t, "More clean text", resp.Data.Results[2].Corrected)
 }
 
 func TestSpellcheckBatch_UsageCountHeader(t *testing.T) {
@@ -221,4 +225,19 @@ func TestSpellcheckBatch_MissingBody(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSpellcheckBatch_ServiceError(t *testing.T) {
+	t.Parallel()
+	// Point the service at a port where nothing is listening so every
+	// LanguageTool call fails, simulating an unreachable backend.
+	r := setupRouter("http://localhost:19999")
+
+	body := `{"texts":["Hello world","Clean text"]}`
+	req := httptest.NewRequest(http.MethodPost, "/spellcheck/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/apps/api/services/text/spellcheck/type.go
+++ b/apps/api/services/text/spellcheck/type.go
@@ -1,0 +1,38 @@
+package spellcheck
+
+// Request is the input for the spell check endpoint.
+type Request struct {
+	Text string `json:"text" validate:"required"`
+}
+
+// Correction describes a single spelling mistake and its suggested fix.
+// Suggested holds the best replacement (used in the auto-corrected text).
+// Suggestions holds the top-3 alternatives returned by LanguageTool so
+// callers can surface a picker instead of applying the first option blindly.
+type Correction struct {
+	Original    string   `json:"original"`
+	Suggested   string   `json:"suggested"`
+	Suggestions []string `json:"suggestions"`
+	Position    int      `json:"position"`
+}
+
+// Result is the response payload for the spell check endpoint.
+type Result struct {
+	Corrected   string       `json:"corrected"`
+	Corrections []Correction `json:"corrections"`
+}
+
+func (Result) IsData() {}
+
+// BatchCheckRequest is the body for checking multiple texts at once.
+type BatchCheckRequest struct {
+	Texts []string `json:"texts" validate:"required,min=1,max=50,dive,required"`
+}
+
+// BatchCheckResponse is the response for a batch spell check request.
+type BatchCheckResponse struct {
+	Results []Result `json:"results"`
+	Total   int      `json:"total"`
+}
+
+func (BatchCheckResponse) IsData() {}

--- a/apps/api/services/text/spellcheck/type.go
+++ b/apps/api/services/text/spellcheck/type.go
@@ -2,11 +2,6 @@ package spellcheck
 
 import "requiems-api/platform/httpx"
 
-// Request is the input for the spell check endpoint.
-type Request struct {
-	Text string `json:"text" validate:"required"`
-}
-
 // Correction describes a single spelling mistake and its suggested fix.
 // Suggested holds the best replacement (used in the auto-corrected text).
 // Suggestions holds the top-3 alternatives returned by LanguageTool so

--- a/apps/api/services/text/spellcheck/type.go
+++ b/apps/api/services/text/spellcheck/type.go
@@ -1,5 +1,7 @@
 package spellcheck
 
+import "requiems-api/platform/httpx"
+
 // Request is the input for the spell check endpoint.
 type Request struct {
 	Text string `json:"text" validate:"required"`
@@ -29,10 +31,5 @@ type BatchCheckRequest struct {
 	Texts []string `json:"texts" validate:"required,min=1,max=50,dive,required"`
 }
 
-// BatchCheckResponse is the response for a batch spell check request.
-type BatchCheckResponse struct {
-	Results []Result `json:"results"`
-	Total   int      `json:"total"`
-}
-
-func (BatchCheckResponse) IsData() {}
+// BatchCheckResponse is the standard batch envelope for spell-check results.
+type BatchCheckResponse = httpx.BatchResponse[Result]

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -428,7 +428,8 @@ apis:
     categories:
       - text
     description: Check spelling and get correction suggestions for misspelled words
-    endpoints_count: 1
+    endpoints_count: 2
+    batch_eligible: true
     status: live
     popular: true
     documentation_url: /apis/spell-check

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -429,7 +429,6 @@ apis:
       - text
     description: Check spelling and get correction suggestions for misspelled words
     endpoints_count: 2
-    batch_eligible: true
     status: live
     popular: true
     documentation_url: /apis/spell-check

--- a/apps/dashboard/config/api_docs/spell-check.yml
+++ b/apps/dashboard/config/api_docs/spell-check.yml
@@ -113,6 +113,110 @@ endpoints:
         data = JSON.parse(response.body)
         puts data['data']['corrected']
         data['data']['corrections'].each { |c| puts "#{c['original']} -> #{c['suggested']}" }
+  - name: Check Spelling (Batch)
+    method: POST
+    path: /v1/text/spellcheck/batch
+    description: Checks multiple texts for spelling mistakes in a single request. Returns a corrected version and per-word corrections for each input text. Results are returned in the same order as the input array.
+    parameters:
+      - name: texts
+        type: array
+        required: true
+        location: body
+        description: The list of texts to spell-check. Between 1 and 50 items.
+        example: '["Ths is a tset", "Smiple example"]'
+    request_example: |
+      {
+        "texts": ["Ths is a tset", "Smiple example"]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "corrected": "This is a test",
+              "corrections": [
+                {"original": "Ths", "suggested": "This", "position": 0},
+                {"original": "tset", "suggested": "test", "position": 9}
+              ]
+            },
+            {
+              "corrected": "Simple example",
+              "corrections": [
+                {"original": "Smiple", "suggested": "Simple", "position": 0}
+              ]
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-01-01T00:00:00Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array of objects
+        description: One entry per input text, in the same order as the input array. Each item contains corrected (the fixed text) and corrections (list of individual corrections with original, suggested, and position).
+      - name: total
+        type: integer
+        description: Number of texts processed. Equals the length of the input array.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The texts field is missing, empty, or exceeds 50 items.
+      - code: bad_request
+        status: 400
+        description: The request body is missing or malformed.
+      - code: internal_error
+        status: 500
+        description: Unexpected server error.
+    code_examples:
+      curl: |
+        curl -X POST https://api.requiems.xyz/v1/text/spellcheck/batch \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"texts": ["Ths is a tset", "Smiple example"]}'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/text/spellcheck/batch"
+        headers = {
+            "requiems-api-key": "YOUR_API_KEY",
+            "Content-Type": "application/json"
+        }
+        payload = {"texts": ["Ths is a tset", "Smiple example"]}
+
+        response = requests.post(url, headers=headers, json=payload)
+        data = response.json()
+        for item in data["data"]["results"]:
+            print(item["corrected"])
+      javascript: |
+        const response = await fetch('https://api.requiems.xyz/v1/text/spellcheck/batch', {
+          method: 'POST',
+          headers: {
+            'requiems-api-key': 'YOUR_API_KEY',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ texts: ['Ths is a tset', 'Smiple example'] })
+        });
+
+        const data = await response.json();
+        data.data.results.forEach(item => console.log(item.corrected));
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/text/spellcheck/batch')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = { texts: ['Ths is a tset', 'Smiple example'] }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        data = JSON.parse(response.body)
+        data['data']['results'].each { |item| puts item['corrected'] }
 faq:
   - question: What language does spell check support?
     answer: The spell checker currently supports English only.

--- a/apps/dashboard/config/api_docs/spell-check.yml
+++ b/apps/dashboard/config/api_docs/spell-check.yml
@@ -11,11 +11,11 @@ overview:
     - Form validation and input sanitisation
     - Educational platforms and grammar tools
   features:
-    - Detects misspelled words using an English dictionary
-    - Provides the best correction suggestion per misspelled word
+    - Detects misspelled words and grammar issues using LanguageTool
+    - Returns the best correction and up to 3 ranked alternative suggestions per misspelled word
     - Returns character positions for each correction
-    - Preserves original capitalisation in suggestions
-    - Only ASCII letter sequences are spell-checked; non-ASCII characters are passed through unchanged
+    - Supports full Unicode input including accented and non-Latin characters
+    - Batch endpoint processes up to 50 texts in a single request
 endpoints:
   - name: Check Spelling
     method: POST
@@ -37,9 +37,24 @@ endpoints:
         "data": {
           "corrected": "This is a simple test",
           "corrections": [
-            {"original": "Ths", "suggested": "This", "position": 0},
-            {"original": "smiple", "suggested": "simple", "position": 9},
-            {"original": "tset", "suggested": "test", "position": 16}
+            {
+              "original": "Ths",
+              "suggested": "This",
+              "suggestions": ["Th's", "Th", "This"],
+              "position": 0
+            },
+            {
+              "original": "smiple",
+              "suggested": "simple",
+              "suggestions": ["simple", "smile", "Siple"],
+              "position": 9
+            },
+            {
+              "original": "tset",
+              "suggested": "test",
+              "suggestions": ["set", "test", "stet"],
+              "position": 16
+            }
           ]
         },
         "metadata": {
@@ -49,12 +64,13 @@ endpoints:
     response_fields:
       - name: corrected
         type: string
-        description: The full input text with all misspelled words replaced by their suggested corrections
+        description: The full input text with all misspelled words replaced by the top-ranked suggestion
       - name: corrections
         type: array of objects
         description: >-
           List of individual corrections. Each item contains: original (the misspelled word), suggested (the
-          correction), and position (0-based character offset in the original text)
+          top-ranked replacement applied to corrected), suggestions (up to 3 ranked alternatives returned by
+          LanguageTool, from most to least likely), and position (0-based Unicode character offset in the original text)
     errors:
       - code: validation_failed
         status: 422
@@ -135,14 +151,29 @@ endpoints:
             {
               "corrected": "This is a test",
               "corrections": [
-                {"original": "Ths", "suggested": "This", "position": 0},
-                {"original": "tset", "suggested": "test", "position": 9}
+                {
+                  "original": "Ths",
+                  "suggested": "This",
+                  "suggestions": ["Th's", "Th", "This"],
+                  "position": 0
+                },
+                {
+                  "original": "tset",
+                  "suggested": "test",
+                  "suggestions": ["set", "test", "stet"],
+                  "position": 9
+                }
               ]
             },
             {
               "corrected": "Simple example",
               "corrections": [
-                {"original": "Smiple", "suggested": "Simple", "position": 0}
+                {
+                  "original": "Smiple",
+                  "suggested": "Simple",
+                  "suggestions": ["Simple", "Smile", "Siple"],
+                  "position": 0
+                }
               ]
             }
           ],
@@ -155,7 +186,9 @@ endpoints:
     response_fields:
       - name: results
         type: array of objects
-        description: One entry per input text, in the same order as the input array. Each item contains corrected (the fixed text) and corrections (list of individual corrections with original, suggested, and position).
+        description: >-
+          One entry per input text, in the same order as the input array. Each item contains corrected (the fixed
+          text) and corrections (list of individual corrections with original, suggested, suggestions, and position).
       - name: total
         type: integer
         description: Number of texts processed. Equals the length of the input array.
@@ -219,17 +252,20 @@ endpoints:
         data['data']['results'].each { |item| puts item['corrected'] }
 faq:
   - question: What language does spell check support?
-    answer: The spell checker currently supports English only.
+    answer: The spell checker currently processes text as English (en-US). Multi-language support is planned for a future release.
   - question: Are positions zero-indexed?
     answer: >-
       Yes. The position field is a 0-based Unicode character (rune) offset in the original input string. This matches
       how Python, JavaScript, and Ruby index strings.
   - question: What happens if the text has no spelling mistakes?
     answer: "The corrected field will equal the input text and corrections will be an empty array: []."
-  - question: Does capitalisation affect the correction?
+  - question: What is the difference between suggested and suggestions?
     answer: >-
-      No. Spell checking is case-insensitive. The suggested correction mirrors the capitalisation of the original word:
-      a capitalised misspelling produces a capitalised suggestion.
+      suggested is the single best replacement, already applied to the corrected text. suggestions is an ordered list
+      of up to 3 alternatives returned by LanguageTool (from most to least likely), which you can use to present a
+      correction picker to your users instead of applying the first option automatically.
+  - question: How many items can I send in a batch request?
+    answer: Between 1 and 50 texts per request. Requests with an empty array or more than 50 items return 422.
 performance:
   p50_ms: 807
   p95_ms: 1147

--- a/docs/apis/text/spell-check.md
+++ b/docs/apis/text/spell-check.md
@@ -133,7 +133,11 @@ Each text in the batch counts as **1 unit** of quota. A request with 10 texts co
 
 ### Partial failure
 
-This endpoint always returns `200` with a result for every input text. There are no per-item errors — if LanguageTool is unreachable, the entire batch fails with `500`.
+This endpoint always returns `200` with a result for every input text. Up to 10
+texts are checked concurrently. If LanguageTool is unreachable for an individual
+text, that slot returns a zero-value result (`corrected: ""`, `corrections: null`)
+and the batch continues — the caller receives a full-length `results` array
+regardless of individual failures.
 
 ### Batch Error Codes
 

--- a/docs/apis/text/spell-check.md
+++ b/docs/apis/text/spell-check.md
@@ -69,6 +69,82 @@ Each `corrections` entry:
   characters (accented letters, CJK, emoji, etc.) are passed through unchanged
   and do not affect position counting.
 
+---
+
+## Batch Endpoint
+
+`POST /v1/text/spellcheck/batch`
+
+Check spelling for multiple texts in a single request. Results are returned in the same order as the input array.
+
+### Request
+
+```json
+{
+  "texts": ["Ths is a tset", "Smiple example"]
+}
+```
+
+| Field   | Type             | Required | Description                                   |
+| ------- | ---------------- | -------- | --------------------------------------------- |
+| `texts` | array of strings | ✅       | Texts to spell-check. Between 1 and 50 items. |
+
+### Response
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "corrected": "This is a test",
+        "corrections": [
+          { "original": "Ths", "suggested": "This", "position": 0 },
+          { "original": "tset", "suggested": "test", "position": 9 }
+        ]
+      },
+      {
+        "corrected": "Simple example",
+        "corrections": [
+          { "original": "Smiple", "suggested": "Simple", "position": 0 }
+        ]
+      }
+    ],
+    "total": 2
+  },
+  "metadata": {
+    "timestamp": "2026-01-01T00:00:00Z"
+  }
+}
+```
+
+| Field     | Type             | Description                                                                                                                     |
+| --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `results` | array of objects | One entry per input text, in input order. Each item has `corrected` and `corrections` (same shape as the single endpoint). |
+| `total`   | integer          | Number of texts processed.                                                                                                      |
+
+### Limits
+
+- Minimum **1** text per request, maximum **50**.
+- Request body capped at **1 MiB**.
+
+### Billing
+
+Each text in the batch counts as **1 unit** of quota. A request with 10 texts consumes 10 units.
+
+### Partial failure
+
+This endpoint always returns `200` with a result for every input text. There are no per-item errors — spell-checking is pure local computation with no external dependencies. If the service is unavailable, the entire request fails with `500`.
+
+### Batch Error Codes
+
+| Code                | Status | When                                                       |
+| ------------------- | ------ | ---------------------------------------------------------- |
+| `validation_failed` | 422    | `texts` is missing, empty, or contains more than 50 items  |
+| `bad_request`       | 400    | Request body is missing or not JSON                        |
+| `internal_error`    | 500    | Unexpected failure                                         |
+
+---
+
 ## Error Codes
 
 | Code                | Status | When                                |

--- a/docs/apis/text/spell-check.md
+++ b/docs/apis/text/spell-check.md
@@ -133,7 +133,7 @@ Each text in the batch counts as **1 unit** of quota. A request with 10 texts co
 
 ### Partial failure
 
-This endpoint always returns `200` with a result for every input text. There are no per-item errors — spell-checking is pure local computation with no external dependencies. If the service is unavailable, the entire request fails with `500`.
+This endpoint always returns `200` with a result for every input text. There are no per-item errors — if LanguageTool is unreachable, the entire batch fails with `500`.
 
 ### Batch Error Codes
 

--- a/docs/apis/text/spell-check.md
+++ b/docs/apis/text/spell-check.md
@@ -133,19 +133,19 @@ Each text in the batch counts as **1 unit** of quota. A request with 10 texts co
 
 ### Partial failure
 
-This endpoint always returns `200` with a result for every input text. Up to 10
-texts are checked concurrently. If LanguageTool is unreachable for an individual
-text, that slot returns a zero-value result (`corrected: ""`, `corrections: null`)
-and the batch continues — the caller receives a full-length `results` array
-regardless of individual failures.
+Once validation passes, this endpoint returns `200` with a result for every input
+text. Up to 10 texts are checked concurrently. If LanguageTool is unreachable for
+an individual text, that slot returns a zero-value result
+(`corrected: ""`, `corrections: null`) and the batch continues — the caller
+receives a full-length `results` array regardless of individual failures.
 
 ### Batch Error Codes
 
-| Code                | Status | When                                                       |
-| ------------------- | ------ | ---------------------------------------------------------- |
-| `validation_failed` | 422    | `texts` is missing, empty, or contains more than 50 items  |
-| `bad_request`       | 400    | Request body is missing or not JSON                        |
-| `internal_error`    | 500    | Unexpected failure                                         |
+| Code                | Status | When                                                                         |
+| ------------------- | ------ | ---------------------------------------------------------------------------- |
+| `validation_failed` | 422    | `texts` is missing, empty, or contains more than 50 items                    |
+| `bad_request`       | 400    | Request body is missing or not JSON                                          |
+| `internal_error`    | 500    | Infrastructure-level failure before processing begins (e.g. handler error)  |
 
 ---
 

--- a/docs/design-plans/2026-05-19-spellcheck-engine-languagetool.md
+++ b/docs/design-plans/2026-05-19-spellcheck-engine-languagetool.md
@@ -1,0 +1,233 @@
+# Spell Check Engine — Trade-off Analysis and Decision
+
+This document justifies the selection of LanguageTool as the spell-check engine
+for the `spell-check` API (REQAPI-350), replacing the previous `sajari/fuzzy`
+implementation, and explains why the alternatives were discarded.
+
+---
+
+## Context
+
+The spell-check API previously used `sajari/fuzzy`, a pure-Go fuzzy matching
+library based on Levenshtein distance. While trivially easy to integrate (no
+external dependencies, embedded in the Go binary), its correction quality was
+inadequate for a commercial product:
+
+- No contextual awareness: "tset" could be corrected to "test" or "set" with
+  no way to choose the better option from surrounding words.
+- English-only: no path to multilingual support without a complete rewrite.
+- Single suggestion per word: the library returns one candidate, not a ranked
+  list of alternatives.
+- Misleading corrections on short or ambiguous inputs.
+
+REQAPI-350 required adding a batch endpoint. Rather than scaling a low-quality
+engine, the team took the opportunity to evaluate better alternatives and
+migrate the underlying engine in the same PR.
+
+---
+
+## Alternatives Evaluated
+
+### 1. sajari/fuzzy (current, replaced)
+
+A pure-Go fuzzy matching library. Correction is based on Levenshtein distance
+against a static word list embedded at compile time.
+
+**Rejected because:** no contextual understanding, English-only, single
+suggestion, poor correction quality on real-world inputs. Its only strength —
+zero infrastructure overhead — does not justify the quality gap for a
+commercial spelling API.
+
+### 2. SymSpell
+
+A correction algorithm optimised for speed using pre-generated delete
+variations. Requires a word-frequency dictionary (a file mapping each word to
+its corpus frequency) to rank candidates.
+
+**Rejected because:** still no contextual understanding, so ambiguous typos
+are resolved arbitrarily. Additionally, the most complete Go implementation
+carries a restrictive license that is incompatible with commercial use.
+
+### 3. Hunspell (via CGO)
+
+The correction engine used by LibreOffice and Firefox. Mature, precise for
+classical spellchecking, and available in many languages via `.dic`/`.aff`
+dictionary pairs.
+
+**Rejected because:** Go has no pure-Go Hunspell binding with suggestion
+support. The only option was CGO (a bridge between Go and C), which
+significantly complicates compilation, Docker images, and CI pipelines. The one
+pure-Go wrapper found only exposed word validation (is this word correct?),
+not suggestion generation, making it unusable for this API.
+
+### 4. Transformer models — ByT5 / mT5 / T5
+
+Neural sequence-to-sequence models trained on large multilingual corpora. They
+understand full-sentence context, tolerate severe typos, and produce
+high-quality corrections across many languages without dictionaries.
+
+**Rejected (for now) because:** Go has no mature ML inference ecosystem.
+Serving a transformer requires a separate Python microservice (FastAPI +
+PyTorch), adding significant operational complexity. The smallest viable model
+(ByT5-small, ~250 MB) takes 2–5 seconds per inference on CPU, which is
+unacceptable for a synchronous API without dedicated GPU hardware. The
+quality gain is real but the infrastructure cost is disproportionate for the
+current stage of the platform.
+
+This option remains the recommended upgrade path if correction quality becomes
+a competitive differentiator in the future.
+
+### 5. Hugging Face Inference API
+
+Running transformer models via Hugging Face's hosted endpoints, removing the
+need for local inference infrastructure.
+
+**Rejected because:** the free tier imposes per-day request limits that are
+incompatible with a multi-tenant commercial product. The paid tier introduces
+a per-request cost and a hard dependency on a third-party service, both of
+which are undesirable for a core text utility.
+
+### 6. LLM APIs (OpenAI, Groq, etc.)
+
+Using a large language model to perform spell correction via prompt.
+
+**Rejected because:** the cost per token accumulates rapidly at volume, the
+latency is higher than purpose-built correction tools, and the approach
+introduces a proprietary external dependency for a task that does not require
+general language understanding. Architecturally, LLMs are significantly
+over-engineered for spellchecking.
+
+---
+
+## Decision: LanguageTool
+
+LanguageTool is an open-source grammar, style, and spell-checking engine that
+combines rule-based NLP, linguistic heuristics, and statistical language
+models. It exposes an HTTP API and runs as a standalone Java service.
+
+It was selected because it occupies the optimal point on the
+complexity-vs-quality curve for the platform's current needs:
+
+| Criterion | sajari/fuzzy | SymSpell | Hunspell | LanguageTool | Transformers |
+|---|---|---|---|---|---|
+| Contextual understanding | ❌ | ❌ | ❌ | Partial ✅ | ✅ |
+| No external dictionary required | ✅ | ❌ | ❌ | ✅ | ✅ |
+| No infrastructure overhead | ✅ | ✅ | ❌ (CGO) | ❌ (Docker) | ❌ (Python + GPU) |
+| Multilingual support | ❌ | ❌ | ✅ | ✅ (30+ langs) | ✅ |
+| Multiple suggestions per word | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Compatible with existing infra | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Correction quality | Poor | Fair | Good | Good | Excellent |
+
+**Key reasons for selecting LanguageTool:**
+
+- **Contextual correction without ML infrastructure.** LanguageTool uses
+  n-gram language models to consider surrounding words when ranking candidates.
+  This eliminates the most common class of absurd corrections produced by
+  pure edit-distance approaches.
+
+- **No licensing cost for self-hosted deployment.** The Community edition is
+  released under the LGPL licence. Running it on Bobadilla's infrastructure
+  incurs zero per-request or per-seat cost regardless of how many API clients
+  use the spell-check endpoint.
+
+- **Client transparency.** LanguageTool runs entirely on Bobadilla's servers.
+  Clients call `/v1/text/spellcheck` and receive results — they have no
+  dependency on, or knowledge of, LanguageTool. Licensing and infrastructure
+  concerns are fully encapsulated on the server side.
+
+- **Incremental infrastructure.** Adding a Docker container is a smaller step
+  than introducing a Python ML microservice. The team already runs Docker in
+  all environments and the existing CI/CD pipeline requires no changes.
+
+- **Multilingual path.** LanguageTool supports 30+ languages out of the box
+  via the same API. Extending the spell-check service to additional languages
+  is a configuration change, not a rewrite.
+
+- **Multiple suggestions.** LanguageTool returns a ranked list of replacement
+  candidates. The implementation surfaces the top three, giving frontend
+  clients enough options to present a correction picker to end users.
+
+---
+
+## Architecture
+
+```
+Client
+  ↓  HTTP  POST /v1/text/spellcheck[/batch]
+Go API (requiems-api)
+  ↓  HTTP  POST /v2/check  (form-encoded)
+LanguageTool Server  (Java, Docker container)
+  ↓
+Correction response (JSON)
+  ↑
+Go API  →  structured Result / batch Results  →  Client
+```
+
+The LanguageTool base URL is injected via the `LANGUAGETOOL_URL` environment
+variable (default: `http://localhost:8010`). This allows each environment to
+point to its own instance without code changes.
+
+---
+
+## Infrastructure Requirements
+
+### Development (local)
+
+```bash
+docker run -d --name languagetool -p 8010:8010 erikvl87/languagetool
+```
+
+Requirements: ~2 GB RAM, 1 vCPU. Any developer machine running Docker can run
+this without additional setup.
+
+### Production
+
+A single LanguageTool container added to the existing Docker Compose or
+Kubernetes deployment. Recommended sizing for moderate load:
+
+| Resource | Minimum | Recommended |
+|---|---|---|
+| RAM | 2 GB | 4 GB |
+| vCPU | 1 | 2 |
+| GPU | Not required | Not required |
+
+No external network access is required — LanguageTool runs fully air-gapped on
+the server's internal network.
+
+---
+
+## Known Trade-offs and Limitations
+
+- **Requires a running Java process.** Unlike `sajari/fuzzy`, which was
+  embedded in the Go binary, LanguageTool is a separate service. If it is
+  unreachable, the spell-check endpoint returns 500. Startup and health-check
+  dependencies must be configured in production.
+
+- **Correction quality on very short or isolated tokens.** LanguageTool
+  performs best on complete sentences. Single-word or very short inputs
+  (e.g., a single misspelled word with no surrounding context) produce
+  lower-quality suggestions than full sentences, similar to the weakness of
+  edit-distance approaches.
+
+- **Not fully neural.** LanguageTool's language models are statistical n-grams,
+  not transformer-based. It does not "reason" about text the way a model like
+  ByT5 would. Contextually ambiguous corrections may still be wrong.
+
+- **Java runtime overhead.** Cold-start time for the LanguageTool container
+  is ~10 seconds. In production this is absorbed at deployment time, but local
+  development environments must ensure the container is running before starting
+  the API.
+
+---
+
+## Future Upgrade Path
+
+If correction quality becomes a business priority, the recommended next step is
+a **ByT5-small** (or similar encoder-decoder transformer) served as a Python
+FastAPI microservice, reachable via a second environment variable
+(e.g., `SPELLCHECK_ML_URL`). The Go service layer would remain unchanged; only
+the HTTP call target would switch.
+
+This migration path is clean because the engine is fully encapsulated inside
+`services/text/spellcheck/service.go`. The transport layer, batch logic,
+validation, and documentation are engine-agnostic.

--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -14,6 +14,7 @@ REDIS_URL=redis://redis:6379
 PORT=8080
 VPN_DATABASE_PATH=dbs/IP2PROXY-LITE-PX2.BIN
 VPN_ASN_DATABASE_PATH=dbs/GeoLite2-ASN.mmdb
+LANGUAGETOOL_URL=http://languagetool:8010
 
 # Rails
 RAILS_ENV=development

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -44,6 +44,14 @@ services:
     ports:
       - "8010:8010"
     restart: unless-stopped
+    profiles:
+      - languagetool
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8010/v2/languages > /dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   api:
     build:
@@ -66,7 +74,8 @@ services:
       redis:
         condition: service_healthy
       languagetool:
-        condition: service_started
+        condition: service_healthy
+        required: false
 
   dashboard:
     build:

--- a/infra/docker/docker-compose.dev.yml
+++ b/infra/docker/docker-compose.dev.yml
@@ -37,6 +37,14 @@ services:
       timeout: 5s
       retries: 5
 
+  languagetool:
+    image: erikvl87/languagetool
+    networks:
+      - stack
+    ports:
+      - "8010:8010"
+    restart: unless-stopped
+
   api:
     build:
       context: ../../apps/api
@@ -57,6 +65,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      languagetool:
+        condition: service_started
 
   dashboard:
     build:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,6 +1,16 @@
 name: requiem-backend
 
 services:
+  languagetool:
+    image: erikvl87/languagetool
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8010/v2/languages > /dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
   api:
     build:
       context: ../../apps/api
@@ -15,6 +25,8 @@ services:
       db:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      languagetool:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]


### PR DESCRIPTION
- Migrate spell-check engine from sajari/fuzzy to LanguageTool (self-hosted, HTTP)
- Add POST /v1/text/spellcheck/batch endpoint (up to 50 texts per request)
- Add suggestions field to corrections (up to 3 ranked candidates per misspelled word)
- Add languagetool service to docker-compose.dev.yml and LANGUAGETOOL_URL to .env.example
- Remove sajari/fuzzy from go.mod
- Full test coverage: 8 service tests + 11 transport tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch spell-check endpoint (1–50 texts per request).
  * Results include up to 3 ranked alternative suggestions.

* **Improvements**
  * Switched spell-check backend to LanguageTool for better corrections and Unicode-aware positions.
  * Per-item partial-failure behavior: batch returns one result per input even if some checks fail.

* **Documentation**
  * Updated API docs, usage limits, FAQ, and added design/plan doc.

* **Chores**
  * Added LanguageTool service to local dev compose and env example; removed prior fuzzy dependency.

* **Tests**
  * Tests updated to exercise LanguageTool integration and batch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->