### PR TITLE
Feat/horoscope batch api

### DIFF
--- a/apps/api/services/entertainment/horoscope/service.go
+++ b/apps/api/services/entertainment/horoscope/service.go
@@ -74,3 +74,18 @@ func hash(s string) uint64 {
 	_, _ = h.Write([]byte(s))
 	return h.Sum64()
 }
+
+// DailyBatch return horoscope reading for multiple zodia sign in single call.
+func (s *Service) DailyBatch(signs []string) ([]Horoscope, error) {
+	results := make([]Horoscope, len(signs))
+
+	for i, sign := range signs {
+		result, err := s.Daily(sign)
+		if err != nil {
+			return []Horoscope{}, err
+		}
+
+		results[i] = result
+	}
+	return results, nil
+}

--- a/apps/api/services/entertainment/horoscope/service_test.go
+++ b/apps/api/services/entertainment/horoscope/service_test.go
@@ -1,0 +1,31 @@
+package horoscope
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_DailyBatch(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	signs := []string{
+		"taurus", "aries", "gemini", "cancer",
+	}
+
+	results, err := svc.DailyBatch(signs)
+
+	require.NoError(t, err)
+	require.Equal(t, 4, len(results))
+
+	for i, sign := range signs {
+		assert.Equal(t, sign, results[i].Sign)
+		assert.NotEmpty(t, results[i].Horoscope)
+		assert.NotEmpty(t, results[i].Mood)
+		assert.NotZero(t, results[i].LuckyNumber)
+		assert.Equal(t, time.Now().UTC().Format("2006-01-02"), results[i].Date)
+	}
+}

--- a/apps/api/services/entertainment/horoscope/transport_http.go
+++ b/apps/api/services/entertainment/horoscope/transport_http.go
@@ -1,6 +1,7 @@
 package horoscope
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -8,6 +9,11 @@ import (
 
 	"requiems-api/platform/httpx"
 )
+
+// BatchRequest is the body for generating multiple horoscope readings in the same call.
+type BatchRequest struct {
+	Signs []string `json:"signs" validate:"required,min=1,max=12,dive,required,oneof=aries taurus gemini cancer leo virgo libra scorpio sagittarius capricorn aquarius pisces"`
+}
 
 // RegisterRoutes mounts horoscope handlers on the given router.
 // Paths are relative to the parent mount point.
@@ -27,4 +33,13 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, h)
 	})
+	r.Post("/horoscope/batch", httpx.HandleBatch(
+		func(ctx context.Context, req BatchRequest) (httpx.BatchResponse[Horoscope], error) {
+			results, err := svc.DailyBatch(req.Signs)
+			if err != nil {
+				return httpx.BatchResponse[Horoscope]{}, err
+			}
+			return httpx.BatchResponse[Horoscope]{Results: results}, nil
+		},
+	))
 }

--- a/apps/api/services/entertainment/horoscope/transport_http_test.go
+++ b/apps/api/services/entertainment/horoscope/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,4 +106,86 @@ func TestHoroscope_DailyConsistency(t *testing.T) {
 	assert.Equal(t, h1.Horoscope, h2.Horoscope, "expected same horoscope for same sign on same day")
 	assert.Equal(t, h1.LuckyNumber, h2.LuckyNumber, "expected same lucky_number for same sign on same day")
 	assert.Equal(t, h1.Mood, h2.Mood, "expected same mood for same sign on same day")
+}
+
+func TestHoroscope_DailyBatch_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	signs := []string{"taurus", "aries", "gemini", "cancer"}
+
+	bodyJSON, err := json.Marshal(BatchRequest{Signs: signs})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/horoscope/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var resp httpx.Response[httpx.BatchResponse[Horoscope]]
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Equal(t, 4, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 4)
+}
+
+func TestHoroscope_DailyBatch_EmptySigns(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	bodyJSON, err := json.Marshal(BatchRequest{Signs: []string{}})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/horoscope/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestHoroscope_DailyBatch_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	signs := make([]string, 13)
+
+	for i := range signs {
+		signs[i] = "cancer"
+	}
+
+	signsJSON, err := json.Marshal(BatchRequest{
+		Signs: signs,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/horoscope/batch", strings.NewReader(string(signsJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+
+}
+
+func TestHoroscope_DailyBatch_SetUsageCountHeader(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	signs := []string{"taurus", "aries", "gemini", "cancer"}
+
+	bodyJSON, err := json.Marshal(BatchRequest{Signs: signs})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/horoscope/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	require.Equal(t, "4", w.Header().Get("X-Usage-Count"))
 }

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -793,7 +793,7 @@ apis:
     categories:
       - entertainment
     description: Get daily horoscope readings for all 12 zodiac signs
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: false
     documentation_url: /apis/horoscope

--- a/apps/dashboard/config/api_docs/horoscope.yml
+++ b/apps/dashboard/config/api_docs/horoscope.yml
@@ -88,6 +88,178 @@ endpoints:
 
         data = JSON.parse(response.body)
         puts data['data']['horoscope']
+  - name: Batch Daily Horoscopes
+    method: POST
+    path: /v1/entertainment/horoscope/batch
+    description: Returns up to 12 daily horoscopes in a single request.
+    parameters:
+      - name: signs
+        type: array
+        required: true
+        location: body
+        description: "Array of signs to get (min: 1, max: 12)."
+        example: |
+          ["taurus","cancer","libra"]
+    request_example: |
+      {
+        "signs": ["taurus","cancer","libra"]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "sign": "taurus",
+              "date": "2026-05-21",
+              "horoscope": "Your patience will be rewarded. Take time to reflect before making important decisions today.",
+              "lucky_number": 26,
+              "mood": "reflective"
+            },
+            {
+              "sign": "cancer",
+              "date": "2026-05-21",
+              "horoscope": "Your patience will be rewarded. Take time to reflect before making important decisions today.",
+              "lucky_number": 2,
+              "mood": "reflective"
+            },
+            {
+              "sign": "libra",
+              "date": "2026-05-21",
+              "horoscope": "Rest and self-care are essential today. Taking care of yourself enables you to take care of others.",
+              "lucky_number": 82,
+              "mood": "peaceful"
+            }
+          ],
+          "total": 3
+        },
+        "metadata": {
+          "timestamp": "2026-05-21T04:09:20Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: List of daily horoscopes returned in the same order as the input signs.
+      - name: results[].sign
+        type: string
+        description: Zodiac sign the horoscope corresponds to.
+      - name: results[].date
+        type: string
+        description: Date the horoscope is for, in YYYY-MM-DD format.
+      - name: results[].horoscope
+        type: string
+        description: Daily horoscope reading for the given sign.
+      - name: results[].lucky_number
+        type: integer
+        description: Lucky number for the given sign on that date.
+      - name: results[].mood
+        type: string
+        description: Predicted mood for the given sign on that date.
+      - name: total
+        type: integer
+        description: Total number of horoscopes returned.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The signs array is missing, empty, or contains more than 12 items.
+      - code: bad_request
+        status: 400
+        description: Invalid JSON, malformed request body, or unexpected field types.
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/entertainment/horoscope/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "signs": [
+              "taurus",
+              "cancer",
+              "libra"
+            ]
+          }'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/entertainment/horoscope/batch"
+
+        headers = {
+          "requiems-api-key": "YOUR_API_KEY",
+          "Content-Type": "application/json"
+        }
+
+        payload = {
+          "signs": [
+            "taurus",
+            "cancer",
+            "libra"
+          ]
+        }
+
+        response = requests.post(url, headers=headers, json=payload)
+
+        for item in response.json()["data"]["results"]:
+          print(item["sign"], "-", item["date"])
+          print("Horoscope:", item["horoscope"])
+          print("Mood:", item["mood"])
+          print("Lucky number:", item["lucky_number"])
+
+      javascript: |
+        const response = await fetch(
+          'https://api.requiems.xyz/v1/entertainment/horoscope/batch',
+          {
+            method: 'POST',
+            headers: {
+              'requiems-api-key': 'YOUR_API_KEY',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              signs: [
+                'taurus',
+                'cancer',
+                'libra'
+              ]
+            })
+          }
+        );
+
+        const { data } = await response.json();
+
+        data.results.forEach(item => {
+          console.log(item.sign, '-', item.date);
+          console.log('Horoscope:', item.horoscope);
+          console.log('Mood:', item.mood);
+          console.log('Lucky number:', item.lucky_number);
+        });
+
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/entertainment/horoscope/batch')
+
+        request = Net::HTTP::Post.new(uri)
+
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+
+        request.body = {
+          signs: [
+            'taurus',
+            'cancer',
+            'libra'
+          ]
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        JSON.parse(response.body)['data']['results'].each do |item|
+          puts "#{item['sign']} - #{item['date']}"
+          puts "Horoscope: #{item['horoscope']}"
+          puts "Mood: #{item['mood']}"
+          puts "Lucky number: #{item['lucky_number']}"
+        end
 faq:
   - question: Are horoscope readings the same for all users on the same day?
     answer: >-

--- a/apps/dashboard/config/api_docs/horoscope.yml
+++ b/apps/dashboard/config/api_docs/horoscope.yml
@@ -97,7 +97,7 @@ endpoints:
         type: array
         required: true
         location: body
-        description: "Array of signs to get (min: 1, max: 12)."
+        description: "Array of signs to get (min: 1, max: 12). Allowed values: aries, taurus, gemini, cancer, leo, virgo, libra, scorpio, sagittarius, capricorn, aquarius, pisces."
         example: |
           ["taurus","cancer","libra"]
     request_example: |
@@ -161,7 +161,7 @@ endpoints:
     errors:
       - code: validation_failed
         status: 422
-        description: The signs array is missing, empty, or contains more than 12 items.
+        description: The signs array is missing, empty, or contains more than 12 items, or includes unsupported sign values.
       - code: bad_request
         status: 400
         description: Invalid JSON, malformed request body, or unexpected field types.


### PR DESCRIPTION
## Endpoint
- Add DailyBatch method to Service
- Add BatchRequest type with validation (min 1, max 12, valid signs)
- Add POST /horoscope/batch route using httpx.HandleBatch

## Tests
- Add TestService_DailyBatch
- Add TestHoroscope_DailyBatch_HappyPath
- Add TestHoroscope_DailyBatch_EmptySigns
- Add TestHoroscope_DailyBatch_ExceedsLimit
- Add TestHoroscope_DailyBatch_SetUsageCountHeader

## Docs
- Update api_catalog horoscope documentation
- Update endpoint count from 1 to 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch horoscope endpoint (`POST /horoscope/batch`) to generate daily horoscopes for multiple zodiac signs in a single request.
  * Supports 1–12 zodiac signs per batch request with full validation.

* **Documentation**
  * Added comprehensive API documentation and code examples (curl, Python, JavaScript, Ruby) for the batch endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->