### PR TITLE
Feat/trivia batch api

### DIFF
--- a/apps/api/services/entertainment/trivia/service.go
+++ b/apps/api/services/entertainment/trivia/service.go
@@ -14,6 +14,16 @@ type Question struct {
 	Difficulty string   `json:"difficulty"`
 }
 
+// BatchResponse represents the result of a single trivia query
+// within a batch request, pairing the original filter (category
+// and difficulty) with either a question or an error.
+type BatchResponse struct {
+	Category   string   `json:"category"`
+	Difficulty string   `json:"difficulty"`
+	Error      string   `json:"error,omitempty"`
+	Data       Question `json:"data"`
+}
+
 // questions is the in-memory trivia question database.
 var questions = []Question{
 	// --- science ---
@@ -513,4 +523,32 @@ func (s *Service) Random(category, difficulty string) (Question, error) {
 	}
 
 	return pool[rand.IntN(len(pool))], nil //nolint:gosec // Good enough for trivia selection.
+}
+
+// RandomBatch retrieves a random trivia question for each filter in the batch.
+// It applies partial failure — if a filter yields no results, that entry will
+// contain an error message while the rest of the results are still returned.
+// The order of results matches the order of the input filters.
+func (s *Service) RandomBatch(filters []Request) []BatchResponse {
+	results := make([]BatchResponse, len(filters))
+
+	for i, filter := range filters {
+		result, err := s.Random(filter.Category, filter.Difficulty)
+		if err != nil {
+			results[i] = BatchResponse{
+				Category:   filter.Category,
+				Difficulty: filter.Difficulty,
+				Error:      err.Error(),
+			}
+			continue
+		}
+
+		results[i] = BatchResponse{
+			Category:   filter.Category,
+			Difficulty: filter.Difficulty,
+			Data:       result,
+		}
+	}
+
+	return results
 }

--- a/apps/api/services/entertainment/trivia/service_test.go
+++ b/apps/api/services/entertainment/trivia/service_test.go
@@ -34,9 +34,9 @@ func TestService_RandomBatch_PreservedOrder(t *testing.T) {
 	svc := NewService()
 
 	filters := []Request{
-		{Category: "sports", Difficulty: "hard"},    // fails
-		{Category: "science", Difficulty: "hard"},   // succeeds
-		{Category: "history", Difficulty: "medium"}, // succeeds
+		{Category: "__invalid__", Difficulty: "__invalid__"}, // fails
+		{Category: "science", Difficulty: "hard"},            // succeeds
+		{Category: "history", Difficulty: "medium"},          // succeeds
 	}
 
 	results := svc.RandomBatch(filters)

--- a/apps/api/services/entertainment/trivia/service_test.go
+++ b/apps/api/services/entertainment/trivia/service_test.go
@@ -1,0 +1,58 @@
+package trivia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_RandomBatch_AllSucceed(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	filters := []Request{
+		{Category: "science", Difficulty: "hard"},
+		{Category: "history", Difficulty: "medium"},
+	}
+
+	results := svc.RandomBatch(filters)
+
+	require.Equal(t, len(filters), len(results))
+	for i, filter := range filters {
+		assert.Equal(t, filter.Category, results[i].Category)
+		assert.Equal(t, filter.Difficulty, results[i].Difficulty)
+		assert.Empty(t, results[i].Error)
+		assert.NotEmpty(t, results[i].Data.Question)
+		assert.NotEmpty(t, results[i].Data.Answer)
+		assert.NotEmpty(t, results[i].Data.Options)
+	}
+}
+
+func TestService_RandomBatch_PreservedOrder(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+
+	filters := []Request{
+		{Category: "sports", Difficulty: "hard"},    // fails
+		{Category: "science", Difficulty: "hard"},   // succeeds
+		{Category: "history", Difficulty: "medium"}, // succeeds
+	}
+
+	results := svc.RandomBatch(filters)
+
+	require.Equal(t, len(filters), len(results))
+	for i, filter := range filters {
+		assert.Equal(t, filter.Category, results[i].Category)
+		assert.Equal(t, filter.Difficulty, results[i].Difficulty)
+	}
+
+	assert.NotEmpty(t, results[0].Error)
+	assert.Empty(t, results[0].Data.Question)
+
+	assert.Empty(t, results[1].Error)
+	assert.NotEmpty(t, results[1].Data.Question)
+
+	assert.Empty(t, results[2].Error)
+	assert.NotEmpty(t, results[2].Data.Question)
+}

--- a/apps/api/services/entertainment/trivia/transport_http.go
+++ b/apps/api/services/entertainment/trivia/transport_http.go
@@ -1,6 +1,7 @@
 package trivia
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -12,6 +13,12 @@ import (
 type Request struct {
 	Category   string `query:"category"   validate:"omitempty,oneof=science history geography sports music movies literature math technology nature"`
 	Difficulty string `query:"difficulty" validate:"omitempty,oneof=easy medium hard"`
+}
+
+// BatchRequest is the request payload for fetching multiple sets
+// of trivia questions in a single call.
+type BatchRequest struct {
+	Filters []Request `json:"filters" validate:"required,min=1,max=50,dive"`
 }
 
 // RegisterRoutes mounts trivia handlers on the given router.
@@ -32,4 +39,10 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 
 		httpx.JSON(w, http.StatusOK, q)
 	})
+
+	r.Post("/trivia/batch", httpx.HandleBatch(
+		func(_ context.Context, req BatchRequest) (httpx.BatchResponse[BatchResponse], error) {
+			return httpx.BatchResponse[BatchResponse]{Results: svc.RandomBatch(req.Filters)}, nil
+		},
+	))
 }

--- a/apps/api/services/entertainment/trivia/transport_http_test.go
+++ b/apps/api/services/entertainment/trivia/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -152,4 +153,88 @@ func TestService_Random_NoMatch(t *testing.T) {
 	svc := NewService()
 	_, err := svc.Random("science", "impossible")
 	assert.Error(t, err, "expected error for filters with no matching questions, got nil")
+}
+
+func TestTrivia_RandomBatch_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	filters := []Request{
+		{Category: "science", Difficulty: "hard"},
+		{Category: "history", Difficulty: "medium"},
+	}
+
+	bodyJSON, err := json.Marshal(BatchRequest{Filters: filters})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/trivia/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var resp httpx.Response[httpx.BatchResponse[Question]]
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, resp.Data.Total)
+	require.Len(t, resp.Data.Results, 2)
+}
+
+func TestTrivia_RandomBatch_EmptyFilters(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	bodyJSON, err := json.Marshal(BatchRequest{Filters: []Request{}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/trivia/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestTrivia_RandomBatch_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	filters := make([]Request, 51)
+	for i := range filters {
+		filters[i] = Request{Category: "science", Difficulty: "easy"}
+	}
+
+	bodyJSON, err := json.Marshal(BatchRequest{Filters: filters})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/trivia/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestTrivia_RandomBatch_SetUsageCountHeader(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	filters := []Request{
+		{Category: "science", Difficulty: "hard"},
+		{Category: "history", Difficulty: "medium"},
+	}
+
+	bodyJSON, err := json.Marshal(BatchRequest{Filters: filters})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/trivia/batch", strings.NewReader(string(bodyJSON)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "2", w.Header().Get("X-Usage-Count"))
 }

--- a/apps/api/services/entertainment/trivia/transport_http_test.go
+++ b/apps/api/services/entertainment/trivia/transport_http_test.go
@@ -175,12 +175,13 @@ func TestTrivia_RandomBatch_HappyPath(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
 
-	var resp httpx.Response[httpx.BatchResponse[Question]]
+	var resp httpx.Response[httpx.BatchResponse[BatchResponse]]
 	err = json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, resp.Data.Total)
 	require.Len(t, resp.Data.Results, 2)
+	require.NotEmpty(t, resp.Data.Results[0].Data.Question)
 }
 
 func TestTrivia_RandomBatch_EmptyFilters(t *testing.T) {

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -751,7 +751,7 @@ apis:
     categories:
       - entertainment
     description: Get random trivia questions with multiple-choice answers. Filter by category (science, history, geography, sports, music, movies, literature, math, technology, nature) and difficulty (easy, medium, hard).
-    endpoints_count: 1
+    endpoints_count: 2
     status: live
     popular: false
     documentation_url: /apis/trivia

--- a/apps/dashboard/config/api_docs/trivia.yml
+++ b/apps/dashboard/config/api_docs/trivia.yml
@@ -225,6 +225,12 @@ endpoints:
       - code: bad_request
         status: 400
         description: Invalid JSON, malformed request body, or unexpected field types.
+      - code: unauthorized
+        status: 401
+        description: Missing API key.
+      - code: forbidden
+        status: 403
+        description: Invalid or revoked API key.
     code_examples:
       curl: |
         curl -X POST "https://api.requiems.xyz/v1/entertainment/trivia/batch" \

--- a/apps/dashboard/config/api_docs/trivia.yml
+++ b/apps/dashboard/config/api_docs/trivia.yml
@@ -125,6 +125,208 @@ endpoints:
         data = JSON.parse(response.body)['data']
         puts data['question']
         puts "Answer: #{data['answer']}"
+  - name: Get Batch Trivia Questions
+    method: POST
+    path: /v1/entertainment/trivia/batch
+    description: Returns up to 50 trivia questions in a single request.
+    parameters:
+      - name: filters
+        type: array
+        required: true
+        location: body
+        description: "Array of filters to get (min: 1, max: 50)."
+        example: |
+          [{"category": "sports", "difficulty": "easy"},{"category": "history", "difficulty": "medium"}]
+    request_example: |
+      {
+        "filters": [{"category": "sports", "difficulty": "easy"},{"category": "history", "difficulty": "medium"}]
+      }
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "category": "sports",
+              "difficulty": "easy",
+              "data": {
+                "question": "In which country did the ancient Olympic Games originate?",
+                "options": [
+                  "Italy",
+                  "Turkey",
+                  "Greece",
+                  "Egypt"
+                ],
+                "answer": "Greece",
+                "category": "sports",
+                "difficulty": "easy"
+              }
+            },
+            {
+              "category": "history",
+              "difficulty": "medium",
+              "data": {
+                "question": "In what year was the Magna Carta signed?",
+                "options": [
+                  "1215",
+                  "1066",
+                  "1415",
+                  "1305"
+                ],
+                "answer": "1215",
+                "category": "history",
+                "difficulty": "medium"
+              }
+            }
+          ],
+          "total": 2
+        },
+        "metadata": {
+          "timestamp": "2026-05-22T22:27:35Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: List of trivia questions returned in the same order as the input filters.
+      - name: results[].category
+        type: string
+        description: The topic filter used to retrieve the trivia question.
+      - name: results[].difficulty
+        type: string
+        description: The complexity level filter used to retrieve the trivia question.
+      - name: results[].error
+        type: string
+        description: Describes why the question could not be retrieved for this filter. Omitted if the query was successful.
+      - name: results[].data
+        type: object
+        description: The trivia question returned for this filter. Empty if the query failed.
+      - name: results[].data.question
+        type: string
+        description: The trivia question text.
+      - name: results[].data.options
+        type: array
+        description: List of possible answers for the question.
+      - name: results[].data.answer
+        type: string
+        description: The correct answer to the trivia question.
+      - name: results[].data.category
+        type: string
+        description: The category the trivia question belongs to.
+      - name: results[].data.difficulty
+        type: string
+        description: The difficulty level of the trivia question.
+      - name: total
+        type: integer
+        description: Total number of trivia results returned.
+    errors:
+      - code: validation_failed
+        status: 422
+        description: The filters array is missing, empty, or contains more than 50 items.
+      - code: bad_request
+        status: 400
+        description: Invalid JSON, malformed request body, or unexpected field types.
+    code_examples:
+      curl: |
+        curl -X POST "https://api.requiems.xyz/v1/entertainment/trivia/batch" \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "filters": [
+              { "category": "sports", "difficulty": "easy" },
+              { "category": "history", "difficulty": "medium" }
+            ]
+          }'
+      python: |
+        import requests
+
+        url = "https://api.requiems.xyz/v1/entertainment/trivia/batch"
+
+        headers = {
+          "requiems-api-key": "YOUR_API_KEY",
+          "Content-Type": "application/json"
+        }
+
+        payload = {
+          "filters": [
+            { "category": "sports", "difficulty": "easy" },
+            { "category": "history", "difficulty": "medium" }
+          ]
+        }
+
+        response = requests.post(url, headers=headers, json=payload)
+
+        for item in response.json()["data"]["results"]:
+          print(item["category"], "-", item["difficulty"])
+          if item.get("error"):
+            print("Error:", item["error"])
+          else:
+            print("Question:", item["data"]["question"])
+            print("Options:", item["data"]["options"])
+            print("Answer:", item["data"]["answer"])
+
+      javascript: |
+        const response = await fetch(
+          'https://api.requiems.xyz/v1/entertainment/trivia/batch',
+          {
+            method: 'POST',
+            headers: {
+              'requiems-api-key': 'YOUR_API_KEY',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              filters: [
+                { category: 'sports', difficulty: 'easy' },
+                { category: 'history', difficulty: 'medium' }
+              ]
+            })
+          }
+        );
+
+        const { data } = await response.json();
+
+        data.results.forEach(item => {
+          console.log(item.category, '-', item.difficulty);
+          if (item.error) {
+            console.log('Error:', item.error);
+          } else {
+            console.log('Question:', item.data.question);
+            console.log('Options:', item.data.options);
+            console.log('Answer:', item.data.answer);
+          }
+        });
+
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/entertainment/trivia/batch')
+
+        request = Net::HTTP::Post.new(uri)
+
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+
+        request.body = {
+          filters: [
+            { category: 'sports', difficulty: 'easy' },
+            { category: 'history', difficulty: 'medium' }
+          ]
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+          http.request(request)
+        end
+
+        JSON.parse(response.body)['data']['results'].each do |item|
+          puts "#{item['category']} - #{item['difficulty']}"
+          if item['error']
+            puts "Error: #{item['error']}"
+          else
+            puts "Question: #{item['data']['question']}"
+            puts "Options: #{item['data']['options']}"
+            puts "Answer: #{item['data']['answer']}"
+          end
+        end
 faq:
   - question: What categories are available?
     answer: >-


### PR DESCRIPTION
**Endpoint**
- Add POST /trivia/batch accepting up to 50 filters
- Each filter combines category and difficulty to fetch a random question
- Implements partial failure — failed filters return an error while successful ones still return results
- Results preserve the same order as the input filters

**Tests**
- Add service tests for all succeed and preserved order
- Add handler tests for happy path, empty filters, exceeds limit, and usage count header

**Docs**
- Add endpoint documentation
- update enspoints_count from 1 to 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a batch trivia endpoint to fetch multiple questions with distinct filters in a single request; preserves per-filter category/difficulty and returns either a question or an error for each entry.
  * Supports up to 50 filters per batch.

* **Tests**
  * Added unit and HTTP tests covering success, ordering, validation errors, and batch size limits.

* **Documentation**
  * API docs updated with endpoint details and multi-language examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bobadilla-tech/requiems-api/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->