### PR TITLE
Fix batch endpoints to use real batch processing

### DIFF
--- a/apps/api/services/entertainment/quotes/service.go
+++ b/apps/api/services/entertainment/quotes/service.go
@@ -62,8 +62,8 @@ SELECT id, text, author
 FROM quotes
 ORDER BY random()
 LIMIT $1`, n)
-	
-if err != nil {
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/apps/api/services/entertainment/quotes/service.go
+++ b/apps/api/services/entertainment/quotes/service.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"requiems-api/platform/db"
 )
 
 type Quote struct {
@@ -16,8 +15,13 @@ type Quote struct {
 	Author string `json:"author,omitempty"`
 }
 
+type quotesDB interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
 type Service struct {
-	db db.Querier
+	db quotesDB
 }
 
 func NewService(pool *pgxpool.Pool) *Service {
@@ -44,10 +48,7 @@ LIMIT 1;
 	return q, nil
 }
 
-// RandomBatch returns n random quotes in a single operation.
-// If an individual quote fails to scan (e.g. transient DB error), a zero-value
-// Quote is used for that slot so the batch always returns exactly n results.
-// The batch is aborted only if the context is cancelled or times out.
+// RandomBatch returns n random quotes in a single query.
 func (s *Service) RandomBatch(ctx context.Context, n int) ([]Quote, error) {
 	if n < 1 {
 		return nil, fmt.Errorf("count must be at least 1")
@@ -56,23 +57,28 @@ func (s *Service) RandomBatch(ctx context.Context, n int) ([]Quote, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	results := make([]Quote, n)
-	for i := 0; i < n; i++ {
-		row := s.db.QueryRow(ctx, `
+	rows, err := s.db.Query(ctx, `
 SELECT id, text, author
 FROM quotes
 ORDER BY random()
-LIMIT 1;
-`)
+LIMIT $1`, n)
+	
+if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	results := make([]Quote, 0, n)
+
+	for rows.Next() {
 		var q Quote
-		if err := row.Scan(&q.ID, &q.Text, &q.Author); err != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
-			// Individual scan error: keep zero-value Quote and continue.
+		if err := rows.Scan(&q.ID, &q.Text, &q.Author); err != nil {
 			continue
 		}
-		results[i] = q
+
+		results = append(results, q)
 	}
-	return results, nil
+
+	return results, rows.Err()
 }

--- a/apps/api/services/entertainment/quotes/service_test.go
+++ b/apps/api/services/entertainment/quotes/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,29 +18,60 @@ type mockRow struct {
 
 func (m *mockRow) Scan(dest ...any) error { return m.scanFn(dest...) }
 
-// mockQuerier implements querier, always returning the same row.
+// mockQuerier implements quotesDB for single-row tests.
 type mockQuerier struct {
 	row pgx.Row
 }
 
-func (m *mockQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
-	return m.row
+func (m *mockQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return m.row }
+func (m *mockQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return &mockRows{}, nil
 }
 
-// multiMockQuerier implements querier returning a different row on each call.
-// This allows testing that results are returned in the same order as requests.
-type multiMockQuerier struct {
-	rows  []pgx.Row
-	index int
+// mockRows implements pgx.Rows for batch tests.
+// Set quotes for happy-path rows; set total+scanErr to simulate scan failures.
+type mockRows struct {
+	quotes  []Quote
+	total   int // used when simulating scan errors (quotes is nil)
+	index   int
+	err     error
+	scanErr error
 }
 
-func (m *multiMockQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
-	if m.index >= len(m.rows) {
-		return m.rows[len(m.rows)-1]
+func (m *mockRows) Close()                                       {}
+func (m *mockRows) Err() error                                   { return m.err }
+func (m *mockRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (m *mockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (m *mockRows) Values() ([]any, error)                       { return nil, nil }
+func (m *mockRows) RawValues() [][]byte                          { return nil }
+func (m *mockRows) Conn() *pgx.Conn                              { return nil }
+func (m *mockRows) Next() bool {
+	if m.quotes != nil {
+		return m.index < len(m.quotes)
 	}
-	row := m.rows[m.index]
+	return m.index < m.total
+}
+func (m *mockRows) Scan(dest ...any) error {
 	m.index++
-	return row
+	if m.scanErr != nil {
+		return m.scanErr
+	}
+	q := m.quotes[m.index-1]
+	*dest[0].(*int) = q.ID
+	*dest[1].(*string) = q.Text
+	*dest[2].(*string) = q.Author
+	return nil
+}
+
+// batchQuerier returns fixed rows from Query and a fixed row from QueryRow.
+type batchQuerier struct {
+	row  pgx.Row
+	rows *mockRows
+}
+
+func (b *batchQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return b.row }
+func (b *batchQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return b.rows, nil
 }
 
 func newTestService(row pgx.Row) *Service {
@@ -115,14 +147,15 @@ func TestRandom_EmptyAuthorAllowed(t *testing.T) {
 
 func TestRandomBatch_ReturnsNQuotes(t *testing.T) {
 	t.Parallel()
-	svc := newTestService(&mockRow{
-		scanFn: func(dest ...any) error {
-			*dest[0].(*int) = 1
-			*dest[1].(*string) = "Test quote."
-			*dest[2].(*string) = "Test Author"
-			return nil
+	svc := &Service{db: &batchQuerier{
+		rows: &mockRows{
+			quotes: []Quote{
+				{ID: 1, Text: "Test quote.", Author: "Test Author"},
+				{ID: 2, Text: "Test quote.", Author: "Test Author"},
+				{ID: 3, Text: "Test quote.", Author: "Test Author"},
+			},
 		},
-	})
+	}}
 
 	got, err := svc.RandomBatch(context.Background(), 3)
 	require.NoError(t, err)
@@ -133,29 +166,23 @@ func TestRandomBatch_ReturnsNQuotes(t *testing.T) {
 
 func TestRandomBatch_ContinuesOnItemError(t *testing.T) {
 	t.Parallel()
-	// When a single quote fails to scan, the batch must not abort:
-	// it returns n zero-value Quotes with no error.
-	svc := newTestService(&mockRow{
-		scanFn: func(_ ...any) error { return pgx.ErrNoRows },
-	})
+	// Scan errors are skipped; the batch returns only successfully scanned rows.
+	svc := &Service{db: &batchQuerier{
+		rows: &mockRows{total: 2, scanErr: pgx.ErrNoRows},
+	}}
 
 	results, err := svc.RandomBatch(context.Background(), 2)
 	assert.NoError(t, err)
-	assert.Len(t, results, 2)
-	assert.Equal(t, 0, results[0].ID)
-	assert.Equal(t, "", results[0].Text)
+	assert.Empty(t, results)
 }
 
 func TestRandomBatch_SingleItem(t *testing.T) {
 	t.Parallel()
-	svc := newTestService(&mockRow{
-		scanFn: func(dest ...any) error {
-			*dest[0].(*int) = 5
-			*dest[1].(*string) = "One is enough."
-			*dest[2].(*string) = "Someone"
-			return nil
+	svc := &Service{db: &batchQuerier{
+		rows: &mockRows{
+			quotes: []Quote{{ID: 5, Text: "One is enough.", Author: "Someone"}},
 		},
-	})
+	}}
 
 	got, err := svc.RandomBatch(context.Background(), 1)
 	require.NoError(t, err)
@@ -177,24 +204,13 @@ func TestRandomBatch_InvalidCount(t *testing.T) {
 
 func TestRandomBatch_ReturnsResultsInOrder(t *testing.T) {
 	t.Parallel()
-	// Each call to QueryRow should return a different quote.
-	// The batch must preserve the order: result[0] comes from the first call, etc.
-	makeRow := func(id int, text, author string) pgx.Row {
-		return &mockRow{
-			scanFn: func(dest ...any) error {
-				*dest[0].(*int) = id
-				*dest[1].(*string) = text
-				*dest[2].(*string) = author
-				return nil
+	svc := &Service{db: &batchQuerier{
+		rows: &mockRows{
+			quotes: []Quote{
+				{ID: 1, Text: "First quote.", Author: "Author A"},
+				{ID: 2, Text: "Second quote.", Author: "Author B"},
+				{ID: 3, Text: "Third quote.", Author: "Author C"},
 			},
-		}
-	}
-
-	svc := &Service{db: &multiMockQuerier{
-		rows: []pgx.Row{
-			makeRow(1, "First quote.", "Author A"),
-			makeRow(2, "Second quote.", "Author B"),
-			makeRow(3, "Third quote.", "Author C"),
 		},
 	}}
 

--- a/apps/api/services/entertainment/quotes/transport_http_test.go
+++ b/apps/api/services/entertainment/quotes/transport_http_test.go
@@ -15,11 +15,13 @@ import (
 )
 
 type httpMockQuerier struct {
-	row pgx.Row
+	row  pgx.Row
+	rows *mockRows
 }
 
-func (m *httpMockQuerier) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
-	return m.row
+func (m *httpMockQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row { return m.row }
+func (m *httpMockQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return m.rows, nil
 }
 
 func TestTransport_HappyPath(t *testing.T) {
@@ -91,14 +93,15 @@ func TestTransport_MethodNotAllowed(t *testing.T) {
 func TestTransportBatch_HappyPath(t *testing.T) {
 	t.Parallel()
 	svc := &Service{
-		db: &httpMockQuerier{row: &mockRow{
-			scanFn: func(dest ...any) error {
-				*dest[0].(*int) = 1
-				*dest[1].(*string) = "Test quote."
-				*dest[2].(*string) = "Author"
-				return nil
+		db: &httpMockQuerier{
+			rows: &mockRows{
+				quotes: []Quote{
+					{ID: 1, Text: "Test quote.", Author: "Author"},
+					{ID: 2, Text: "Test quote.", Author: "Author"},
+					{ID: 3, Text: "Test quote.", Author: "Author"},
+				},
 			},
-		}},
+		},
 	}
 
 	r := chi.NewRouter()

--- a/apps/api/services/finance/iban/service.go
+++ b/apps/api/services/finance/iban/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/jackc/pgx/v5"
@@ -185,14 +186,28 @@ func extract(s string, offset, length int) string {
 // Infrastructure failures for individual items are absorbed: the item is returned with Valid: false
 // rather than failing the entire batch.
 func (s *Service) ParseBatch(ctx context.Context, numbers []string) []ParseResponse {
+	const maxWorkers = 8
+
 	results := make([]ParseResponse, len(numbers))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
+
 	for i, n := range numbers {
-		result, err := s.Parse(ctx, n)
-		if err != nil {
-			results[i] = ParseResponse{IBAN: n, Valid: false}
-			continue
-		}
-		results[i] = result
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, n string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			result, err := s.Parse(ctx, n)
+			if err != nil {
+				results[i] = ParseResponse{IBAN: n, Valid: false}
+				return
+			}
+			results[i] = result
+		}(i, n)
 	}
+
+	wg.Wait()
 	return results
 }

--- a/apps/api/services/finance/inflation/service.go
+++ b/apps/api/services/finance/inflation/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -104,27 +105,34 @@ func (s *Service) GetInflation(ctx context.Context, rawCode string) (Response, e
 // GetInflationBatch returns inflation data for multiple countries in the same
 // order as the input slice. Countries with no data are returned with Found: false.
 func (s *Service) GetInflationBatch(ctx context.Context, countries []string) []BatchItem {
+	const maxWorkers = 8
+
 	results := make([]BatchItem, len(countries))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
 
 	for i, c := range countries {
-		resp, err := s.GetInflation(ctx, c)
-		if err != nil {
-			// Country not found or unexpected error: return in-band with Found: false.
-			results[i] = BatchItem{
-				Country: strings.ToUpper(c),
-				Found:   false,
-			}
-			continue
-		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, c string) {
+			defer wg.Done()
+			defer func() { <-sem }()
 
-		results[i] = BatchItem{
-			Country:    resp.Country,
-			Found:      true,
-			Rate:       resp.Rate,
-			Period:     resp.Period,
-			Historical: resp.Historical,
-		}
+			resp, err := s.GetInflation(ctx, c)
+			if err != nil {
+				results[i] = BatchItem{Country: strings.ToUpper(c), Found: false}
+				return
+			}
+			results[i] = BatchItem{
+				Country:    resp.Country,
+				Found:      true,
+				Rate:       resp.Rate,
+				Period:     resp.Period,
+				Historical: resp.Historical,
+			}
+		}(i, c)
 	}
 
+	wg.Wait()
 	return results
 }

--- a/apps/api/services/networking/mx/service.go
+++ b/apps/api/services/networking/mx/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net"
 	"sort"
+	"sync"
+	"time"
 )
 
 // Record represents a single MX record entry.
@@ -61,23 +63,34 @@ func (s *Service) Lookup(ctx context.Context, domain string) (LookupResponse, er
 }
 
 func (s *Service) LookupBatch(ctx context.Context, domains []string) []BatchLookupItem {
+	const (
+		maxWorkers     = 10
+		perItemTimeout = 3 * time.Second
+	)
+
 	results := make([]BatchLookupItem, len(domains))
+	sem := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
 
 	for i, d := range domains {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, d string) {
+			defer wg.Done()
+			defer func() { <-sem }()
 
-		result, err := s.Lookup(ctx, d)
+			itemCtx, cancel := context.WithTimeout(ctx, perItemTimeout)
+			defer cancel()
 
-		if err != nil {
-			results[i] = BatchLookupItem{Domain: d, Found: false, Error: err.Error()}
-			continue
-		}
-
-		results[i] = BatchLookupItem{
-			Domain: d,
-			Found:  true,
-			Data:   result,
-		}
+			result, err := s.Lookup(itemCtx, d)
+			if err != nil {
+				results[i] = BatchLookupItem{Domain: d, Found: false, Error: err.Error()}
+				return
+			}
+			results[i] = BatchLookupItem{Domain: d, Found: true, Data: result}
+		}(i, d)
 	}
 
+	wg.Wait()
 	return results
 }

--- a/docs/core/batch-apis.md
+++ b/docs/core/batch-apis.md
@@ -77,9 +77,114 @@ still count as **1** request.
 
 ---
 
+## Service-layer implementation rules
+
+The transport layer (`httpx.HandleBatch`) handles HTTP concerns. The service
+method it calls must itself be a real batch — not a loop over the single-item
+method.
+
+### The anti-pattern (do not do this)
+
+```go
+// WRONG: N serial round-trips disguised as a batch.
+func (s *Service) LookupBatch(ctx context.Context, domains []string) []Result {
+    results := make([]Result, len(domains))
+    for i, d := range domains {
+        results[i], _ = s.Lookup(ctx, d) // one DNS/HTTP/DB call per iteration
+    }
+    return results
+}
+```
+
+This compiles, tests green, and silently gives callers no throughput benefit
+over N individual API calls. A 50-item batch takes 50× the latency of one call.
+
+### Rule 1 — Database: write a batch query, do not call the single-item method
+
+If the single-item method runs a SQL query, the batch version must issue **one
+query** that fetches all items, not N queries in a loop.
+
+```go
+// WRONG — N queries
+for _, id := range ids {
+    row := s.db.QueryRow(ctx, `SELECT ... FROM t WHERE id = $1`, id)
+    ...
+}
+
+// RIGHT — 1 query using ANY / IN / LIMIT n (pick the form that fits the schema)
+rows, err := s.db.Query(ctx, `SELECT ... FROM t WHERE id = ANY($1::int[])`, ids)
+
+// For "N random rows" patterns:
+rows, err := s.db.Query(ctx, `SELECT ... FROM t ORDER BY random() LIMIT $1`, n)
+```
+
+Reusing the single-item method for the batch case is only acceptable when the
+single-item method performs **no I/O** (pure in-memory computation).
+
+### Rule 2 — Network I/O (DNS, HTTP): fan out with goroutines + semaphore
+
+When each item requires an independent network call (DNS lookup, outbound HTTP),
+fan out concurrently. Cap concurrency with a semaphore to avoid exhausting the
+upstream or the connection pool.
+
+```go
+const maxWorkers = 10
+
+results := make([]BatchItem, len(items))
+sem := make(chan struct{}, maxWorkers)
+var wg sync.WaitGroup
+
+for i, item := range items {
+    wg.Add(1)
+    sem <- struct{}{}
+    go func(i int, item string) {
+        defer wg.Done()
+        defer func() { <-sem }()
+
+        itemCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+        defer cancel()
+
+        r, err := s.singleItemCall(itemCtx, item)
+        if err != nil {
+            results[i] = BatchItem{Found: false, Error: err.Error()}
+            return
+        }
+        results[i] = BatchItem{Found: true, Data: r}
+    }(i, item)
+}
+
+wg.Wait()
+```
+
+Results are written to pre-allocated index slots, so input order is preserved
+without sorting. See `networking/whois/service.go` and
+`validation/email/service.go` for the canonical in-codebase reference.
+
+### Rule 3 — Error handling: in-band, never fail-fast
+
+Consistent with the **Partial failure** standard above, goroutine-based batch
+methods must absorb per-item errors in-band (`Found: false` / `Valid: false` /
+`error` field on that item) and continue. Do not use `errgroup` with its
+fail-fast semantics unless the RFC for that endpoint explicitly documents
+all-or-nothing behaviour.
+
+### Summary table
+
+| Underlying operation        | Correct batch strategy                       |
+| --------------------------- | -------------------------------------------- |
+| DB query (rows by key / ID) | Single `WHERE id = ANY($1)` or equivalent    |
+| DB query (N random rows)    | Single `ORDER BY random() LIMIT $1`          |
+| DNS lookup                  | Goroutines + semaphore (`maxWorkers ≈ 10`)   |
+| Outbound HTTP               | Goroutines + semaphore (`maxWorkers ≈ 10`)   |
+| Pure in-memory computation  | Sequential loop is fine — no I/O, no latency |
+
+---
+
 ## Checklist before merging a new batch endpoint
 
 - [ ] Uses `httpx.HandleBatch`
+- [ ] Service method is a real batch — no sequential loop over the single-item
+      method for DB or network I/O (see **Service-layer implementation rules**).
 - [ ] Struct validation documents **min/max** batch size; tests cover boundary
       and oversize.
 - [ ] Public docs include curl example and error cases.

--- a/docs/design-plans/2026-05-20-sequential-batch-anti-pattern.md
+++ b/docs/design-plans/2026-05-20-sequential-batch-anti-pattern.md
@@ -1,0 +1,199 @@
+# Sequential Batch Anti-pattern Fix
+
+Several `*Batch` functions across the API advertised batch throughput but
+implemented it as a sequential `for` loop over the single-item method — making N
+serial I/O calls. For network endpoints (DNS, HTTP) this means wall-clock time
+scales linearly with input size, eliminating any benefit over N individual
+calls.
+
+## Problem
+
+Go has no type or lint rule that prevents a "batch" function from being a hidden
+sequential loop. The functions compiled and tested correctly — the anti-pattern
+was invisible until a reviewer measured the actual call graph.
+
+```go
+// Looks like a batch. Makes N serial DNS lookups.
+func (s *Service) LookupBatch(ctx context.Context, domains []string) []BatchLookupItem {
+    results := make([]BatchLookupItem, len(domains))
+    for i, d := range domains {
+        result, err := s.Lookup(ctx, d) // one DNS round-trip per iteration
+        ...
+        results[i] = ...
+    }
+    return results
+}
+```
+
+For 50 domains, this is 50 sequential DNS queries. A caller expecting batch
+throughput gets the same wall time as 50 individual API calls.
+
+---
+
+## Status Before Changes
+
+### Affected Functions
+
+| File                                       | Function            | I/O type | Before behavior                            |
+| ------------------------------------------ | ------------------- | -------- | ------------------------------------------ |
+| `services/networking/mx/service.go`        | `LookupBatch`       | DNS      | Sequential `for` loop over `Lookup`        |
+| `services/finance/inflation/service.go`    | `GetInflationBatch` | DB query | Sequential `for` loop over `GetInflation`  |
+| `services/finance/iban/service.go`         | `ParseBatch`        | DB query | Sequential `for` loop over `Parse`         |
+| `services/entertainment/quotes/service.go` | `RandomBatch`       | DB query | N × `SELECT ... ORDER BY random() LIMIT 1` |
+
+### Already-Correct Implementations (reference)
+
+Two services already had the right pattern before this change:
+
+- `services/networking/whois/service.go` — `LookupBatch`: goroutines + semaphore
+  channel, `maxWorkers=10`, 3s per-item timeout
+- `services/validation/email/service.go` — `ValidateEmailBatch`: goroutines +
+  semaphore channel, `maxWorkers=8`
+
+These served as the implementation template.
+
+---
+
+## Fix
+
+Two strategies applied depending on the I/O type.
+
+### Pattern A — Goroutines + Semaphore (network / DB fan-out)
+
+Used when each item needs its own I/O call and calls are independent.
+
+```go
+const maxWorkers = 10
+
+results := make([]BatchLookupItem, len(domains))
+sem := make(chan struct{}, maxWorkers)
+var wg sync.WaitGroup
+
+for i, d := range domains {
+    wg.Add(1)
+    sem <- struct{}{}
+    go func(i int, d string) {
+        defer wg.Done()
+        defer func() { <-sem }()
+
+        itemCtx, cancel := context.WithTimeout(ctx, perItemTimeout)
+        defer cancel()
+
+        result, err := s.Lookup(itemCtx, d)
+        if err != nil {
+            results[i] = BatchLookupItem{Domain: d, Found: false, Error: err.Error()}
+            return
+        }
+        results[i] = BatchLookupItem{Domain: d, Found: true, Data: result}
+    }(i, d)
+}
+
+wg.Wait()
+```
+
+The semaphore caps concurrency so a large batch can't exhaust the DNS resolver
+or DB connection pool. Results are written to pre-allocated index slots, so
+input order is always preserved without a sort.
+
+Applied to:
+
+| Function                      | `maxWorkers` | Per-item timeout        |
+| ----------------------------- | ------------ | ----------------------- |
+| `mx.LookupBatch`              | 10           | 3s                      |
+| `inflation.GetInflationBatch` | 8            | — (inherits caller ctx) |
+| `iban.ParseBatch`             | 8            | — (inherits caller ctx) |
+
+### Pattern B — Single Batch Query (DB, when all items share one table)
+
+Used when the N items can be collapsed into one SQL statement.
+
+```go
+// Before: N queries
+for i := 0; i < n; i++ {
+    row := s.db.QueryRow(ctx, `SELECT ... FROM quotes ORDER BY random() LIMIT 1`)
+    ...
+}
+
+// After: 1 query
+rows, err := s.db.Query(ctx, `
+SELECT id, text, author
+FROM quotes
+ORDER BY random()
+LIMIT $1`, n)
+```
+
+Applied to `quotes.RandomBatch` — reduced N DB round-trips to 1.
+
+### Interface Change (quotes only)
+
+`platform/db.Querier` only exposes `QueryRow`. Expanding it would cascade into
+all mocks across four services. Instead, a local `quotesDB` interface was
+defined in `quotes/service.go`:
+
+```go
+type quotesDB interface {
+    QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+    Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+```
+
+`*pgxpool.Pool` satisfies it directly. The shared `db.Querier` interface remains
+unchanged.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `go test ./services/networking/mx/...` — pass
+- [ ] `go test ./services/finance/inflation/...` — pass
+- [ ] `go test ./services/finance/iban/...` — pass
+- [ ] `go test ./services/entertainment/quotes/...` — pass
+- [ ] `go build ./...` — clean
+- [ ] No `*Batch` function with network/DB I/O uses a sequential `for` loop over
+      the single-item method
+
+All criteria met at time of merge.
+
+---
+
+## Lessons Learned
+
+**1. "Batch" is a contract, not a label.** A function named `*Batch` promises
+throughput benefit. A sequential loop breaks that promise silently — no compiler
+error, no test failure, no runtime panic. Reviewers must check the call graph,
+not just the function signature.
+
+**2. Two failure modes, two fixes.** "Sequential I/O" can mean two different
+things:
+
+- N independent calls that could run in parallel → goroutines + semaphore
+- N queries that could be collapsed into one → SQL `IN` / `ANY` / `LIMIT n`
+
+Applying goroutines to `quotes.RandomBatch` would still make N DB round-trips.
+The right diagnosis determines the right fix.
+
+**3. Minimal shared interfaces have hidden costs.** `db.Querier` was
+intentionally narrow (`QueryRow` only — "services that only need single-row
+queries"). When one service evolved beyond that, expanding the shared interface
+would have required updating mocks in four unrelated packages. Scoping a local
+interface to the one package that needs it is the right tradeoff: isolation over
+uniformity.
+
+**4. Tests encode the implementation, not just the contract.**
+`quotes.RandomBatch` tests used `multiMockQuerier` to simulate N sequential
+`QueryRow` calls and verify ordering. When the implementation changed to a
+single `Query` call, the tests were invalid — not just failing, but testing the
+wrong thing. Implementation changes that affect the call shape require
+rethinking the test setup, not just adjusting assertions.
+
+**5. Positive examples are the cheapest template.** `whois.LookupBatch` already
+had the correct goroutine + semaphore pattern. Every new fix was a copy of that
+pattern with adjusted constants. No design work was needed — just recognition
+that the reference already existed.
+
+**6. Batch functions must always use in-band errors.** PR #650 review suggested
+`errgroup` (one error aborts the entire batch). That is wrong for this codebase.
+A failed item gets `Found: false` / `Valid: false` / an `error` field — the
+batch continues and returns 200. Fail-fast (`errgroup`) is never acceptable for
+batch service methods: it punishes all items in a request for one item's failure
+and breaks the partial-success contract documented in `docs/core/batch-apis.md`.


### PR DESCRIPTION
This pull request implements major improvements to the batch processing logic across several service layers, ensuring that batch endpoints perform real concurrent or set-based operations rather than looping over single-item methods. It introduces proper database batching, concurrent network operations with goroutine fan-out, and updates documentation to enforce these best practices. The test code and mock implementations are also refactored to match the new batch logic.

**Batch Processing Improvements**

* The `quotes` service's `RandomBatch` method now performs a single SQL query to fetch multiple random quotes, replacing the previous N-loop over single-item queries. The interface and all related mocks and tests are updated accordingly. [[1]](diffhunk://#diff-f3e9e7c52bb3ad754bbc0827c93647609aa5e888ca6f7c0deb87a5449ad384aeR8-L10) [[2]](diffhunk://#diff-f3e9e7c52bb3ad754bbc0827c93647609aa5e888ca6f7c0deb87a5449ad384aeR18-R24) [[3]](diffhunk://#diff-f3e9e7c52bb3ad754bbc0827c93647609aa5e888ca6f7c0deb87a5449ad384aeL47-R51) [[4]](diffhunk://#diff-f3e9e7c52bb3ad754bbc0827c93647609aa5e888ca6f7c0deb87a5449ad384aeL59-R83) [[5]](diffhunk://#diff-23753f1a0324958d5da9ca341553e0eee01e15361ea3ea2a3470e1222af8a4feR9) [[6]](diffhunk://#diff-23753f1a0324958d5da9ca341553e0eee01e15361ea3ea2a3470e1222af8a4feL20-R74) [[7]](diffhunk://#diff-23753f1a0324958d5da9ca341553e0eee01e15361ea3ea2a3470e1222af8a4feL118-R158) [[8]](diffhunk://#diff-23753f1a0324958d5da9ca341553e0eee01e15361ea3ea2a3470e1222af8a4feL136-R185) [[9]](diffhunk://#diff-23753f1a0324958d5da9ca341553e0eee01e15361ea3ea2a3470e1222af8a4feL180-L197) [[10]](diffhunk://#diff-e67280ad01a43ac3134b3ba989e4a35c0ccafae365219efafd71b9dd73d055bbR19-R24) [[11]](diffhunk://#diff-e67280ad01a43ac3134b3ba989e4a35c0ccafae365219efafd71b9dd73d055bbL94-L101)
* The `iban` and `inflation` finance services' batch methods now use goroutines with a semaphore to process items concurrently, capping parallelism to avoid resource exhaustion, and preserving input order. [[1]](diffhunk://#diff-0fc557feb847dd41b3694bfd92202e68096d2876e9a050af06b5cbbc4b0b91bfR7) [[2]](diffhunk://#diff-0fc557feb847dd41b3694bfd92202e68096d2876e9a050af06b5cbbc4b0b91bfR189-R211) [[3]](diffhunk://#diff-52cb20401e71aabe5e500a65631b19840409c6d9e54c533dab68edcbeef79669R7) [[4]](diffhunk://#diff-52cb20401e71aabe5e500a65631b19840409c6d9e54c533dab68edcbeef79669R108-R136)
* The `mx` networking service's `LookupBatch` method is refactored to use concurrent lookups with a semaphore and per-item timeouts, ensuring efficient and robust batch DNS queries. [[1]](diffhunk://#diff-38aa233a23b8ddddd3f0c181680961ebc800fbc2a04707cd016a424e704a8d27R7-R8) [[2]](diffhunk://#diff-38aa233a23b8ddddd3f0c181680961ebc800fbc2a04707cd016a424e704a8d27R66-R94)

**Documentation Updates**

* The batch API documentation (`batch-apis.md`) is expanded with clear service-layer implementation rules, anti-patterns to avoid, and correct strategies for database and network batch operations. A summary table and checklist are added to guide future endpoint development.

These changes ensure that all batch endpoints are efficient, scalable, and consistent with the documented standards for partial failure and concurrency.