### PR TITLE
Feat: Systems MVP

### DIFF
--- a/apps/api/app/routes_v1.go
+++ b/apps/api/app/routes_v1.go
@@ -88,7 +88,7 @@ func registerV1Routes(ctx context.Context, r chi.Router, pool *pgxpool.Pool, rdb
 
 	if serviceEnabled(cfg, "systems") {
 		systemsRouter := chi.NewRouter()
-		systems.RegisterRoutes(systemsRouter)
+		systems.RegisterRoutes(systemsRouter, pool, rdb, cfg)
 		r.Mount("/systems", systemsRouter)
 	}
 }

--- a/apps/api/app/routes_v1.go
+++ b/apps/api/app/routes_v1.go
@@ -14,6 +14,7 @@ import (
 	"requiems-api/services/health"
 	"requiems-api/services/networking"
 	"requiems-api/services/places"
+	"requiems-api/services/systems"
 	"requiems-api/services/technology"
 	"requiems-api/services/text"
 	"requiems-api/services/validation"
@@ -83,5 +84,11 @@ func registerV1Routes(ctx context.Context, r chi.Router, pool *pgxpool.Pool, rdb
 		validationRouter := chi.NewRouter()
 		validation.RegisterRoutes(validationRouter)
 		r.Mount("/validation", validationRouter)
+	}
+
+	if serviceEnabled(cfg, "systems") {
+		systemsRouter := chi.NewRouter()
+		systems.RegisterRoutes(systemsRouter)
+		r.Mount("/systems", systemsRouter)
 	}
 }

--- a/apps/api/app/routes_v1.go
+++ b/apps/api/app/routes_v1.go
@@ -29,11 +29,13 @@ func serviceEnabled(cfg config.Config, key string) bool {
 	if strings.TrimSpace(cfg.EnabledServices) == "" {
 		return true
 	}
+
 	for s := range strings.SplitSeq(cfg.EnabledServices, ",") {
 		if strings.TrimSpace(s) == key {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/apps/api/cmd/seed-bins/normalize.go
+++ b/apps/api/cmd/seed-bins/normalize.go
@@ -194,10 +194,10 @@ func combineSources(a, b string) string {
 		return a
 	}
 	existing := make(map[string]bool)
-	for _, s := range strings.Split(a, ",") {
+	for s := range strings.SplitSeq(a, ",") {
 		existing[strings.TrimSpace(s)] = true
 	}
-	for _, s := range strings.Split(b, ",") {
+	for s := range strings.SplitSeq(b, ",") {
 		s = strings.TrimSpace(s)
 		if s != "" && !existing[s] {
 			existing[s] = true
@@ -302,7 +302,7 @@ func atoi6(s string) int {
 		return 0
 	}
 	v := 0
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		v = v*10 + digitVal(s[i])
 	}
 	return v

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -73,5 +73,5 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/text v0.35.0
 )

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -151,8 +151,6 @@ github.com/ringsaturn/tzf-dist v0.0.2026-b-fix1/go.mod h1:MLn3mRLioai5ceZLV8k+uA
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sajari/fuzzy v1.0.0 h1:+FmwVvJErsd0d0hAPlj4CxqxUtQY/fOoY0DwX4ykpRY=
-github.com/sajari/fuzzy v1.0.0/go.mod h1:OjYR6KxoWOe9+dOlXeiCJd4dIbED4Oo8wpS89o0pwOo=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=

--- a/apps/api/platform/middleware/requestid_test.go
+++ b/apps/api/platform/middleware/requestid_test.go
@@ -53,7 +53,7 @@ func TestRequestID(t *testing.T) {
 		t.Parallel()
 
 		ids := make(map[string]struct{}, 100)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			var ctxID string
 			handler := RequestID(captureHandler(&ctxID))
 			req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)

--- a/apps/api/services/entertainment/trivia/transport_http_test.go
+++ b/apps/api/services/entertainment/trivia/transport_http_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -130,13 +131,7 @@ func TestTrivia_InvalidDifficulty(t *testing.T) {
 func TestTrivia_AnswerIsInOptions(t *testing.T) {
 	t.Parallel()
 	for _, q := range questions {
-		found := false
-		for _, opt := range q.Options {
-			if opt == q.Answer {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(q.Options, q.Answer)
 		assert.True(t, found, "question %q: answer %q is not in options %v", q.Question, q.Answer, q.Options)
 	}
 }

--- a/apps/api/services/finance/bin/service.go
+++ b/apps/api/services/finance/bin/service.go
@@ -246,7 +246,7 @@ func atoiN(s string, n int) int {
 		return 0
 	}
 	v := 0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		b := s[i]
 		if b < '0' || b > '9' {
 			return 0

--- a/apps/api/services/finance/crypto/service_test.go
+++ b/apps/api/services/finance/crypto/service_test.go
@@ -82,7 +82,7 @@ func TestGetPrice_NoRedis_CallsUpstream(t *testing.T) {
 
 	svc := newServiceWithClient(srv.Client(), srv.URL)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		_, err := svc.GetPrice(context.Background(), "BTC")
 		require.NoError(t, err, "call %d failed", i+1)
 	}

--- a/apps/api/services/networking/disposable/service.go
+++ b/apps/api/services/networking/disposable/service.go
@@ -95,10 +95,7 @@ func (s *Service) GetDomains(page, perPage int) (DomainsListResponse, error) {
 
 	start := (page - 1) * perPage
 
-	end := start + perPage
-	if end > total {
-		end = total
-	}
+	end := min(start+perPage, total)
 
 	return DomainsListResponse{
 		Domains: allDomains[start:end],

--- a/apps/api/services/networking/mx/service.go
+++ b/apps/api/services/networking/mx/service.go
@@ -25,7 +25,7 @@ type BatchLookupItem struct {
 	Domain string         `json:"domain"`
 	Found  bool           `json:"found"`
 	Error  string         `json:"error,omitempty"`
-	Data   LookupResponse `json:"data,omitempty"`
+	Data   LookupResponse `json:"data"`
 }
 
 // Service performs MX DNS record lookups.

--- a/apps/api/services/networking/whois/service.go
+++ b/apps/api/services/networking/whois/service.go
@@ -27,7 +27,7 @@ type BatchLookupItem struct {
 	Domain string         `json:"domain"`
 	Found  bool           `json:"found"`
 	Error  string         `json:"error,omitempty"`
-	Data   LookupResponse `json:"data,omitempty"`
+	Data   LookupResponse `json:"data"`
 }
 
 // Does raw WHOIS queries.

--- a/apps/api/services/places/geocode/service.go
+++ b/apps/api/services/places/geocode/service.go
@@ -19,20 +19,22 @@ import (
 
 // GeocodeResponse is returned for address-to-coordinates lookups.
 type GeocodeResponse struct { //nolint:revive // established public API type name
-	Address string  `json:"address"`
-	City    string  `json:"city"`
-	Country string  `json:"country"`
-	Lat     float64 `json:"lat"`
-	Lon     float64 `json:"lon"`
+	Address     string  `json:"address"`
+	City        string  `json:"city"`
+	Country     string  `json:"country"`      // ISO alpha-2 country code (e.g. "DE")
+	CountryName string  `json:"country_name"` // human-readable country name (e.g. "Germany")
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
 }
 
 // ReverseGeocodeResponse is returned for coordinates-to-address lookups.
 type ReverseGeocodeResponse struct {
-	Lat     float64 `json:"lat"`
-	Lon     float64 `json:"lon"`
-	Address string  `json:"address"`
-	City    string  `json:"city"`
-	Country string  `json:"country"`
+	Lat         float64 `json:"lat"`
+	Lon         float64 `json:"lon"`
+	Address     string  `json:"address"`
+	City        string  `json:"city"`
+	Country     string  `json:"country"`      // ISO alpha-2 country code (e.g. "DE")
+	CountryName string  `json:"country_name"` // human-readable country name (e.g. "Germany")
 }
 
 const (
@@ -95,11 +97,12 @@ func (s *Service) Geocode(ctx context.Context, address string) (GeocodeResponse,
 	lon, _ := strconv.ParseFloat(first.Lon, 64)
 
 	resp := GeocodeResponse{
-		Address: first.DisplayName,
-		City:    first.Address.resolveCity(),
-		Country: strings.ToUpper(first.Address.CountryCode),
-		Lat:     lat,
-		Lon:     lon,
+		Address:     first.DisplayName,
+		City:        first.Address.resolveCity(),
+		Country:     strings.ToUpper(first.Address.CountryCode),
+		CountryName: first.Address.Country,
+		Lat:         lat,
+		Lon:         lon,
 	}
 
 	s.toCache(ctx, cacheKey, resp)
@@ -136,11 +139,12 @@ func (s *Service) ReverseGeocode(ctx context.Context, lat, lon float64) (Reverse
 	}
 
 	resp := ReverseGeocodeResponse{
-		Lat:     lat,
-		Lon:     lon,
-		Address: result.DisplayName,
-		City:    result.Address.resolveCity(),
-		Country: strings.ToUpper(result.Address.CountryCode),
+		Lat:         lat,
+		Lon:         lon,
+		Address:     result.DisplayName,
+		City:        result.Address.resolveCity(),
+		Country:     strings.ToUpper(result.Address.CountryCode),
+		CountryName: result.Address.Country,
 	}
 
 	s.toCache(ctx, cacheKey, resp)
@@ -280,7 +284,8 @@ type nominatimAddress struct {
 	Town        string `json:"town"`
 	Village     string `json:"village"`
 	County      string `json:"county"`
-	CountryCode string `json:"country_code"`
+	Country     string `json:"country"`      // human-readable country name from Nominatim
+	CountryCode string `json:"country_code"` // ISO alpha-2 code from Nominatim
 }
 
 // resolveCity returns the most specific city-level place name available.

--- a/apps/api/services/places/geocode/service_test.go
+++ b/apps/api/services/places/geocode/service_test.go
@@ -31,9 +31,6 @@ func newTestService(srv *httptest.Server) *Service {
 	return NewService(srv.URL, srv.Client(), nil)
 }
 
-//go:fix inline
-func ptrF(v float64) *float64 { return new(v) }
-
 // --- Geocode ---
 
 func TestGeocodeService_HappyPath(t *testing.T) {

--- a/apps/api/services/places/geocode/service_test.go
+++ b/apps/api/services/places/geocode/service_test.go
@@ -31,7 +31,8 @@ func newTestService(srv *httptest.Server) *Service {
 	return NewService(srv.URL, srv.Client(), nil)
 }
 
-func ptrF(v float64) *float64 { return &v }
+//go:fix inline
+func ptrF(v float64) *float64 { return new(v) }
 
 // --- Geocode ---
 
@@ -258,7 +259,7 @@ func TestReverseGeocodeBatch_Service_HappyPath(t *testing.T) {
 	defer srv.Close()
 
 	svc := newTestService(srv)
-	items := []ReverseQuery{{Lat: ptrF(48.8584), Lon: ptrF(2.2945)}, {Lat: ptrF(51.5014), Lon: ptrF(-0.1419)}}
+	items := []ReverseQuery{{Lat: new(48.8584), Lon: new(2.2945)}, {Lat: new(51.5014), Lon: new(-0.1419)}}
 	results := svc.ReverseGeocodeBatch(t.Context(), items)
 
 	require.Len(t, results, 2)
@@ -284,7 +285,7 @@ func TestReverseGeocodeBatch_Service_PartialNotFound(t *testing.T) {
 	defer srv.Close()
 
 	svc := newTestService(srv)
-	items := []ReverseQuery{{Lat: ptrF(48.8584), Lon: ptrF(2.2945)}, {Lat: ptrF(0), Lon: ptrF(0)}}
+	items := []ReverseQuery{{Lat: new(48.8584), Lon: new(2.2945)}, {Lat: ptrF(0), Lon: ptrF(0)}}
 	results := svc.ReverseGeocodeBatch(t.Context(), items)
 
 	require.Len(t, results, 2)

--- a/apps/api/services/places/geocode/service_test.go
+++ b/apps/api/services/places/geocode/service_test.go
@@ -285,7 +285,7 @@ func TestReverseGeocodeBatch_Service_PartialNotFound(t *testing.T) {
 	defer srv.Close()
 
 	svc := newTestService(srv)
-	items := []ReverseQuery{{Lat: new(48.8584), Lon: new(2.2945)}, {Lat: ptrF(0), Lon: ptrF(0)}}
+	items := []ReverseQuery{{Lat: new(48.8584), Lon: new(2.2945)}, {Lat: new(float64(0)), Lon: new(float64(0))}}
 	results := svc.ReverseGeocodeBatch(t.Context(), items)
 
 	require.Len(t, results, 2)

--- a/apps/api/services/places/timezone/service.go
+++ b/apps/api/services/places/timezone/service.go
@@ -164,10 +164,7 @@ func isDST(t time.Time) bool {
 	}
 
 	// Standard time is the offset that is less positive (more negative) of the two.
-	standardOffset := offsetJan
-	if offsetJul < offsetJan {
-		standardOffset = offsetJul
-	}
+	standardOffset := min(offsetJul, offsetJan)
 
 	return offsetNow != standardOffset
 }

--- a/apps/api/services/systems/data_integrity/router.go
+++ b/apps/api/services/systems/data_integrity/router.go
@@ -1,0 +1,11 @@
+package dataintegrity
+
+import (
+	"github.com/go-chi/chi/v5"
+
+	textnormalize "requiems-api/services/systems/data_integrity/text_normalize"
+)
+
+func RegisterRoutes(r chi.Router) {
+	textnormalize.RegisterRoutes(r, textnormalize.NewService())
+}

--- a/apps/api/services/systems/data_integrity/text_normalize/service.go
+++ b/apps/api/services/systems/data_integrity/text_normalize/service.go
@@ -1,0 +1,86 @@
+package textnormalize
+
+import (
+	"html"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+var (
+	reWhitespace  = regexp.MustCompile(`\s+`)
+	reHTMLTags    = regexp.MustCompile(`<[^>]+>`)
+	rePunctuation = regexp.MustCompile(`[^\p{L}\p{N}\s]`)
+)
+
+// Operation names accepted in the operations array.
+const (
+	OpTrim               = "trim"
+	OpLowercase          = "lowercase"
+	OpUppercase          = "uppercase"
+	OpNormalizeUnicode   = "normalize_unicode"
+	OpCollapseWhitespace = "collapse_whitespace"
+	OpStripHTML          = "strip_html"
+	OpRemovePunctuation  = "remove_punctuation"
+)
+
+// Request is the input for the text normalize endpoint.
+type Request struct {
+	Text       string   `json:"text" validate:"required"`
+	Operations []string `json:"operations" validate:"required,min=1"`
+}
+
+// Result is the response from the text normalize endpoint.
+type Result struct {
+	Original   string   `json:"original"`
+	Normalized string   `json:"normalized"`
+	Operations []string `json:"operations"`
+}
+
+// Service applies text normalization operations.
+type Service struct{}
+
+// NewService returns a new Service.
+func NewService() *Service { return &Service{} }
+
+// Normalize applies the requested operations in order and returns the result.
+func (s *Service) Normalize(text string, operations []string) Result {
+	out := text
+	for _, op := range operations {
+		out = apply(out, op)
+	}
+	return Result{
+		Original:   text,
+		Normalized: out,
+		Operations: operations,
+	}
+}
+
+func apply(text, op string) string {
+	switch op {
+	case OpTrim:
+		return strings.TrimSpace(text)
+	case OpLowercase:
+		return strings.ToLower(text)
+	case OpUppercase:
+		return strings.ToUpper(text)
+	case OpNormalizeUnicode:
+		return norm.NFC.String(text)
+	case OpCollapseWhitespace:
+		return reWhitespace.ReplaceAllString(text, " ")
+	case OpStripHTML:
+		stripped := reHTMLTags.ReplaceAllString(text, " ")
+		return html.UnescapeString(stripped)
+	case OpRemovePunctuation:
+		return strings.Map(func(r rune) rune {
+			if unicode.IsPunct(r) || unicode.IsSymbol(r) {
+				return -1
+			}
+			return r
+		}, text)
+	default:
+		return text
+	}
+}

--- a/apps/api/services/systems/data_integrity/text_normalize/service.go
+++ b/apps/api/services/systems/data_integrity/text_normalize/service.go
@@ -10,9 +10,8 @@ import (
 )
 
 var (
-	reWhitespace  = regexp.MustCompile(`\s+`)
-	reHTMLTags    = regexp.MustCompile(`<[^>]+>`)
-	rePunctuation = regexp.MustCompile(`[^\p{L}\p{N}\s]`)
+	reWhitespace = regexp.MustCompile(`\s+`)
+	reHTMLTags   = regexp.MustCompile(`<[^>]+>`)
 )
 
 // Operation names accepted in the operations array.

--- a/apps/api/services/systems/data_integrity/text_normalize/transport_http.go
+++ b/apps/api/services/systems/data_integrity/text_normalize/transport_http.go
@@ -1,0 +1,18 @@
+package textnormalize
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts the text normalize handler on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/text/normalize", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			return svc.Normalize(req.Text, req.Operations), nil
+		},
+	))
+}

--- a/apps/api/services/systems/data_integrity/text_normalize/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/text_normalize/transport_http_test.go
@@ -1,0 +1,168 @@
+package textnormalize
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+)
+
+func setupRouter() chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService())
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/text/normalize", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestNormalize_Trim(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"  hello world  ","operations":["trim"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "hello world", resp.Data.Normalized)
+	assert.Equal(t, "  hello world  ", resp.Data.Original)
+}
+
+func TestNormalize_Lowercase(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"Hello WORLD","operations":["lowercase"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "hello world", resp.Data.Normalized)
+}
+
+func TestNormalize_Uppercase(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello world","operations":["uppercase"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "HELLO WORLD", resp.Data.Normalized)
+}
+
+func TestNormalize_NormalizeUnicode(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	// café composed vs decomposed — both should produce NFC
+	w := post(t, r, `{"text":"café","operations":["normalize_unicode"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "café", resp.Data.Normalized)
+}
+
+func TestNormalize_CollapseWhitespace(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello   \t world\n\nfoo","operations":["collapse_whitespace"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "hello world foo", resp.Data.Normalized)
+}
+
+func TestNormalize_StripHTML(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"<p>Hello <b>world</b>&amp;!</p>","operations":["strip_html"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Normalized, "Hello")
+	assert.Contains(t, resp.Data.Normalized, "world")
+	assert.Contains(t, resp.Data.Normalized, "&!")
+	assert.NotContains(t, resp.Data.Normalized, "<p>")
+	assert.NotContains(t, resp.Data.Normalized, "<b>")
+}
+
+func TestNormalize_RemovePunctuation(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"Hello, world! How are you?","operations":["remove_punctuation"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Hello world How are you", resp.Data.Normalized)
+}
+
+func TestNormalize_MultipleOperationsOrdered(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	// trim → collapse_whitespace → lowercase applied in order
+	w := post(t, r, `{"text":"  Hello   WORLD  ","operations":["trim","collapse_whitespace","lowercase"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "hello world", resp.Data.Normalized)
+}
+
+func TestNormalize_OperationsEchoedInResponse(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello","operations":["trim","lowercase"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, []string{"trim", "lowercase"}, resp.Data.Operations)
+}
+
+func TestNormalize_UnknownOperationIsNoOp(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello","operations":["unknown_op"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "hello", resp.Data.Normalized)
+}
+
+func TestNormalize_MissingText(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"operations":["trim"]}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestNormalize_MissingOperations(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello"}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestNormalize_EmptyOperationsArray(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	w := post(t, r, `{"text":"hello","operations":[]}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestNormalize_EmptyBody(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+	req := httptest.NewRequest(http.MethodPost, "/text/normalize", http.NoBody)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/apps/api/services/systems/global_data/business_calendar/service.go
+++ b/apps/api/services/systems/global_data/business_calendar/service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"requiems-api/services/places/holidays"
-	workingdays "requiems-api/services/places/working-days"
 )
 
 // -- Dependency interfaces ---------------------------------------------------

--- a/apps/api/services/systems/global_data/business_calendar/service.go
+++ b/apps/api/services/systems/global_data/business_calendar/service.go
@@ -8,8 +8,6 @@ import (
 	"requiems-api/services/places/holidays"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type HolidaysGetter interface {
 	GetHolidays(country string, year int) (holidays.HolidayList, error)
 }
@@ -18,34 +16,21 @@ type WorkingDaysGetter interface {
 	GetWorkingDays(from, to time.Time, country, subdivision string) int
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service returns holiday and working-day data for a country/period.
 type Service struct {
 	holidays    HolidaysGetter
 	workingDays WorkingDaysGetter
 }
 
-// NewService returns a new business calendar Service.
 func NewService(h HolidaysGetter, w WorkingDaysGetter) *Service {
 	return &Service{holidays: h, workingDays: w}
 }
 
-// Request is the input for GET /business-calendar/{country}.
-type Request struct {
-	Country string `query:"country"` // set from path param by transport
-	Year    int    `query:"year"`
-	Month   int    `query:"month"` // 0 = full year scope
-}
-
-// Holiday is a single holiday entry.
 type Holiday struct {
 	Date string `json:"date"`
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-// Result is the business calendar response.
 type Result struct {
 	CountryCode  string    `json:"country_code"`
 	Year         int       `json:"year"`
@@ -58,7 +43,6 @@ type Result struct {
 	NextHoliday  *Holiday  `json:"next_holiday"`
 }
 
-// Get returns business calendar data for the given country and period.
 func (s *Service) Get(_ context.Context, req Request) (Result, error) {
 	year := req.Year
 	if year == 0 {
@@ -74,7 +58,6 @@ func (s *Service) Get(_ context.Context, req Request) (Result, error) {
 	allHolidays := toHolidays(list.Holidays)
 
 	if req.Month != 0 {
-		// Month-scoped response.
 		monthStart := time.Date(year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
 		monthEnd := monthStart.AddDate(0, 1, 0).Add(-time.Second)
 		totalDays := int(monthEnd.Sub(monthStart).Hours()/24) + 1
@@ -100,7 +83,6 @@ func (s *Service) Get(_ context.Context, req Request) (Result, error) {
 		}, nil
 	}
 
-	// Full-year scope.
 	yearStart := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
 	yearEnd := time.Date(year, 12, 31, 23, 59, 59, 0, time.UTC)
 	workDays := s.workingDays.GetWorkingDays(yearStart, yearEnd, req.Country, "")

--- a/apps/api/services/systems/global_data/business_calendar/service.go
+++ b/apps/api/services/systems/global_data/business_calendar/service.go
@@ -1,0 +1,164 @@
+package businesscalendar
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"requiems-api/services/places/holidays"
+	workingdays "requiems-api/services/places/working-days"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type HolidaysGetter interface {
+	GetHolidays(country string, year int) (holidays.HolidayList, error)
+}
+
+type WorkingDaysGetter interface {
+	GetWorkingDays(from, to time.Time, country, subdivision string) int
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service returns holiday and working-day data for a country/period.
+type Service struct {
+	holidays    HolidaysGetter
+	workingDays WorkingDaysGetter
+}
+
+// NewService returns a new business calendar Service.
+func NewService(h HolidaysGetter, w WorkingDaysGetter) *Service {
+	return &Service{holidays: h, workingDays: w}
+}
+
+// Request is the input for GET /business-calendar/{country}.
+type Request struct {
+	Country string `query:"country"` // set from path param by transport
+	Year    int    `query:"year"`
+	Month   int    `query:"month"` // 0 = full year scope
+}
+
+// Holiday is a single holiday entry.
+type Holiday struct {
+	Date string `json:"date"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Result is the business calendar response.
+type Result struct {
+	CountryCode  string    `json:"country_code"`
+	Year         int       `json:"year"`
+	Month        *int      `json:"month,omitempty"`
+	WorkingDays  int       `json:"working_days"`
+	TotalDays    *int      `json:"total_days,omitempty"`
+	WeekendDays  *int      `json:"weekend_days,omitempty"`
+	Holidays     []Holiday `json:"holidays"`
+	HolidayCount int       `json:"holiday_count"`
+	NextHoliday  *Holiday  `json:"next_holiday"`
+}
+
+// Get returns business calendar data for the given country and period.
+func (s *Service) Get(_ context.Context, req Request) (Result, error) {
+	year := req.Year
+	if year == 0 {
+		year = time.Now().Year()
+	}
+
+	list, err := s.holidays.GetHolidays(req.Country, year)
+	if err != nil {
+		list = holidays.HolidayList{Country: req.Country, Year: year, Holidays: nil}
+	}
+
+	now := time.Now()
+	allHolidays := toHolidays(list.Holidays)
+
+	if req.Month != 0 {
+		// Month-scoped response.
+		monthStart := time.Date(year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
+		monthEnd := monthStart.AddDate(0, 1, 0).Add(-time.Second)
+		totalDays := int(monthEnd.Sub(monthStart).Hours()/24) + 1
+		weekendDays := countWeekendDays(monthStart, monthEnd)
+
+		inMonth := filterByMonth(allHolidays, year, req.Month)
+		workDays := s.workingDays.GetWorkingDays(monthStart, monthEnd, req.Country, "")
+		nextH := findNextHoliday(allHolidays, now)
+
+		m := req.Month
+		total := totalDays
+		wknd := weekendDays
+		return Result{
+			CountryCode:  req.Country,
+			Year:         year,
+			Month:        &m,
+			WorkingDays:  workDays,
+			TotalDays:    &total,
+			WeekendDays:  &wknd,
+			Holidays:     inMonth,
+			HolidayCount: len(inMonth),
+			NextHoliday:  nextH,
+		}, nil
+	}
+
+	// Full-year scope.
+	yearStart := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+	yearEnd := time.Date(year, 12, 31, 23, 59, 59, 0, time.UTC)
+	workDays := s.workingDays.GetWorkingDays(yearStart, yearEnd, req.Country, "")
+	nextH := findNextHoliday(allHolidays, now)
+
+	return Result{
+		CountryCode:  req.Country,
+		Year:         year,
+		WorkingDays:  workDays,
+		Holidays:     allHolidays,
+		HolidayCount: len(allHolidays),
+		NextHoliday:  nextH,
+	}, nil
+}
+
+func toHolidays(src []holidays.Holiday) []Holiday {
+	out := make([]Holiday, 0, len(src))
+	for _, h := range src {
+		out = append(out, Holiday{Date: h.Date, Name: h.Name, Type: "national"})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Date < out[j].Date })
+	return out
+}
+
+func filterByMonth(all []Holiday, year, month int) []Holiday {
+	prefix := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).Format("2006-01")
+	var out []Holiday
+	for _, h := range all {
+		if len(h.Date) >= 7 && h.Date[:7] == prefix {
+			out = append(out, h)
+		}
+	}
+	if out == nil {
+		out = []Holiday{}
+	}
+	return out
+}
+
+func findNextHoliday(all []Holiday, after time.Time) *Holiday {
+	cutoff := after.AddDate(0, 0, 90)
+	todayStr := after.Format("2006-01-02")
+	cutoffStr := cutoff.Format("2006-01-02")
+	for i := range all {
+		if all[i].Date >= todayStr && all[i].Date <= cutoffStr {
+			h := all[i]
+			return &h
+		}
+	}
+	return nil
+}
+
+func countWeekendDays(from, to time.Time) int {
+	count := 0
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		if d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+			count++
+		}
+	}
+	return count
+}

--- a/apps/api/services/systems/global_data/business_calendar/transport_http.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http.go
@@ -1,0 +1,56 @@
+package businesscalendar
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
+)
+
+// RegisterRoutes mounts GET /business-calendar/{country} on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Get("/business-calendar/{country}", func(w http.ResponseWriter, r *http.Request) {
+		country := strings.ToUpper(chi.URLParam(r, "country"))
+		if len(country) != 2 {
+			httpx.Error(w, http.StatusUnprocessableEntity, "validation_failed", "country must be a 2-letter ISO 3166-1 alpha-2 code")
+			return
+		}
+
+		now := time.Now()
+		req := Request{Country: country, Year: now.Year()}
+
+		if y := r.URL.Query().Get("year"); y != "" {
+			n, err := strconv.Atoi(y)
+			if err != nil || n < 1900 || n > 2100 {
+				httpx.Error(w, http.StatusUnprocessableEntity, "validation_failed", "year must be between 1900 and 2100")
+				return
+			}
+			req.Year = n
+		}
+		if m := r.URL.Query().Get("month"); m != "" {
+			n, err := strconv.Atoi(m)
+			if err != nil || n < 1 || n > 12 {
+				httpx.Error(w, http.StatusUnprocessableEntity, "validation_failed", "month must be between 1 and 12")
+				return
+			}
+			req.Month = n
+		}
+
+		res, err := svc.Get(context.WithValue(r.Context(), struct{}{}, nil), req)
+		if err != nil {
+			if se, ok := err.(*svcerr.Error); ok {
+				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)
+				return
+			}
+			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
+			return
+		}
+		httpx.JSON(w, http.StatusOK, res)
+	})
+}

--- a/apps/api/services/systems/global_data/business_calendar/transport_http.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http.go
@@ -1,7 +1,6 @@
 package businesscalendar
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -47,7 +46,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 			req.Month = n
 		}
 
-		res, err := svc.Get(context.WithValue(r.Context(), struct{}{}, nil), req)
+		res, err := svc.Get(r.Context(), req)
 		if err != nil {
 			if se, ok := err.(*svcerr.Error); ok {
 				httpx.Error(w, svcerr.HTTPStatus(se), se.Code, se.Message)

--- a/apps/api/services/systems/global_data/business_calendar/transport_http.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http.go
@@ -13,7 +13,12 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
-// RegisterRoutes mounts GET /business-calendar/{country} on the given router.
+type Request struct {
+	Country string
+	Year    int
+	Month   int // 0 = full year scope
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Get("/business-calendar/{country}", func(w http.ResponseWriter, r *http.Request) {
 		country := strings.ToUpper(chi.URLParam(r, "country"))

--- a/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
@@ -15,8 +15,6 @@ import (
 	"requiems-api/services/places/holidays"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubHolidays struct {
 	r   holidays.HolidayList
 	err error
@@ -29,8 +27,6 @@ func (s *stubHolidays) GetHolidays(_ string, _ int) (holidays.HolidayList, error
 type stubWorkingDays struct{ n int }
 
 func (s *stubWorkingDays) GetWorkingDays(_, _ time.Time, _, _ string) int { return s.n }
-
-// -- helpers -----------------------------------------------------------------
 
 func setupRouter(h *stubHolidays, w *stubWorkingDays) chi.Router {
 	r := chi.NewRouter()
@@ -54,8 +50,6 @@ func deHolidays() holidays.HolidayList {
 		Total:    1,
 	}
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestBusinessCalendar_ValidCountryAndMonth(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
@@ -1,0 +1,129 @@
+package businesscalendar
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/places/holidays"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubHolidays struct {
+	r   holidays.HolidayList
+	err error
+}
+
+func (s *stubHolidays) GetHolidays(_ string, _ int) (holidays.HolidayList, error) {
+	return s.r, s.err
+}
+
+type stubWorkingDays struct{ n int }
+
+func (s *stubWorkingDays) GetWorkingDays(_, _ time.Time, _, _ string) int { return s.n }
+
+// -- helpers -----------------------------------------------------------------
+
+func setupRouter(h *stubHolidays, w *stubWorkingDays) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(h, w))
+	return r
+}
+
+func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func deHolidays() holidays.HolidayList {
+	parsed, _ := time.Parse("2006-01-02", "2026-01-01")
+	return holidays.HolidayList{
+		Country:  "DE",
+		Year:     2026,
+		Holidays: []holidays.Holiday{{Name: "New Year", Date: parsed}},
+		Total:    1,
+	}
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestBusinessCalendar_ValidCountryAndMonth(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubHolidays{r: deHolidays()}, &stubWorkingDays{n: 21})
+	w := get(t, r, "/business-calendar/DE?year=2026&month=1")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "DE", resp.Data.CountryCode)
+	assert.Equal(t, 2026, resp.Data.Year)
+	assert.NotNil(t, resp.Data.Month)
+	assert.Greater(t, resp.Data.WorkingDays, 0)
+	assert.NotNil(t, resp.Data.TotalDays)
+}
+
+func TestBusinessCalendar_YearScopeNoMonth(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubHolidays{r: deHolidays()}, &stubWorkingDays{n: 252})
+	w := get(t, r, "/business-calendar/DE?year=2026")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.Month)
+	assert.Nil(t, resp.Data.TotalDays)
+	assert.Equal(t, 252, resp.Data.WorkingDays)
+}
+
+func TestBusinessCalendar_NoHolidaysThisMonth(t *testing.T) {
+	t.Parallel()
+	// holidays only in January, request for February
+	parsed, _ := time.Parse("2006-01-02", "2026-01-01")
+	list := holidays.HolidayList{Country: "DE", Year: 2026,
+		Holidays: []holidays.Holiday{{Name: "New Year", Date: parsed}}}
+	r := setupRouter(&stubHolidays{r: list}, &stubWorkingDays{n: 20})
+	w := get(t, r, "/business-calendar/DE?year=2026&month=2")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Data.HolidayCount)
+	assert.Empty(t, resp.Data.Holidays)
+}
+
+func TestBusinessCalendar_UnknownCountry(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubHolidays{}, &stubWorkingDays{})
+	// Too long — not a valid alpha-2
+	w := get(t, r, "/business-calendar/XYZZY?year=2026")
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestBusinessCalendar_MissingCountry(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubHolidays{}, &stubWorkingDays{})
+	w := get(t, r, "/business-calendar/?year=2026")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestBusinessCalendar_NextHolidayNull(t *testing.T) {
+	t.Parallel()
+	// past holiday only — next_holiday should be null
+	parsed, _ := time.Parse("2006-01-02", "2000-01-01")
+	list := holidays.HolidayList{Country: "DE", Year: 2000,
+		Holidays: []holidays.Holiday{{Name: "Old Year", Date: parsed}}}
+	r := setupRouter(&stubHolidays{r: list}, &stubWorkingDays{n: 20})
+	w := get(t, r, "/business-calendar/DE?year=2000")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.NextHoliday)
+}

--- a/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
@@ -36,7 +36,7 @@ func setupRouter(h *stubHolidays, w *stubWorkingDays) chi.Router {
 
 func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
+++ b/apps/api/services/systems/global_data/business_calendar/transport_http_test.go
@@ -47,11 +47,10 @@ func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
 }
 
 func deHolidays() holidays.HolidayList {
-	parsed, _ := time.Parse("2006-01-02", "2026-01-01")
 	return holidays.HolidayList{
 		Country:  "DE",
 		Year:     2026,
-		Holidays: []holidays.Holiday{{Name: "New Year", Date: parsed}},
+		Holidays: []holidays.Holiday{{Name: "New Year", Date: "2026-01-01"}},
 		Total:    1,
 	}
 }
@@ -87,9 +86,8 @@ func TestBusinessCalendar_YearScopeNoMonth(t *testing.T) {
 func TestBusinessCalendar_NoHolidaysThisMonth(t *testing.T) {
 	t.Parallel()
 	// holidays only in January, request for February
-	parsed, _ := time.Parse("2006-01-02", "2026-01-01")
 	list := holidays.HolidayList{Country: "DE", Year: 2026,
-		Holidays: []holidays.Holiday{{Name: "New Year", Date: parsed}}}
+		Holidays: []holidays.Holiday{{Name: "New Year", Date: "2026-01-01"}}}
 	r := setupRouter(&stubHolidays{r: list}, &stubWorkingDays{n: 20})
 	w := get(t, r, "/business-calendar/DE?year=2026&month=2")
 	require.Equal(t, http.StatusOK, w.Code)
@@ -117,9 +115,8 @@ func TestBusinessCalendar_MissingCountry(t *testing.T) {
 func TestBusinessCalendar_NextHolidayNull(t *testing.T) {
 	t.Parallel()
 	// past holiday only — next_holiday should be null
-	parsed, _ := time.Parse("2006-01-02", "2000-01-01")
 	list := holidays.HolidayList{Country: "DE", Year: 2000,
-		Holidays: []holidays.Holiday{{Name: "Old Year", Date: parsed}}}
+		Holidays: []holidays.Holiday{{Name: "Old Year", Date: "2000-01-01"}}}
 	r := setupRouter(&stubHolidays{r: list}, &stubWorkingDays{n: 20})
 	w := get(t, r, "/business-calendar/DE?year=2000")
 	require.Equal(t, http.StatusOK, w.Code)

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -8,7 +8,6 @@ import (
 	"requiems-api/services/places/geocode"
 	"requiems-api/services/places/holidays"
 	"requiems-api/services/places/timezone"
-	workingdays "requiems-api/services/places/working-days"
 )
 
 // -- Dependency interfaces ---------------------------------------------------

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -79,14 +79,15 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		lat = req.Coordinates.Lat
 		lon = req.Coordinates.Lng
 		rev, err := s.geocoder.ReverseGeocode(ctx, lat, lon)
-		if err == nil {
-			address = rev.Address
-			city = rev.City
-			country = rev.Country
-			countryCode = rev.Country // nominatim returns country_code in Country field (uppercase)
-			if req.CountryCode != "" {
-				countryCode = req.CountryCode
-			}
+		if err != nil {
+			return Result{}, err
+		}
+		address = rev.Address
+		city = rev.City
+		country = rev.Country
+		countryCode = rev.Country // nominatim returns country_code in Country field (uppercase)
+		if req.CountryCode != "" {
+			countryCode = req.CountryCode
 		}
 	case req.Address != "":
 		res, err := s.geocoder.Geocode(ctx, req.Address)

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -10,8 +10,6 @@ import (
 	"requiems-api/services/places/timezone"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type Geocoder interface {
 	Geocode(ctx context.Context, address string) (geocode.GeocodeResponse, error)
 	ReverseGeocode(ctx context.Context, lat, lon float64) (geocode.ReverseGeocodeResponse, error)
@@ -29,9 +27,6 @@ type WorkingDaysGetter interface {
 	GetWorkingDays(from, to time.Time, country, subdivision string) int
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service resolves full location context from an address or coordinates.
 type Service struct {
 	geocoder    Geocoder
 	timezone    TimezoneGetter
@@ -39,32 +34,22 @@ type Service struct {
 	workingDays WorkingDaysGetter
 }
 
-// NewService returns a new location resolve Service.
 func NewService(g Geocoder, t TimezoneGetter, h HolidaysGetter, w WorkingDaysGetter) *Service {
 	return &Service{geocoder: g, timezone: t, holidays: h, workingDays: w}
 }
 
-// Coordinates holds lat/lon.
+// Coordinates is shared between Request and Result.
 type Coordinates struct {
 	Lat float64 `json:"lat"`
 	Lng float64 `json:"lng"`
 }
 
-// Request is the input for POST /location/resolve.
-type Request struct {
-	Address     string       `json:"address"`
-	Coordinates *Coordinates `json:"coordinates"`
-	CountryCode string       `json:"country_code"`
-}
-
-// NextHoliday is the next upcoming holiday within 90 days.
 type NextHoliday struct {
 	Date string `json:"date"`
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-// Result is the full location context response.
 type Result struct {
 	Address              string       `json:"address"`
 	City                 string       `json:"city"`
@@ -80,7 +65,6 @@ type Result struct {
 	Flags                []string     `json:"flags"`
 }
 
-// Resolve resolves the location context from address or coordinates.
 func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 	var (
 		lat, lon    float64
@@ -90,7 +74,6 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		countryCode string
 	)
 
-	// Phase 1: resolve coordinates (sequential).
 	if req.Coordinates != nil {
 		lat = req.Coordinates.Lat
 		lon = req.Coordinates.Lng
@@ -122,7 +105,6 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		return Result{}, &missingInputError{}
 	}
 
-	// Phase 2: parallel fan-out — timezone + holidays + working-days.
 	now := time.Now()
 	year := now.Year()
 	month := now.Month()

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -74,7 +74,8 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		countryCode string
 	)
 
-	if req.Coordinates != nil {
+	switch {
+	case req.Coordinates != nil:
 		lat = req.Coordinates.Lat
 		lon = req.Coordinates.Lng
 		rev, err := s.geocoder.ReverseGeocode(ctx, lat, lon)
@@ -87,7 +88,7 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 				countryCode = req.CountryCode
 			}
 		}
-	} else if req.Address != "" {
+	case req.Address != "":
 		res, err := s.geocoder.Geocode(ctx, req.Address)
 		if err != nil {
 			return Result{}, err
@@ -101,7 +102,7 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		if req.CountryCode != "" {
 			countryCode = req.CountryCode
 		}
-	} else {
+	default:
 		return Result{}, &missingInputError{}
 	}
 

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -1,0 +1,222 @@
+package locationresolve
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"requiems-api/services/places/geocode"
+	"requiems-api/services/places/holidays"
+	"requiems-api/services/places/timezone"
+	workingdays "requiems-api/services/places/working-days"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type Geocoder interface {
+	Geocode(ctx context.Context, address string) (geocode.GeocodeResponse, error)
+	ReverseGeocode(ctx context.Context, lat, lon float64) (geocode.ReverseGeocodeResponse, error)
+}
+
+type TimezoneGetter interface {
+	GetTimezoneByCoords(lat, lon float64) (*timezone.Info, error)
+}
+
+type HolidaysGetter interface {
+	GetHolidays(country string, year int) (holidays.HolidayList, error)
+}
+
+type WorkingDaysGetter interface {
+	GetWorkingDays(from, to time.Time, country, subdivision string) int
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service resolves full location context from an address or coordinates.
+type Service struct {
+	geocoder    Geocoder
+	timezone    TimezoneGetter
+	holidays    HolidaysGetter
+	workingDays WorkingDaysGetter
+}
+
+// NewService returns a new location resolve Service.
+func NewService(g Geocoder, t TimezoneGetter, h HolidaysGetter, w WorkingDaysGetter) *Service {
+	return &Service{geocoder: g, timezone: t, holidays: h, workingDays: w}
+}
+
+// Coordinates holds lat/lon.
+type Coordinates struct {
+	Lat float64 `json:"lat"`
+	Lng float64 `json:"lng"`
+}
+
+// Request is the input for POST /location/resolve.
+type Request struct {
+	Address     string       `json:"address"`
+	Coordinates *Coordinates `json:"coordinates"`
+	CountryCode string       `json:"country_code"`
+}
+
+// NextHoliday is the next upcoming holiday within 90 days.
+type NextHoliday struct {
+	Date string `json:"date"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Result is the full location context response.
+type Result struct {
+	Address              string       `json:"address"`
+	City                 string       `json:"city"`
+	Country              string       `json:"country"`
+	CountryCode          string       `json:"country_code"`
+	Coordinates          Coordinates  `json:"coordinates"`
+	Timezone             *string      `json:"timezone"`
+	UTCOffset            *string      `json:"utc_offset"`
+	CurrentTime          *string      `json:"current_time"`
+	IsHolidayToday       bool         `json:"is_holiday_today"`
+	WorkingDaysThisMonth int          `json:"working_days_this_month"`
+	NextHoliday          *NextHoliday `json:"next_holiday"`
+	Flags                []string     `json:"flags"`
+}
+
+// Resolve resolves the location context from address or coordinates.
+func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
+	var (
+		lat, lon    float64
+		address     string
+		city        string
+		country     string
+		countryCode string
+	)
+
+	// Phase 1: resolve coordinates (sequential).
+	if req.Coordinates != nil {
+		lat = req.Coordinates.Lat
+		lon = req.Coordinates.Lng
+		rev, err := s.geocoder.ReverseGeocode(ctx, lat, lon)
+		if err == nil {
+			address = rev.Address
+			city = rev.City
+			country = rev.Country
+			countryCode = rev.Country // nominatim returns country_code in Country field (uppercase)
+			if req.CountryCode != "" {
+				countryCode = req.CountryCode
+			}
+		}
+	} else if req.Address != "" {
+		res, err := s.geocoder.Geocode(ctx, req.Address)
+		if err != nil {
+			return Result{}, err
+		}
+		lat = res.Lat
+		lon = res.Lon
+		address = res.Address
+		city = res.City
+		country = res.Country
+		countryCode = res.Country
+		if req.CountryCode != "" {
+			countryCode = req.CountryCode
+		}
+	} else {
+		return Result{}, &missingInputError{}
+	}
+
+	// Phase 2: parallel fan-out — timezone + holidays + working-days.
+	now := time.Now()
+	year := now.Year()
+	month := now.Month()
+	monthStart := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	monthEnd := monthStart.AddDate(0, 1, 0).Add(-time.Second)
+
+	type tzOut struct {
+		r   *timezone.Info
+		err error
+	}
+	type holOut struct {
+		r   holidays.HolidayList
+		err error
+	}
+	type wdOut struct{ n int }
+
+	tzCh := make(chan tzOut, 1)
+	holCh := make(chan holOut, 1)
+	wdCh := make(chan wdOut, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		r, err := s.timezone.GetTimezoneByCoords(lat, lon)
+		tzCh <- tzOut{r, err}
+	}()
+	go func() {
+		defer wg.Done()
+		r, err := s.holidays.GetHolidays(countryCode, year)
+		holCh <- holOut{r, err}
+	}()
+	go func() {
+		defer wg.Done()
+		n := s.workingDays.GetWorkingDays(monthStart, monthEnd, countryCode, "")
+		wdCh <- wdOut{n}
+	}()
+
+	wg.Wait()
+
+	tzResult := <-tzCh
+	holResult := <-holCh
+	wdResult := <-wdCh
+
+	flags := make([]string, 0, 2)
+	out := Result{
+		Address:     address,
+		City:        city,
+		Country:     country,
+		CountryCode: countryCode,
+		Coordinates: Coordinates{Lat: lat, Lng: lon},
+		Flags:       flags,
+	}
+
+	if tzResult.err != nil {
+		flags = append(flags, "timezone_unavailable")
+	} else {
+		out.Timezone = &tzResult.r.Timezone
+		out.UTCOffset = &tzResult.r.Offset
+		out.CurrentTime = &tzResult.r.CurrentTime
+	}
+
+	if holResult.err != nil {
+		flags = append(flags, "calendar_unavailable")
+	} else {
+		todayStr := now.Format("2006-01-02")
+		for _, h := range holResult.r.Holidays {
+			if h.Date == todayStr {
+				out.IsHolidayToday = true
+				break
+			}
+		}
+		out.NextHoliday = findNext(holResult.r.Holidays, now)
+	}
+
+	out.WorkingDaysThisMonth = wdResult.n
+	out.Flags = flags
+	return out, nil
+}
+
+func findNext(all []holidays.Holiday, after time.Time) *NextHoliday {
+	cutoff := after.AddDate(0, 0, 90)
+	todayStr := after.Format("2006-01-02")
+	cutoffStr := cutoff.Format("2006-01-02")
+	for _, h := range all {
+		if h.Date >= todayStr && h.Date <= cutoffStr {
+			return &NextHoliday{Date: h.Date, Name: h.Name, Type: "national"}
+		}
+	}
+	return nil
+}
+
+type missingInputError struct{}
+
+func (e *missingInputError) Error() string { return "address or coordinates required" }

--- a/apps/api/services/systems/global_data/location_resolve/service.go
+++ b/apps/api/services/systems/global_data/location_resolve/service.go
@@ -84,8 +84,8 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		}
 		address = rev.Address
 		city = rev.City
-		country = rev.Country
-		countryCode = rev.Country // nominatim returns country_code in Country field (uppercase)
+		country = rev.CountryName
+		countryCode = rev.Country
 		if req.CountryCode != "" {
 			countryCode = req.CountryCode
 		}
@@ -98,7 +98,7 @@ func (s *Service) Resolve(ctx context.Context, req Request) (Result, error) {
 		lon = res.Lon
 		address = res.Address
 		city = res.City
-		country = res.Country
+		country = res.CountryName
 		countryCode = res.Country
 		if req.CountryCode != "" {
 			countryCode = req.CountryCode

--- a/apps/api/services/systems/global_data/location_resolve/transport_http.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http.go
@@ -27,6 +27,9 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 				if _, ok := err.(*missingInputError); ok {
 					return Result{}, svcerr.Unknown("validation_failed", err.Error())
 				}
+				if se, ok := err.(*svcerr.Error); ok {
+					return Result{}, se
+				}
 				return Result{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 			}
 

--- a/apps/api/services/systems/global_data/location_resolve/transport_http.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http.go
@@ -1,0 +1,29 @@
+package locationresolve
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
+)
+
+// RegisterRoutes mounts POST /location/resolve on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/location/resolve", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			if req.Address == "" && req.Coordinates == nil {
+				return Result{}, svcerr.Invalid("validation_failed", "address or coordinates is required")
+			}
+			res, err := svc.Resolve(ctx, req)
+			if err != nil {
+				if _, ok := err.(*missingInputError); ok {
+					return Result{}, svcerr.Invalid("validation_failed", err.Error())
+				}
+				return Result{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
+			}
+			return res, nil
+		},
+	))
+}

--- a/apps/api/services/systems/global_data/location_resolve/transport_http.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http.go
@@ -9,20 +9,23 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
-// RegisterRoutes mounts POST /location/resolve on the given router.
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/location/resolve", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
 			if req.Address == "" && req.Coordinates == nil {
 				return Result{}, svcerr.Invalid("validation_failed", "address or coordinates is required")
 			}
+
 			res, err := svc.Resolve(ctx, req)
+
 			if err != nil {
 				if _, ok := err.(*missingInputError); ok {
 					return Result{}, svcerr.Invalid("validation_failed", err.Error())
 				}
+
 				return Result{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 			}
+
 			return res, nil
 		},
 	))

--- a/apps/api/services/systems/global_data/location_resolve/transport_http.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http.go
@@ -9,6 +9,12 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
+type Request struct {
+	Address     string       `json:"address"`
+	Coordinates *Coordinates `json:"coordinates"`
+	CountryCode string       `json:"country_code"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/location/resolve", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
@@ -17,12 +23,10 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 			}
 
 			res, err := svc.Resolve(ctx, req)
-
 			if err != nil {
 				if _, ok := err.(*missingInputError); ok {
 					return Result{}, svcerr.Unknown("validation_failed", err.Error())
 				}
-
 				return Result{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")
 			}
 

--- a/apps/api/services/systems/global_data/location_resolve/transport_http.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http.go
@@ -13,14 +13,14 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/location/resolve", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
 			if req.Address == "" && req.Coordinates == nil {
-				return Result{}, svcerr.Invalid("validation_failed", "address or coordinates is required")
+				return Result{}, svcerr.Unknown("validation_failed", "address or coordinates is required")
 			}
 
 			res, err := svc.Resolve(ctx, req)
 
 			if err != nil {
 				if _, ok := err.(*missingInputError); ok {
-					return Result{}, svcerr.Invalid("validation_failed", err.Error())
+					return Result{}, svcerr.Unknown("validation_failed", err.Error())
 				}
 
 				return Result{}, svcerr.Upstream("upstream_error", "geocoding service unavailable")

--- a/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
@@ -20,8 +20,6 @@ import (
 	"requiems-api/services/places/timezone"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubGeocoder struct {
 	geocodeR   geocode.GeocodeResponse
 	geocodeErr error
@@ -57,8 +55,6 @@ type stubWorkingDays struct{ n int }
 
 func (s *stubWorkingDays) GetWorkingDays(_, _ time.Time, _, _ string) int { return s.n }
 
-// -- helpers -----------------------------------------------------------------
-
 func buildSvc(g *stubGeocoder, tz *stubTimezone, h *stubHolidays, w *stubWorkingDays) *Service {
 	return NewService(g, tz, h, w)
 }
@@ -79,8 +75,6 @@ func post(t *testing.T, r chi.Router, path string, body any) *httptest.ResponseR
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestLocationResolve_ByAddress(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
@@ -87,7 +87,7 @@ func TestLocationResolve_ByAddress(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{{Date: "2026-07-14", Name: "Bastille Day"}}}},
 		&stubWorkingDays{n: 21},
 	)
-	w := post(t, r,map[string]any{"address": "Paris, France"})
+	w := post(t, r, map[string]any{"address": "Paris, France"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -110,7 +110,7 @@ func TestLocationResolve_ByCoordinates(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
 		&stubWorkingDays{n: 20},
 	)
-	w := post(t, r,map[string]any{
+	w := post(t, r, map[string]any{
 		"coordinates": map[string]any{"lat": 40.71, "lng": -74.00},
 	})
 	require.Equal(t, http.StatusOK, w.Code)
@@ -130,7 +130,7 @@ func TestLocationResolve_MissingInput(t *testing.T) {
 		&stubHolidays{},
 		&stubWorkingDays{},
 	)
-	w := post(t, r,map[string]any{})
+	w := post(t, r, map[string]any{})
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
@@ -144,7 +144,7 @@ func TestLocationResolve_TimezoneUnavailable(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
 		&stubWorkingDays{n: 22},
 	)
-	w := post(t, r,map[string]any{"address": "Berlin, DE"})
+	w := post(t, r, map[string]any{"address": "Berlin, DE"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -163,7 +163,7 @@ func TestLocationResolve_CalendarUnavailable(t *testing.T) {
 		&stubHolidays{err: fmt.Errorf("holiday api down")},
 		&stubWorkingDays{n: 22},
 	)
-	w := post(t, r,map[string]any{"address": "Berlin, DE"})
+	w := post(t, r, map[string]any{"address": "Berlin, DE"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -179,6 +179,6 @@ func TestLocationResolve_GeocodeFail(t *testing.T) {
 		&stubHolidays{},
 		&stubWorkingDays{},
 	)
-	w := post(t, r,map[string]any{"address": "nowhere xyz"})
+	w := post(t, r, map[string]any{"address": "nowhere xyz"})
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }

--- a/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
@@ -1,0 +1,190 @@
+package locationresolve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/places/geocode"
+	"requiems-api/services/places/holidays"
+	"requiems-api/services/places/timezone"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubGeocoder struct {
+	geocodeR   geocode.GeocodeResponse
+	geocodeErr error
+	revR       geocode.ReverseGeocodeResponse
+	revErr     error
+}
+
+func (s *stubGeocoder) Geocode(_ context.Context, _ string) (geocode.GeocodeResponse, error) {
+	return s.geocodeR, s.geocodeErr
+}
+
+func (s *stubGeocoder) ReverseGeocode(_ context.Context, _, _ float64) (geocode.ReverseGeocodeResponse, error) {
+	return s.revR, s.revErr
+}
+
+type stubTimezone struct {
+	r   *timezone.Info
+	err error
+}
+
+func (s *stubTimezone) GetTimezoneByCoords(_, _ float64) (*timezone.Info, error) { return s.r, s.err }
+
+type stubHolidays struct {
+	r   holidays.HolidayList
+	err error
+}
+
+func (s *stubHolidays) GetHolidays(_ string, _ int) (holidays.HolidayList, error) {
+	return s.r, s.err
+}
+
+type stubWorkingDays struct{ n int }
+
+func (s *stubWorkingDays) GetWorkingDays(_, _ time.Time, _, _ string) int { return s.n }
+
+// -- helpers -----------------------------------------------------------------
+
+func buildSvc(g *stubGeocoder, tz *stubTimezone, h *stubHolidays, w *stubWorkingDays) *Service {
+	return NewService(g, tz, h, w)
+}
+
+func setupLocationRouter(g *stubGeocoder, tz *stubTimezone, h *stubHolidays, w *stubWorkingDays) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, buildSvc(g, tz, h, w))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestLocationResolve_ByAddress(t *testing.T) {
+	t.Parallel()
+	tzInfo := &timezone.Info{Timezone: "Europe/Paris", Offset: "+02:00", CurrentTime: "2026-05-26T12:00:00Z"}
+	r := setupLocationRouter(
+		&stubGeocoder{geocodeR: geocode.GeocodeResponse{
+			Address: "Paris, France", City: "Paris", Country: "FR", Lat: 48.85, Lon: 2.35,
+		}},
+		&stubTimezone{r: tzInfo},
+		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{{Date: "2026-07-14", Name: "Bastille Day"}}}},
+		&stubWorkingDays{n: 21},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{"address": "Paris, France"})
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "Paris, France", resp.Data.Address)
+	assert.Equal(t, "Paris", resp.Data.City)
+	require.NotNil(t, resp.Data.Timezone)
+	assert.Equal(t, "Europe/Paris", *resp.Data.Timezone)
+	assert.Equal(t, 21, resp.Data.WorkingDaysThisMonth)
+	assert.Empty(t, resp.Data.Flags)
+}
+
+func TestLocationResolve_ByCoordinates(t *testing.T) {
+	t.Parallel()
+	tzInfo := &timezone.Info{Timezone: "America/New_York", Offset: "-04:00", CurrentTime: "2026-05-26T08:00:00Z"}
+	r := setupLocationRouter(
+		&stubGeocoder{revR: geocode.ReverseGeocodeResponse{
+			Address: "New York, US", City: "New York", Country: "US", Lat: 40.71, Lon: -74.00,
+		}},
+		&stubTimezone{r: tzInfo},
+		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
+		&stubWorkingDays{n: 20},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{
+		"coordinates": map[string]any{"lat": 40.71, "lng": -74.00},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "New York, US", resp.Data.Address)
+	require.NotNil(t, resp.Data.Timezone)
+	assert.Equal(t, "America/New_York", *resp.Data.Timezone)
+	assert.Empty(t, resp.Data.Flags)
+}
+
+func TestLocationResolve_MissingInput(t *testing.T) {
+	t.Parallel()
+	r := setupLocationRouter(
+		&stubGeocoder{},
+		&stubTimezone{},
+		&stubHolidays{},
+		&stubWorkingDays{},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{})
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestLocationResolve_TimezoneUnavailable(t *testing.T) {
+	t.Parallel()
+	r := setupLocationRouter(
+		&stubGeocoder{geocodeR: geocode.GeocodeResponse{
+			Address: "Berlin, DE", City: "Berlin", Country: "DE", Lat: 52.52, Lon: 13.40,
+		}},
+		&stubTimezone{err: fmt.Errorf("tz db unavailable")},
+		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
+		&stubWorkingDays{n: 22},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{"address": "Berlin, DE"})
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.Timezone)
+	assert.Contains(t, resp.Data.Flags, "timezone_unavailable")
+}
+
+func TestLocationResolve_CalendarUnavailable(t *testing.T) {
+	t.Parallel()
+	tzInfo := &timezone.Info{Timezone: "Europe/Berlin", Offset: "+02:00", CurrentTime: "2026-05-26T12:00:00Z"}
+	r := setupLocationRouter(
+		&stubGeocoder{geocodeR: geocode.GeocodeResponse{
+			Address: "Berlin, DE", City: "Berlin", Country: "DE", Lat: 52.52, Lon: 13.40,
+		}},
+		&stubTimezone{r: tzInfo},
+		&stubHolidays{err: fmt.Errorf("holiday api down")},
+		&stubWorkingDays{n: 22},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{"address": "Berlin, DE"})
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.NextHoliday)
+	assert.Contains(t, resp.Data.Flags, "calendar_unavailable")
+}
+
+func TestLocationResolve_GeocodeFail(t *testing.T) {
+	t.Parallel()
+	r := setupLocationRouter(
+		&stubGeocoder{geocodeErr: fmt.Errorf("not found")},
+		&stubTimezone{},
+		&stubHolidays{},
+		&stubWorkingDays{},
+	)
+	w := post(t, r, "/location/resolve", map[string]any{"address": "nowhere xyz"})
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}

--- a/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
+++ b/apps/api/services/systems/global_data/location_resolve/transport_http_test.go
@@ -65,11 +65,11 @@ func setupLocationRouter(g *stubGeocoder, tz *stubTimezone, h *stubHolidays, w *
 	return r
 }
 
-func post(t *testing.T, r chi.Router, path string, body any) *httptest.ResponseRecorder {
+func post(t *testing.T, r chi.Router, body any) *httptest.ResponseRecorder {
 	t.Helper()
 	b, err := json.Marshal(body)
 	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/location/resolve", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -87,7 +87,7 @@ func TestLocationResolve_ByAddress(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{{Date: "2026-07-14", Name: "Bastille Day"}}}},
 		&stubWorkingDays{n: 21},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{"address": "Paris, France"})
+	w := post(t, r,map[string]any{"address": "Paris, France"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -110,7 +110,7 @@ func TestLocationResolve_ByCoordinates(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
 		&stubWorkingDays{n: 20},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{
+	w := post(t, r,map[string]any{
 		"coordinates": map[string]any{"lat": 40.71, "lng": -74.00},
 	})
 	require.Equal(t, http.StatusOK, w.Code)
@@ -130,7 +130,7 @@ func TestLocationResolve_MissingInput(t *testing.T) {
 		&stubHolidays{},
 		&stubWorkingDays{},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{})
+	w := post(t, r,map[string]any{})
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
@@ -144,7 +144,7 @@ func TestLocationResolve_TimezoneUnavailable(t *testing.T) {
 		&stubHolidays{r: holidays.HolidayList{Holidays: []holidays.Holiday{}}},
 		&stubWorkingDays{n: 22},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{"address": "Berlin, DE"})
+	w := post(t, r,map[string]any{"address": "Berlin, DE"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -163,7 +163,7 @@ func TestLocationResolve_CalendarUnavailable(t *testing.T) {
 		&stubHolidays{err: fmt.Errorf("holiday api down")},
 		&stubWorkingDays{n: 22},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{"address": "Berlin, DE"})
+	w := post(t, r,map[string]any{"address": "Berlin, DE"})
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -179,6 +179,6 @@ func TestLocationResolve_GeocodeFail(t *testing.T) {
 		&stubHolidays{},
 		&stubWorkingDays{},
 	)
-	w := post(t, r, "/location/resolve", map[string]any{"address": "nowhere xyz"})
+	w := post(t, r,map[string]any{"address": "nowhere xyz"})
 	assert.NotEqual(t, http.StatusOK, w.Code)
 }

--- a/apps/api/services/systems/global_data/router.go
+++ b/apps/api/services/systems/global_data/router.go
@@ -41,11 +41,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	calSvc := businesscalendar.NewService(holidaysSvc, workingDaysSvc)
 	businesscalendar.RegisterRoutes(r, calSvc)
 
-	infoSvc := ipinfo.NewService(deps.IPIClient)
-	tzIPSvc := timezoneip.NewService(infoSvc, timezoneSvc)
-	timezoneip.RegisterRoutes(r, tzIPSvc)
+	if deps.IPIClient != nil && timezoneSvc != nil {
+		infoSvc := ipinfo.NewService(deps.IPIClient)
+		tzIPSvc := timezoneip.NewService(infoSvc, timezoneSvc)
+		timezoneip.RegisterRoutes(r, tzIPSvc)
+	}
 
 	geocodeSvc := geocode.NewService(deps.Cfg.NominatimURL, &http.Client{Timeout: 10 * time.Second}, deps.RDB)
-	locSvc := locationresolve.NewService(geocodeSvc, timezoneSvc, holidaysSvc, workingDaysSvc)
-	locationresolve.RegisterRoutes(r, locSvc)
+	if timezoneSvc != nil {
+		locSvc := locationresolve.NewService(geocodeSvc, timezoneSvc, holidaysSvc, workingDaysSvc)
+		locationresolve.RegisterRoutes(r, locSvc)
+	}
 }

--- a/apps/api/services/systems/global_data/router.go
+++ b/apps/api/services/systems/global_data/router.go
@@ -1,0 +1,51 @@
+package globaldata
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/redis/go-redis/v9"
+
+	"requiems-api/platform/config"
+	ipinfo "requiems-api/services/networking/ip/info"
+	"requiems-api/services/places/geocode"
+	"requiems-api/services/places/holidays"
+	"requiems-api/services/places/timezone"
+	workingdays "requiems-api/services/places/working-days"
+	businesscalendar "requiems-api/services/systems/global_data/business_calendar"
+	locationresolve "requiems-api/services/systems/global_data/location_resolve"
+	timezoneip "requiems-api/services/systems/global_data/timezone_ip"
+
+	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
+)
+
+// Deps holds the external clients needed by the Global Data system.
+type Deps struct {
+	IPIClient *ipi.Client
+	Cfg       config.Config
+	RDB       *redis.Client
+}
+
+// RegisterRoutes mounts all Global Data system endpoints on r.
+func RegisterRoutes(r chi.Router, deps Deps) {
+	timezoneSvc, err := timezone.NewService()
+	if err != nil {
+		log.Printf("global_data: failed to initialize timezone service: %v", err)
+	}
+
+	holidaysSvc := holidays.NewService()
+	workingDaysSvc := workingdays.NewService()
+
+	calSvc := businesscalendar.NewService(holidaysSvc, workingDaysSvc)
+	businesscalendar.RegisterRoutes(r, calSvc)
+
+	infoSvc := ipinfo.NewService(deps.IPIClient)
+	tzIPSvc := timezoneip.NewService(infoSvc, timezoneSvc)
+	timezoneip.RegisterRoutes(r, tzIPSvc)
+
+	geocodeSvc := geocode.NewService(deps.Cfg.NominatimURL, &http.Client{Timeout: 10 * time.Second}, deps.RDB)
+	locSvc := locationresolve.NewService(geocodeSvc, timezoneSvc, holidaysSvc, workingDaysSvc)
+	locationresolve.RegisterRoutes(r, locSvc)
+}

--- a/apps/api/services/systems/global_data/timezone_ip/service.go
+++ b/apps/api/services/systems/global_data/timezone_ip/service.go
@@ -8,8 +8,6 @@ import (
 	"requiems-api/services/places/timezone"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type IPInfoChecker interface {
 	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
 }
@@ -19,20 +17,15 @@ type TimezoneGetter interface {
 	GetTimezoneByCity(city string) (*timezone.Info, error)
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service resolves timezone from an IP address.
 type Service struct {
 	ipInfo   IPInfoChecker
 	timezone TimezoneGetter
 }
 
-// NewService returns a new timezone-from-IP Service.
 func NewService(i IPInfoChecker, t TimezoneGetter) *Service {
 	return &Service{ipInfo: i, timezone: t}
 }
 
-// Result is the response for GET /timezone/from-ip/{ip}.
 type Result struct {
 	IP          string  `json:"ip"`
 	City        string  `json:"city"`
@@ -43,8 +36,6 @@ type Result struct {
 	CurrentTime *string `json:"current_time"`
 }
 
-// Resolve looks up the timezone for the given IP.
-// If IP is empty, callerIP is used (caller IP fallback).
 func (s *Service) Resolve(ctx context.Context, ip string) (Result, error) {
 	info, err := s.ipInfo.CheckInfo(ctx, ip)
 	if err != nil {
@@ -59,10 +50,7 @@ func (s *Service) Resolve(ctx context.Context, ip string) (Result, error) {
 
 	tzInfo, err := s.timezone.GetTimezoneByCity(info.City)
 	if err != nil {
-		// Timezone resolution failed — return response with timezone: null.
-		flag := "timezone_unavailable"
-		res.Timezone = nil
-		_ = flag
+		// timezone unavailable — return 200 with timezone: null
 		return res, nil
 	}
 

--- a/apps/api/services/systems/global_data/timezone_ip/service.go
+++ b/apps/api/services/systems/global_data/timezone_ip/service.go
@@ -1,0 +1,75 @@
+package timezoneip
+
+import (
+	"context"
+	"fmt"
+
+	ipinfo "requiems-api/services/networking/ip/info"
+	"requiems-api/services/places/timezone"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type IPInfoChecker interface {
+	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
+}
+
+type TimezoneGetter interface {
+	GetTimezoneByCoords(lat, lon float64) (*timezone.Info, error)
+	GetTimezoneByCity(city string) (*timezone.Info, error)
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service resolves timezone from an IP address.
+type Service struct {
+	ipInfo   IPInfoChecker
+	timezone TimezoneGetter
+}
+
+// NewService returns a new timezone-from-IP Service.
+func NewService(i IPInfoChecker, t TimezoneGetter) *Service {
+	return &Service{ipInfo: i, timezone: t}
+}
+
+// Result is the response for GET /timezone/from-ip/{ip}.
+type Result struct {
+	IP          string  `json:"ip"`
+	City        string  `json:"city"`
+	CountryCode string  `json:"country_code"`
+	Timezone    *string `json:"timezone"`
+	UTCOffset   *string `json:"utc_offset"`
+	DSTActive   *bool   `json:"dst_active"`
+	CurrentTime *string `json:"current_time"`
+}
+
+// Resolve looks up the timezone for the given IP.
+// If IP is empty, callerIP is used (caller IP fallback).
+func (s *Service) Resolve(ctx context.Context, ip string) (Result, error) {
+	info, err := s.ipInfo.CheckInfo(ctx, ip)
+	if err != nil {
+		return Result{}, fmt.Errorf("ip_not_found")
+	}
+
+	res := Result{
+		IP:          ip,
+		City:        info.City,
+		CountryCode: info.CountryCode,
+	}
+
+	tzInfo, err := s.timezone.GetTimezoneByCity(info.City)
+	if err != nil {
+		// Timezone resolution failed — return response with timezone: null.
+		flag := "timezone_unavailable"
+		res.Timezone = nil
+		_ = flag
+		return res, nil
+	}
+
+	res.Timezone = &tzInfo.Timezone
+	res.UTCOffset = &tzInfo.Offset
+	res.CurrentTime = &tzInfo.CurrentTime
+	dst := tzInfo.IsDST
+	res.DSTActive = &dst
+	return res, nil
+}

--- a/apps/api/services/systems/global_data/timezone_ip/transport_http.go
+++ b/apps/api/services/systems/global_data/timezone_ip/transport_http.go
@@ -1,6 +1,7 @@
 package timezoneip
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -14,11 +15,12 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Get("/timezone/from-ip/{ip}", func(w http.ResponseWriter, r *http.Request) {
 		ip := chi.URLParam(r, "ip")
 		if ip == "" || ip == "me" {
-			// Fall back to caller IP.
-			ip = r.Header.Get("X-Forwarded-For")
-			if ip == "" {
-				ip = strings.Split(r.RemoteAddr, ":")[0]
-			}
+			ip = callerIP(r)
+		}
+
+		if net.ParseIP(ip) == nil {
+			httpx.Error(w, http.StatusBadRequest, "bad_request", "invalid IP address")
+			return
 		}
 
 		res, err := svc.Resolve(r.Context(), ip)
@@ -28,4 +30,23 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 		}
 		httpx.JSON(w, http.StatusOK, res)
 	})
+}
+
+// callerIP extracts the real client IP from the request, checking
+// X-Forwarded-For, X-Real-IP, and RemoteAddr in that order.
+func callerIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if before, _, ok := strings.Cut(xff, ","); ok {
+			return strings.TrimSpace(before)
+		}
+		return strings.TrimSpace(xff)
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	addr := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }

--- a/apps/api/services/systems/global_data/timezone_ip/transport_http.go
+++ b/apps/api/services/systems/global_data/timezone_ip/transport_http.go
@@ -1,0 +1,31 @@
+package timezoneip
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts GET /timezone/from-ip/{ip} on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Get("/timezone/from-ip/{ip}", func(w http.ResponseWriter, r *http.Request) {
+		ip := chi.URLParam(r, "ip")
+		if ip == "" || ip == "me" {
+			// Fall back to caller IP.
+			ip = r.Header.Get("X-Forwarded-For")
+			if ip == "" {
+				ip = strings.Split(r.RemoteAddr, ":")[0]
+			}
+		}
+
+		res, err := svc.Resolve(r.Context(), ip)
+		if err != nil {
+			httpx.Error(w, http.StatusNotFound, "ip_not_found", "IP address not found in geolocation database")
+			return
+		}
+		httpx.JSON(w, http.StatusOK, res)
+	})
+}

--- a/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
+++ b/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
@@ -1,0 +1,100 @@
+package timezoneip
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	ipinfo "requiems-api/services/networking/ip/info"
+	"requiems-api/services/places/timezone"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubIPInfo struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupResponse, error) {
+	return s.r, s.err
+}
+
+type stubTimezone struct {
+	r   *timezone.Info
+	err error
+}
+
+func (s *stubTimezone) GetTimezoneByCoords(_, _ float64) (*timezone.Info, error) { return s.r, s.err }
+func (s *stubTimezone) GetTimezoneByCity(_ string) (*timezone.Info, error)       { return s.r, s.err }
+
+// -- helpers -----------------------------------------------------------------
+
+func setupRouter(i *stubIPInfo, t *stubTimezone) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(i, t))
+	return r
+}
+
+func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestTimezoneIP_ValidPublicIP(t *testing.T) {
+	t.Parallel()
+	tzInfo := &timezone.Info{
+		Timezone:    "Europe/Berlin",
+		Offset:      "+02:00",
+		CurrentTime: "2026-05-25T19:00:00Z",
+		IsDST:       true,
+	}
+	r := setupRouter(
+		&stubIPInfo{r: ipinfo.LookupResponse{IP: "203.0.113.42", City: "Berlin", CountryCode: "DE"}},
+		&stubTimezone{r: tzInfo},
+	)
+	w := get(t, r, "/timezone/from-ip/203.0.113.42")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.NotNil(t, resp.Data.Timezone)
+	assert.Equal(t, "Europe/Berlin", *resp.Data.Timezone)
+	assert.Equal(t, "DE", resp.Data.CountryCode)
+	require.NotNil(t, resp.Data.CurrentTime)
+}
+
+func TestTimezoneIP_UnknownIP(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubIPInfo{err: fmt.Errorf("not found")},
+		&stubTimezone{},
+	)
+	w := get(t, r, "/timezone/from-ip/192.0.2.1")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestTimezoneIP_IPFoundTimezoneFailure(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubIPInfo{r: ipinfo.LookupResponse{City: "Nowhere", CountryCode: "ZZ"}},
+		&stubTimezone{err: fmt.Errorf("unknown city")},
+	)
+	w := get(t, r, "/timezone/from-ip/1.2.3.4")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.Timezone)
+}

--- a/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
+++ b/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
@@ -17,8 +17,6 @@ import (
 	"requiems-api/services/places/timezone"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubIPInfo struct {
 	r   ipinfo.LookupResponse
 	err error
@@ -36,8 +34,6 @@ type stubTimezone struct {
 func (s *stubTimezone) GetTimezoneByCoords(_, _ float64) (*timezone.Info, error) { return s.r, s.err }
 func (s *stubTimezone) GetTimezoneByCity(_ string) (*timezone.Info, error)       { return s.r, s.err }
 
-// -- helpers -----------------------------------------------------------------
-
 func setupRouter(i *stubIPInfo, t *stubTimezone) chi.Router {
 	r := chi.NewRouter()
 	RegisterRoutes(r, NewService(i, t))
@@ -51,8 +47,6 @@ func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestTimezoneIP_ValidPublicIP(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
+++ b/apps/api/services/systems/global_data/timezone_ip/transport_http_test.go
@@ -42,7 +42,7 @@ func setupRouter(i *stubIPInfo, t *stubTimezone) chi.Router {
 
 func get(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -247,7 +247,7 @@ func Compute(s Signals) ScoreResult {
 	}
 	confidence := math.Round(float64(present)/float64(totalSignals)*100) / 100
 
-	isSafe := score < 0.5 && confidence > 0.6
+	isSafe := score < 0.5 && confidence > 0.6 && !s.IsTOR && !s.IsProxy
 
 	return ScoreResult{
 		RiskScore:  score,

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -1,6 +1,3 @@
-// Package scorer contains the shared risk-signal resolution and risk-score
-// computation used by both risk_score and signup_protect. Keeping the weight
-// table and fan-out logic here prevents drift between the two endpoints.
 package scorer
 
 import (
@@ -15,33 +12,22 @@ import (
 	"requiems-api/services/validation/phone"
 )
 
-// -- Dependency interfaces --------------------------------------------------
-
-// EmailChecker validates an email address.
 type EmailChecker interface {
 	ValidateEmail(ctx context.Context, addr string) email.Validation
 }
 
-// PhoneChecker validates a phone number.
 type PhoneChecker interface {
 	Validate(number string) phone.ValidateResponse
 }
 
-// VPNChecker checks an IP for VPN/proxy/TOR signals.
 type VPNChecker interface {
 	CheckIP(ctx context.Context, ip net.IP) (ipvpn.IPCheckResponse, error)
 }
 
-// IPInfoChecker looks up geolocation for an IP address.
 type IPInfoChecker interface {
 	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
 }
 
-// -- Resolution ---------------------------------------------------------------
-
-// Resolved holds the raw service results plus the derived Signals used for
-// scoring. signup_protect uses the raw fields for its signal breakdown;
-// risk_score only uses Signals.
 type Resolved struct {
 	Signals Signals
 
@@ -51,9 +37,6 @@ type Resolved struct {
 	IPResult    *ipinfo.LookupResponse
 }
 
-// Resolve fans out to whichever services correspond to the non-empty fields and
-// returns a Resolved bundle. An empty string for a field means "not provided".
-// Service errors are treated as "no signal" to keep the endpoint non-blocking.
 func Resolve(
 	ctx context.Context,
 	emailSvc EmailChecker,
@@ -140,9 +123,6 @@ func Resolve(
 	return out
 }
 
-// -- Scoring ------------------------------------------------------------------
-
-// Signals is the normalised boolean/numeric set fed into Compute.
 type Signals struct {
 	EmailPresent    bool
 	EmailDisposable bool
@@ -160,11 +140,10 @@ type Signals struct {
 	IsProxy    bool
 	IsVPN      bool
 	IsHosting  bool
-	FraudScore int // 0–100; Compute normalises to 0–1
+	FraudScore int
 	IPCountry  string
 }
 
-// ScoreResult is the computed output.
 type ScoreResult struct {
 	RiskScore  float64
 	Confidence float64
@@ -172,10 +151,8 @@ type ScoreResult struct {
 	Flags      []string
 }
 
-const totalSignals = 3 // email, phone, ip
+const totalSignals = 3
 
-// Compute calculates the risk score, confidence, and derived is_safe from the
-// provided signals. All weights are additive and capped at 1.0.
 func Compute(s Signals) ScoreResult {
 	score := 0.0
 	flags := make([]string, 0, 4)

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -1,0 +1,258 @@
+// Package scorer contains the shared risk-signal resolution and risk-score
+// computation used by both risk_score and signup_protect. Keeping the weight
+// table and fan-out logic here prevents drift between the two endpoints.
+package scorer
+
+import (
+	"context"
+	"math"
+	"net"
+	"sync"
+
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+)
+
+// -- Dependency interfaces --------------------------------------------------
+
+// EmailChecker validates an email address.
+type EmailChecker interface {
+	ValidateEmail(ctx context.Context, addr string) email.Validation
+}
+
+// PhoneChecker validates a phone number.
+type PhoneChecker interface {
+	Validate(number string) phone.ValidateResponse
+}
+
+// VPNChecker checks an IP for VPN/proxy/TOR signals.
+type VPNChecker interface {
+	CheckIP(ctx context.Context, ip net.IP) (ipvpn.IPCheckResponse, error)
+}
+
+// IPInfoChecker looks up geolocation for an IP address.
+type IPInfoChecker interface {
+	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
+}
+
+// -- Resolution ---------------------------------------------------------------
+
+// Resolved holds the raw service results plus the derived Signals used for
+// scoring. signup_protect uses the raw fields for its signal breakdown;
+// risk_score only uses Signals.
+type Resolved struct {
+	Signals Signals
+
+	EmailResult *email.Validation
+	PhoneResult *phone.ValidateResponse
+	VPNResult   *ipvpn.IPCheckResponse
+	IPResult    *ipinfo.LookupResponse
+}
+
+// Resolve fans out to whichever services correspond to the non-empty fields and
+// returns a Resolved bundle. An empty string for a field means "not provided".
+// Service errors are treated as "no signal" to keep the endpoint non-blocking.
+func Resolve(
+	ctx context.Context,
+	emailSvc EmailChecker,
+	phoneSvc PhoneChecker,
+	vpnSvc VPNChecker,
+	ipInfoSvc IPInfoChecker,
+	emailAddr, phoneNum, ipAddr string,
+) Resolved {
+	var (
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		out Resolved
+	)
+
+	if emailAddr != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := emailSvc.ValidateEmail(ctx, emailAddr)
+			mu.Lock()
+			out.EmailResult = &r
+			out.Signals.EmailPresent = true
+			out.Signals.EmailDisposable = r.Disposable
+			out.Signals.EmailInvalid = !r.Valid
+			out.Signals.EmailNoMX = !r.MxValid
+			mu.Unlock()
+		}()
+	}
+
+	if phoneNum != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := phoneSvc.Validate(phoneNum)
+			mu.Lock()
+			out.PhoneResult = &r
+			out.Signals.PhonePresent = true
+			out.Signals.PhoneInvalid = !r.Valid
+			if r.Risk != nil {
+				out.Signals.PhoneVoIP = r.Risk.IsVoIP
+				out.Signals.PhoneVirtual = r.Risk.IsVirtual
+			}
+			out.Signals.PhoneCountry = r.Country
+			mu.Unlock()
+		}()
+	}
+
+	parsedIP := net.ParseIP(ipAddr)
+	if ipAddr != "" && parsedIP != nil {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			r, err := vpnSvc.CheckIP(ctx, parsedIP)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			out.VPNResult = &r
+			out.Signals.IPPresent = true
+			out.Signals.IsTOR = r.IsTor
+			out.Signals.IsProxy = r.IsProxy
+			out.Signals.IsVPN = r.IsVPN
+			out.Signals.IsHosting = r.IsHosting
+			out.Signals.FraudScore = r.FraudScore
+			mu.Unlock()
+		}()
+
+		go func() {
+			defer wg.Done()
+			r, err := ipInfoSvc.CheckInfo(ctx, ipAddr)
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			out.IPResult = &r
+			out.Signals.IPCountry = r.CountryCode
+			out.Signals.IPPresent = true
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	return out
+}
+
+// -- Scoring ------------------------------------------------------------------
+
+// Signals is the normalised boolean/numeric set fed into Compute.
+type Signals struct {
+	EmailPresent    bool
+	EmailDisposable bool
+	EmailInvalid    bool
+	EmailNoMX       bool
+
+	PhonePresent bool
+	PhoneInvalid bool
+	PhoneVoIP    bool
+	PhoneVirtual bool
+	PhoneCountry string
+
+	IPPresent  bool
+	IsTOR      bool
+	IsProxy    bool
+	IsVPN      bool
+	IsHosting  bool
+	FraudScore int // 0–100; Compute normalises to 0–1
+	IPCountry  string
+}
+
+// ScoreResult is the computed output.
+type ScoreResult struct {
+	RiskScore  float64
+	Confidence float64
+	IsSafe     bool
+	Flags      []string
+}
+
+const totalSignals = 3 // email, phone, ip
+
+// Compute calculates the risk score, confidence, and derived is_safe from the
+// provided signals. All weights are additive and capped at 1.0.
+func Compute(s Signals) ScoreResult {
+	score := 0.0
+	flags := make([]string, 0, 4)
+
+	if s.EmailPresent {
+		if s.EmailInvalid {
+			score += 0.40
+			flags = append(flags, "email_invalid")
+		}
+		if s.EmailNoMX {
+			score += 0.25
+			flags = append(flags, "email_no_mx")
+		}
+		if s.EmailDisposable {
+			score += 0.30
+			flags = append(flags, "disposable_email")
+		}
+	}
+
+	if s.PhonePresent {
+		if s.PhoneInvalid {
+			score += 0.25
+			flags = append(flags, "phone_invalid")
+		} else if s.PhoneVoIP {
+			score += 0.15
+			flags = append(flags, "phone_voip")
+		} else if s.PhoneVirtual {
+			score += 0.15
+			flags = append(flags, "phone_virtual")
+		}
+		if s.IPPresent && s.PhoneCountry != "" && s.IPCountry != "" && s.PhoneCountry != s.IPCountry {
+			score += 0.10
+			flags = append(flags, "geo_mismatch_phone_ip")
+		}
+	}
+
+	if s.IPPresent {
+		if s.IsTOR {
+			score += 0.40
+			flags = append(flags, "tor_detected")
+		}
+		if s.IsProxy {
+			score += 0.25
+			flags = append(flags, "proxy_detected")
+		}
+		if s.IsVPN {
+			score += 0.20
+			flags = append(flags, "vpn_detected")
+		}
+		if s.IsHosting {
+			score += 0.10
+			flags = append(flags, "hosting_ip")
+		}
+		score += float64(s.FraudScore) / 100.0 * 0.30
+	}
+
+	score = math.Min(score, 1.0)
+	score = math.Round(score*100) / 100
+
+	present := 0
+	if s.EmailPresent {
+		present++
+	}
+	if s.PhonePresent {
+		present++
+	}
+	if s.IPPresent {
+		present++
+	}
+	confidence := math.Round(float64(present)/float64(totalSignals)*100) / 100
+
+	isSafe := score < 0.5 && confidence > 0.6
+
+	return ScoreResult{
+		RiskScore:  score,
+		Confidence: confidence,
+		IsSafe:     isSafe,
+		Flags:      flags,
+	}
+}

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -82,37 +82,36 @@ func Resolve(
 
 	parsedIP := net.ParseIP(ipAddr)
 	if ipAddr != "" && parsedIP != nil {
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			r, err := vpnSvc.CheckIP(ctx, parsedIP)
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			out.VPNResult = &r
-			out.Signals.IPPresent = true
-			out.Signals.IsTOR = r.IsTor
-			out.Signals.IsProxy = r.IsProxy
-			out.Signals.IsVPN = r.IsVPN
-			out.Signals.IsHosting = r.IsHosting
-			out.Signals.FraudScore = r.FraudScore
-			mu.Unlock()
-		}()
-
-		go func() {
-			defer wg.Done()
-			r, err := ipInfoSvc.CheckInfo(ctx, ipAddr)
-			if err != nil {
-				return
-			}
-			mu.Lock()
-			out.IPResult = &r
-			out.Signals.IPCountry = r.CountryCode
-			out.Signals.IPPresent = true
-			mu.Unlock()
-		}()
+		if vpnSvc != nil {
+			wg.Go(func() {
+				r, err := vpnSvc.CheckIP(ctx, parsedIP)
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				out.VPNResult = &r
+				out.Signals.IPPresent = true
+				out.Signals.IsTOR = r.IsTor
+				out.Signals.IsProxy = r.IsProxy
+				out.Signals.IsVPN = r.IsVPN
+				out.Signals.IsHosting = r.IsHosting
+				out.Signals.FraudScore = r.FraudScore
+				mu.Unlock()
+			})
+		}
+		if ipInfoSvc != nil {
+			wg.Go(func() {
+				r, err := ipInfoSvc.CheckInfo(ctx, ipAddr)
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				out.IPResult = &r
+				out.Signals.IPCountry = r.CountryCode
+				out.Signals.IPPresent = true
+				mu.Unlock()
+			})
+		}
 	}
 
 	wg.Wait()

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -52,9 +52,7 @@ func Resolve(
 	)
 
 	if emailAddr != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r := emailSvc.ValidateEmail(ctx, emailAddr)
 			mu.Lock()
 			out.EmailResult = &r
@@ -63,13 +61,11 @@ func Resolve(
 			out.Signals.EmailInvalid = !r.Valid
 			out.Signals.EmailNoMX = !r.MxValid
 			mu.Unlock()
-		}()
+		})
 	}
 
 	if phoneNum != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r := phoneSvc.Validate(phoneNum)
 			mu.Lock()
 			out.PhoneResult = &r
@@ -81,7 +77,7 @@ func Resolve(
 			}
 			out.Signals.PhoneCountry = r.Country
 			mu.Unlock()
-		}()
+		})
 	}
 
 	parsedIP := net.ParseIP(ipAddr)

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -169,13 +169,14 @@ func Compute(s Signals) ScoreResult {
 	}
 
 	if s.PhonePresent {
-		if s.PhoneInvalid {
+		switch {
+		case s.PhoneInvalid:
 			score += 0.25
 			flags = append(flags, "phone_invalid")
-		} else if s.PhoneVoIP {
+		case s.PhoneVoIP:
 			score += 0.15
 			flags = append(flags, "phone_voip")
-		} else if s.PhoneVirtual {
+		case s.PhoneVirtual:
 			score += 0.15
 			flags = append(flags, "phone_virtual")
 		}

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -149,65 +149,94 @@ type ScoreResult struct {
 const totalSignals = 3
 
 func Compute(s Signals) ScoreResult {
-	score := 0.0
 	flags := make([]string, 0, 4)
+	score := scoreEmail(s, &flags) + scorePhone(s, &flags) + scoreIP(s, &flags)
+	score = roundScore(score)
 
+	confidence := signalConfidence(s)
+	isSafe := score < 0.5 && confidence > 0.6 && !s.IsTOR && !s.IsProxy
+
+	return ScoreResult{
+		RiskScore:  score,
+		Confidence: confidence,
+		IsSafe:     isSafe,
+		Flags:      flags,
+	}
+}
+
+func scoreEmail(s Signals, flags *[]string) float64 {
 	if s.EmailPresent {
+		score := 0.0
 		if s.EmailInvalid {
 			score += 0.40
-			flags = append(flags, "email_invalid")
+			*flags = append(*flags, "email_invalid")
 		}
 		if s.EmailNoMX {
 			score += 0.25
-			flags = append(flags, "email_no_mx")
+			*flags = append(*flags, "email_no_mx")
 		}
 		if s.EmailDisposable {
 			score += 0.30
-			flags = append(flags, "disposable_email")
+			*flags = append(*flags, "disposable_email")
 		}
+		return score
 	}
+	return 0
+}
 
+func scorePhone(s Signals, flags *[]string) float64 {
 	if s.PhonePresent {
+		score := 0.0
 		switch {
 		case s.PhoneInvalid:
 			score += 0.25
-			flags = append(flags, "phone_invalid")
+			*flags = append(*flags, "phone_invalid")
 		case s.PhoneVoIP:
 			score += 0.15
-			flags = append(flags, "phone_voip")
+			*flags = append(*flags, "phone_voip")
 		case s.PhoneVirtual:
 			score += 0.15
-			flags = append(flags, "phone_virtual")
+			*flags = append(*flags, "phone_virtual")
 		}
 		if s.IPPresent && s.PhoneCountry != "" && s.IPCountry != "" && s.PhoneCountry != s.IPCountry {
 			score += 0.10
-			flags = append(flags, "geo_mismatch_phone_ip")
+			*flags = append(*flags, "geo_mismatch_phone_ip")
 		}
+		return score
 	}
+	return 0
+}
 
+func scoreIP(s Signals, flags *[]string) float64 {
 	if s.IPPresent {
+		score := 0.0
 		if s.IsTOR {
 			score += 0.40
-			flags = append(flags, "tor_detected")
+			*flags = append(*flags, "tor_detected")
 		}
 		if s.IsProxy {
 			score += 0.25
-			flags = append(flags, "proxy_detected")
+			*flags = append(*flags, "proxy_detected")
 		}
 		if s.IsVPN {
 			score += 0.20
-			flags = append(flags, "vpn_detected")
+			*flags = append(*flags, "vpn_detected")
 		}
 		if s.IsHosting {
 			score += 0.10
-			flags = append(flags, "hosting_ip")
+			*flags = append(*flags, "hosting_ip")
 		}
 		score += float64(s.FraudScore) / 100.0 * 0.30
+		return score
 	}
+	return 0
+}
 
-	score = math.Min(score, 1.0)
-	score = math.Round(score*100) / 100
+func roundScore(score float64) float64 {
+	return math.Round(math.Min(score, 1.0)*100) / 100
+}
 
+func signalConfidence(s Signals) float64 {
 	present := 0
 	if s.EmailPresent {
 		present++
@@ -218,14 +247,5 @@ func Compute(s Signals) ScoreResult {
 	if s.IPPresent {
 		present++
 	}
-	confidence := math.Round(float64(present)/float64(totalSignals)*100) / 100
-
-	isSafe := score < 0.5 && confidence > 0.6 && !s.IsTOR && !s.IsProxy
-
-	return ScoreResult{
-		RiskScore:  score,
-		Confidence: confidence,
-		IsSafe:     isSafe,
-		Flags:      flags,
-	}
+	return math.Round(float64(present)/float64(totalSignals)*100) / 100
 }

--- a/apps/api/services/systems/identity_risk/risk_score/service.go
+++ b/apps/api/services/systems/identity_risk/risk_score/service.go
@@ -1,0 +1,54 @@
+package riskscore
+
+import (
+	"context"
+
+	"requiems-api/services/systems/identity_risk/internal/scorer"
+)
+
+// Service computes a risk score without per-signal breakdown.
+type Service struct {
+	email  scorer.EmailChecker
+	phone  scorer.PhoneChecker
+	vpn    scorer.VPNChecker
+	ipInfo scorer.IPInfoChecker
+}
+
+// NewService returns a new risk score Service.
+func NewService(e scorer.EmailChecker, p scorer.PhoneChecker, v scorer.VPNChecker, i scorer.IPInfoChecker) *Service {
+	return &Service{email: e, phone: p, vpn: v, ipInfo: i}
+}
+
+// Request is the input for POST /risk/score.
+// At least one field must be present (validated at transport layer).
+type Request struct {
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
+	IPAddress string `json:"ip_address"`
+}
+
+// Result is the response — identical computation to signup_protect but
+// without the signals breakdown object.
+type Result struct {
+	RiskScore  float64  `json:"risk_score"`
+	IsSafe     bool     `json:"is_safe"`
+	Confidence float64  `json:"confidence"`
+	Flags      []string `json:"flags"`
+}
+
+// Score fans out to the relevant services in parallel and returns the risk score.
+func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
+	resolved := scorer.Resolve(ctx, s.email, s.phone, s.vpn, s.ipInfo,
+		req.Email, req.Phone, req.IPAddress)
+	r := scorer.Compute(resolved.Signals)
+	flags := r.Flags
+	if flags == nil {
+		flags = []string{}
+	}
+	return Result{
+		RiskScore:  r.RiskScore,
+		IsSafe:     r.IsSafe,
+		Confidence: r.Confidence,
+		Flags:      flags,
+	}, nil
+}

--- a/apps/api/services/systems/identity_risk/risk_score/service.go
+++ b/apps/api/services/systems/identity_risk/risk_score/service.go
@@ -6,7 +6,6 @@ import (
 	"requiems-api/services/systems/identity_risk/internal/scorer"
 )
 
-// Service computes a risk score without per-signal breakdown.
 type Service struct {
 	email  scorer.EmailChecker
 	phone  scorer.PhoneChecker
@@ -14,21 +13,10 @@ type Service struct {
 	ipInfo scorer.IPInfoChecker
 }
 
-// NewService returns a new risk score Service.
 func NewService(e scorer.EmailChecker, p scorer.PhoneChecker, v scorer.VPNChecker, i scorer.IPInfoChecker) *Service {
 	return &Service{email: e, phone: p, vpn: v, ipInfo: i}
 }
 
-// Request is the input for POST /risk/score.
-// At least one field must be present (validated at transport layer).
-type Request struct {
-	Email     string `json:"email"`
-	Phone     string `json:"phone"`
-	IPAddress string `json:"ip_address"`
-}
-
-// Result is the response — identical computation to signup_protect but
-// without the signals breakdown object.
 type Result struct {
 	RiskScore  float64  `json:"risk_score"`
 	IsSafe     bool     `json:"is_safe"`
@@ -36,7 +24,6 @@ type Result struct {
 	Flags      []string `json:"flags"`
 }
 
-// Score fans out to the relevant services in parallel and returns the risk score.
 func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 	resolved := scorer.Resolve(ctx, s.email, s.phone, s.vpn, s.ipInfo,
 		req.Email, req.Phone, req.IPAddress)

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http.go
@@ -14,7 +14,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/risk/score", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
 			if req.Email == "" && req.Phone == "" && req.IPAddress == "" {
-				return Result{}, svcerr.Invalid("validation_failed", "at least one of email, phone, or ip_address is required")
+				return Result{}, svcerr.Unknown("validation_failed", "at least one of email, phone, or ip_address is required")
 			}
 			return svc.Score(ctx, req)
 		},

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http.go
@@ -9,7 +9,12 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
-// RegisterRoutes mounts POST /risk/score on the given router.
+type Request struct {
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
+	IPAddress string `json:"ip_address"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/risk/score", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http.go
@@ -1,0 +1,22 @@
+package riskscore
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
+)
+
+// RegisterRoutes mounts POST /risk/score on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/risk/score", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			if req.Email == "" && req.Phone == "" && req.IPAddress == "" {
+				return Result{}, svcerr.Invalid("validation_failed", "at least one of email, phone, or ip_address is required")
+			}
+			return svc.Score(ctx, req)
+		},
+	))
+}

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
@@ -1,0 +1,176 @@
+package riskscore
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubEmail struct{ r email.Validation }
+
+func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
+
+type stubPhone struct{ r phone.ValidateResponse }
+
+func (s *stubPhone) Validate(_ string) phone.ValidateResponse { return s.r }
+
+type stubVPN struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
+	return s.r, s.err
+}
+
+type stubIPInfo struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupResponse, error) {
+	return s.r, s.err
+}
+
+// -- helpers -----------------------------------------------------------------
+
+func cleanEmail() email.Validation {
+	v, mx := true, true
+	normalized := "user@example.com"
+	domain := "example.com"
+	return email.Validation{Valid: v, SyntaxValid: true, MxValid: mx, Disposable: false, Normalized: &normalized, Domain: &domain}
+}
+
+func setupRouter(e *stubEmail, p *stubPhone, v *stubVPN, i *stubIPInfo) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(e, p, v, i))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/risk/score", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestRiskScore_AllClean(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Country: "US", Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.IsSafe)
+	assert.Less(t, resp.Data.RiskScore, 0.5)
+	assert.Empty(t, resp.Data.Flags)
+}
+
+func TestRiskScore_DisposableEmail(t *testing.T) {
+	t.Parallel()
+	normalized := "user@tempmail.io"
+	domain := "tempmail.io"
+	r := setupRouter(
+		&stubEmail{r: email.Validation{Valid: true, SyntaxValid: true, MxValid: true, Disposable: true, Normalized: &normalized, Domain: &domain}},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@tempmail.io","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "disposable_email")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.30)
+}
+
+func TestRiskScore_TORDetected(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsTor: true}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.IsSafe)
+	assert.Contains(t, resp.Data.Flags, "tor_detected")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.40)
+}
+
+func TestRiskScore_VoIPPhone(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{IsVoIP: true}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "phone_voip")
+}
+
+func TestRiskScore_NoSignalsField(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubEmail{r: cleanEmail()}, &stubPhone{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	// Response must NOT contain a "signals" key
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&raw))
+	data, _ := raw["data"].(map[string]any)
+	assert.NotContains(t, data, "signals")
+}
+
+func TestRiskScore_NoFieldsProvided(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubEmail{}, &stubPhone{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestRiskScore_OnlyEmailConfidence(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{},
+		&stubVPN{},
+		&stubIPInfo{},
+	)
+	w := post(t, r, `{"email":"user@example.com"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.LessOrEqual(t, resp.Data.Confidence, 0.34)
+}

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
@@ -20,8 +20,6 @@ import (
 	"requiems-api/services/validation/phone"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubEmail struct{ r email.Validation }
 
 func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
@@ -48,8 +46,6 @@ func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupRespon
 	return s.r, s.err
 }
 
-// -- helpers -----------------------------------------------------------------
-
 func cleanEmail() email.Validation {
 	v, mx := true, true
 	normalized := "user@example.com"
@@ -71,8 +67,6 @@ func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestRiskScore_AllClean(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/identity_risk/router.go
+++ b/apps/api/services/systems/identity_risk/router.go
@@ -10,9 +10,10 @@ import (
 	ipvpn "requiems-api/services/networking/ip/vpn"
 	"requiems-api/services/networking/mx"
 	"requiems-api/services/networking/whois"
-	"requiems-api/services/systems/identity_risk/risk_score"
-	"requiems-api/services/systems/identity_risk/signup_protect"
-	"requiems-api/services/systems/identity_risk/user_verify"
+	"requiems-api/services/systems/identity_risk/internal/scorer"
+	riskscore "requiems-api/services/systems/identity_risk/risk_score"
+	signupprotect "requiems-api/services/systems/identity_risk/signup_protect"
+	userverify "requiems-api/services/systems/identity_risk/user_verify"
 	"requiems-api/services/validation/email"
 	"requiems-api/services/validation/phone"
 )
@@ -28,8 +29,15 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	emailSvc := email.NewService()
 	phoneSvc := phone.NewService()
 
-	vpnSvc := ipvpn.NewService(deps.IPIClient)
-	infoSvc := ipinfo.NewService(deps.IPIClient)
+	// Use interface-typed vars so nil is a true nil interface (not a non-nil
+	// interface wrapping a nil concrete pointer), preventing panics in the
+	// scorer when an IP address is supplied but the IPI client is unavailable.
+	var vpnSvc scorer.VPNChecker
+	var infoSvc scorer.IPInfoChecker
+	if deps.IPIClient != nil {
+		vpnSvc = ipvpn.NewService(deps.IPIClient)
+		infoSvc = ipinfo.NewService(deps.IPIClient)
+	}
 
 	riskSvc := riskscore.NewService(emailSvc, phoneSvc, vpnSvc, infoSvc)
 	riskscore.RegisterRoutes(r, riskSvc)

--- a/apps/api/services/systems/identity_risk/router.go
+++ b/apps/api/services/systems/identity_risk/router.go
@@ -1,7 +1,9 @@
 package identityrisk
 
 import (
+	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"requiems-api/services/networking/domain"
 	ipinfo "requiems-api/services/networking/ip/info"
@@ -13,9 +15,6 @@ import (
 	"requiems-api/services/systems/identity_risk/user_verify"
 	"requiems-api/services/validation/email"
 	"requiems-api/services/validation/phone"
-
-	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Deps holds the external service clients needed by the identity risk system.

--- a/apps/api/services/systems/identity_risk/router.go
+++ b/apps/api/services/systems/identity_risk/router.go
@@ -1,0 +1,46 @@
+package identityrisk
+
+import (
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/services/networking/domain"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/networking/mx"
+	"requiems-api/services/networking/whois"
+	"requiems-api/services/systems/identity_risk/risk_score"
+	"requiems-api/services/systems/identity_risk/signup_protect"
+	"requiems-api/services/systems/identity_risk/user_verify"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+
+	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Deps holds the external service clients needed by the identity risk system.
+type Deps struct {
+	Pool      *pgxpool.Pool
+	IPIClient *ipi.Client
+}
+
+// RegisterRoutes mounts all Identity & Risk system endpoints on r.
+func RegisterRoutes(r chi.Router, deps Deps) {
+	emailSvc := email.NewService()
+	phoneSvc := phone.NewService()
+
+	vpnSvc := ipvpn.NewService(deps.IPIClient)
+	infoSvc := ipinfo.NewService(deps.IPIClient)
+
+	riskSvc := riskscore.NewService(emailSvc, phoneSvc, vpnSvc, infoSvc)
+	riskscore.RegisterRoutes(r, riskSvc)
+
+	signupSvc := signupprotect.NewService(emailSvc, phoneSvc, vpnSvc, infoSvc)
+	signupprotect.RegisterRoutes(r, signupSvc)
+
+	whoisSvc := whois.NewService()
+	domainSvc := domain.NewService()
+	mxSvc := mx.NewService()
+	verifySvc := userverify.NewService(emailSvc, whoisSvc, domainSvc, mxSvc, vpnSvc)
+	userverify.RegisterRoutes(r, verifySvc)
+}

--- a/apps/api/services/systems/identity_risk/signup_protect/service.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/service.go
@@ -6,7 +6,6 @@ import (
 	"requiems-api/services/systems/identity_risk/internal/scorer"
 )
 
-// Service composes multiple signals into a full signup protection response.
 type Service struct {
 	email  scorer.EmailChecker
 	phone  scorer.PhoneChecker
@@ -14,19 +13,10 @@ type Service struct {
 	ipInfo scorer.IPInfoChecker
 }
 
-// NewService returns a new signup protect Service.
 func NewService(e scorer.EmailChecker, p scorer.PhoneChecker, v scorer.VPNChecker, i scorer.IPInfoChecker) *Service {
 	return &Service{email: e, phone: p, vpn: v, ipInfo: i}
 }
 
-// Request is the input for POST /signup/protect.
-type Request struct {
-	Email     string `json:"email"`
-	Phone     string `json:"phone"`
-	IPAddress string `json:"ip_address"`
-}
-
-// EmailSignal is the per-signal email breakdown.
 type EmailSignal struct {
 	Valid      bool    `json:"valid"`
 	Disposable bool    `json:"disposable"`
@@ -34,7 +24,6 @@ type EmailSignal struct {
 	Suggestion *string `json:"suggestion"`
 }
 
-// PhoneSignal is the per-signal phone breakdown.
 type PhoneSignal struct {
 	Valid     bool   `json:"valid"`
 	Country   string `json:"country"`
@@ -42,24 +31,21 @@ type PhoneSignal struct {
 	IsVirtual bool   `json:"is_virtual"`
 }
 
-// IPSignal is the per-signal IP breakdown.
 type IPSignal struct {
 	CountryCode string  `json:"country_code"`
 	IsVPN       bool    `json:"is_vpn"`
 	IsProxy     bool    `json:"is_proxy"`
 	IsTOR       bool    `json:"is_tor"`
 	IsHosting   bool    `json:"is_hosting"`
-	FraudScore  float64 `json:"fraud_score"` // normalised 0–1
+	FraudScore  float64 `json:"fraud_score"`
 }
 
-// Signals groups the per-signal breakdowns; omitted fields are null.
 type Signals struct {
 	Email *EmailSignal `json:"email"`
 	Phone *PhoneSignal `json:"phone"`
 	IP    *IPSignal    `json:"ip"`
 }
 
-// Result is the full signup protection response.
 type Result struct {
 	RiskScore  float64  `json:"risk_score"`
 	IsSafe     bool     `json:"is_safe"`
@@ -68,7 +54,6 @@ type Result struct {
 	Signals    Signals  `json:"signals"`
 }
 
-// Protect fans out to the relevant services and returns the full breakdown.
 func (s *Service) Protect(ctx context.Context, req Request) (Result, error) {
 	resolved := scorer.Resolve(ctx, s.email, s.phone, s.vpn, s.ipInfo,
 		req.Email, req.Phone, req.IPAddress)

--- a/apps/api/services/systems/identity_risk/signup_protect/service.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/service.go
@@ -1,0 +1,127 @@
+package signupprotect
+
+import (
+	"context"
+
+	"requiems-api/services/systems/identity_risk/internal/scorer"
+)
+
+// Service composes multiple signals into a full signup protection response.
+type Service struct {
+	email  scorer.EmailChecker
+	phone  scorer.PhoneChecker
+	vpn    scorer.VPNChecker
+	ipInfo scorer.IPInfoChecker
+}
+
+// NewService returns a new signup protect Service.
+func NewService(e scorer.EmailChecker, p scorer.PhoneChecker, v scorer.VPNChecker, i scorer.IPInfoChecker) *Service {
+	return &Service{email: e, phone: p, vpn: v, ipInfo: i}
+}
+
+// Request is the input for POST /signup/protect.
+type Request struct {
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
+	IPAddress string `json:"ip_address"`
+}
+
+// EmailSignal is the per-signal email breakdown.
+type EmailSignal struct {
+	Valid      bool    `json:"valid"`
+	Disposable bool    `json:"disposable"`
+	MXValid    bool    `json:"mx_valid"`
+	Suggestion *string `json:"suggestion"`
+}
+
+// PhoneSignal is the per-signal phone breakdown.
+type PhoneSignal struct {
+	Valid     bool   `json:"valid"`
+	Country   string `json:"country"`
+	IsVoIP    bool   `json:"is_voip"`
+	IsVirtual bool   `json:"is_virtual"`
+}
+
+// IPSignal is the per-signal IP breakdown.
+type IPSignal struct {
+	CountryCode string  `json:"country_code"`
+	IsVPN       bool    `json:"is_vpn"`
+	IsProxy     bool    `json:"is_proxy"`
+	IsTOR       bool    `json:"is_tor"`
+	IsHosting   bool    `json:"is_hosting"`
+	FraudScore  float64 `json:"fraud_score"` // normalised 0–1
+}
+
+// Signals groups the per-signal breakdowns; omitted fields are null.
+type Signals struct {
+	Email *EmailSignal `json:"email"`
+	Phone *PhoneSignal `json:"phone"`
+	IP    *IPSignal    `json:"ip"`
+}
+
+// Result is the full signup protection response.
+type Result struct {
+	RiskScore  float64  `json:"risk_score"`
+	IsSafe     bool     `json:"is_safe"`
+	Confidence float64  `json:"confidence"`
+	Flags      []string `json:"flags"`
+	Signals    Signals  `json:"signals"`
+}
+
+// Protect fans out to the relevant services and returns the full breakdown.
+func (s *Service) Protect(ctx context.Context, req Request) (Result, error) {
+	resolved := scorer.Resolve(ctx, s.email, s.phone, s.vpn, s.ipInfo,
+		req.Email, req.Phone, req.IPAddress)
+	r := scorer.Compute(resolved.Signals)
+
+	flags := r.Flags
+	if flags == nil {
+		flags = []string{}
+	}
+
+	var sigs Signals
+
+	if resolved.EmailResult != nil {
+		sigs.Email = &EmailSignal{
+			Valid:      resolved.EmailResult.Valid,
+			Disposable: resolved.EmailResult.Disposable,
+			MXValid:    resolved.EmailResult.MxValid,
+			Suggestion: resolved.EmailResult.Suggestion,
+		}
+	}
+
+	if resolved.PhoneResult != nil {
+		ps := &PhoneSignal{
+			Valid:   resolved.PhoneResult.Valid,
+			Country: resolved.PhoneResult.Country,
+		}
+		if resolved.PhoneResult.Risk != nil {
+			ps.IsVoIP = resolved.PhoneResult.Risk.IsVoIP
+			ps.IsVirtual = resolved.PhoneResult.Risk.IsVirtual
+		}
+		sigs.Phone = ps
+	}
+
+	if resolved.VPNResult != nil || resolved.IPResult != nil {
+		ip := &IPSignal{}
+		if resolved.VPNResult != nil {
+			ip.IsVPN = resolved.VPNResult.IsVPN
+			ip.IsProxy = resolved.VPNResult.IsProxy
+			ip.IsTOR = resolved.VPNResult.IsTor
+			ip.IsHosting = resolved.VPNResult.IsHosting
+			ip.FraudScore = float64(resolved.VPNResult.FraudScore) / 100.0
+		}
+		if resolved.IPResult != nil {
+			ip.CountryCode = resolved.IPResult.CountryCode
+		}
+		sigs.IP = ip
+	}
+
+	return Result{
+		RiskScore:  r.RiskScore,
+		IsSafe:     r.IsSafe,
+		Confidence: r.Confidence,
+		Flags:      flags,
+		Signals:    sigs,
+	}, nil
+}

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
@@ -9,7 +9,12 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
-// RegisterRoutes mounts POST /signup/protect on the given router.
+type Request struct {
+	Email     string `json:"email"`
+	Phone     string `json:"phone"`
+	IPAddress string `json:"ip_address"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/signup/protect", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
@@ -14,7 +14,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/signup/protect", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
 			if req.Email == "" && req.Phone == "" && req.IPAddress == "" {
-				return Result{}, svcerr.Invalid("validation_failed", "at least one of email, phone, or ip_address is required")
+				return Result{}, svcerr.Unknown("validation_failed", "at least one of email, phone, or ip_address is required")
 			}
 			return svc.Protect(ctx, req)
 		},

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http.go
@@ -1,0 +1,22 @@
+package signupprotect
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
+)
+
+// RegisterRoutes mounts POST /signup/protect on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/signup/protect", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			if req.Email == "" && req.Phone == "" && req.IPAddress == "" {
+				return Result{}, svcerr.Invalid("validation_failed", "at least one of email, phone, or ip_address is required")
+			}
+			return svc.Protect(ctx, req)
+		},
+	))
+}

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
@@ -1,0 +1,185 @@
+package signupprotect
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubEmail struct{ r email.Validation }
+
+func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
+
+type stubPhone struct{ r phone.ValidateResponse }
+
+func (s *stubPhone) Validate(_ string) phone.ValidateResponse { return s.r }
+
+type stubVPN struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
+	return s.r, s.err
+}
+
+type stubIPInfo struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupResponse, error) {
+	return s.r, s.err
+}
+
+// -- helpers -----------------------------------------------------------------
+
+func cleanEmail() email.Validation {
+	v, mx := true, true
+	normalized := "user@example.com"
+	domain := "example.com"
+	return email.Validation{Valid: v, SyntaxValid: true, MxValid: mx, Disposable: false, Normalized: &normalized, Domain: &domain}
+}
+
+func setupRouter(e *stubEmail, p *stubPhone, v *stubVPN, i *stubIPInfo) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(e, p, v, i))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/signup/protect", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestSignupProtect_AllClean(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Country: "US", Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.IsSafe)
+	assert.Less(t, resp.Data.RiskScore, 0.5)
+	assert.Empty(t, resp.Data.Flags)
+	assert.NotNil(t, resp.Data.Signals.Email)
+	assert.NotNil(t, resp.Data.Signals.Phone)
+	assert.NotNil(t, resp.Data.Signals.IP)
+}
+
+func TestSignupProtect_DisposableEmail(t *testing.T) {
+	t.Parallel()
+	normalized := "user@tempmail.io"
+	domain := "tempmail.io"
+	r := setupRouter(
+		&stubEmail{r: email.Validation{Valid: true, SyntaxValid: true, MxValid: true, Disposable: true, Normalized: &normalized, Domain: &domain}},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@tempmail.io","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "disposable_email")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.30)
+	require.NotNil(t, resp.Data.Signals.Email)
+	assert.True(t, resp.Data.Signals.Email.Disposable)
+}
+
+func TestSignupProtect_TORDetected(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsTor: true}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.IsSafe)
+	assert.Contains(t, resp.Data.Flags, "tor_detected")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.40)
+	require.NotNil(t, resp.Data.Signals.IP)
+	assert.True(t, resp.Data.Signals.IP.IsTOR)
+}
+
+func TestSignupProtect_VoIPPhone(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Risk: &phone.Risk{IsVoIP: true}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "phone_voip")
+	require.NotNil(t, resp.Data.Signals.Phone)
+	assert.True(t, resp.Data.Signals.Phone.IsVoIP)
+}
+
+func TestSignupProtect_GeoMismatchPhoneIP(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Country: "US", Risk: &phone.Risk{}}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "NL"}},
+	)
+	w := post(t, r, `{"email":"user@example.com","phone":"+14155550100","ip_address":"1.2.3.4"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "geo_mismatch_phone_ip")
+}
+
+func TestSignupProtect_OnlyEmailSignalsNullPhoneIP(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubEmail{r: cleanEmail()}, &stubPhone{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{"email":"user@example.com"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Nil(t, resp.Data.Signals.Phone)
+	assert.Nil(t, resp.Data.Signals.IP)
+	assert.LessOrEqual(t, resp.Data.Confidence, 0.34)
+}
+
+func TestSignupProtect_NoFieldsProvided(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubEmail{}, &stubPhone{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
@@ -20,8 +20,6 @@ import (
 	"requiems-api/services/validation/phone"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubEmail struct{ r email.Validation }
 
 func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
@@ -48,8 +46,6 @@ func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupRespon
 	return s.r, s.err
 }
 
-// -- helpers -----------------------------------------------------------------
-
 func cleanEmail() email.Validation {
 	v, mx := true, true
 	normalized := "user@example.com"
@@ -71,8 +67,6 @@ func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestSignupProtect_AllClean(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -182,10 +182,9 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	} else if whoisResult.err != nil {
 		flags = append(flags, "whois_unavailable")
 		servicesResolved--
-		servicesResolved++
 	}
 
-	hasMX := mxResult.err == nil && len(mxResult.r.Records) > 0
+	hasMX := (mxResult.err == nil && len(mxResult.r.Records) > 0) || len(domainResult.r.DNS.MX) > 0
 	hasA := len(domainResult.r.DNS.A) > 0
 	available := domainResult.r.Available
 

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -1,0 +1,287 @@
+package userverify
+
+import (
+	"context"
+	"math"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"requiems-api/services/networking/domain"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/networking/mx"
+	"requiems-api/services/networking/whois"
+	"requiems-api/services/validation/email"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type EmailChecker interface {
+	ValidateEmail(ctx context.Context, addr string) email.Validation
+}
+
+type WHOISLooker interface {
+	Lookup(ctx context.Context, d string) (whois.LookupResponse, error)
+}
+
+type DomainInfoGetter interface {
+	GetInfo(ctx context.Context, d string) domain.InfoResponse
+}
+
+type MXLooker interface {
+	Lookup(ctx context.Context, d string) (mx.LookupResponse, error)
+}
+
+type VPNChecker interface {
+	CheckIP(ctx context.Context, ip net.IP) (ipvpn.IPCheckResponse, error)
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service verifies a user's identity signals.
+type Service struct {
+	email  EmailChecker
+	whois  WHOISLooker
+	domain DomainInfoGetter
+	mx     MXLooker
+	vpn    VPNChecker // optional; only used when ip_address provided
+}
+
+// NewService returns a new user verify Service.
+func NewService(e EmailChecker, w WHOISLooker, d DomainInfoGetter, m MXLooker, v VPNChecker) *Service {
+	return &Service{email: e, whois: w, domain: d, mx: m, vpn: v}
+}
+
+// Request is the input for POST /user/verify.
+type Request struct {
+	Email     string `json:"email" validate:"required"`
+	IPAddress string `json:"ip_address"`
+}
+
+// EmailSignal is the email signal breakdown.
+type EmailSignal struct {
+	Valid      bool `json:"valid"`
+	Disposable bool `json:"disposable"`
+	MXValid    bool `json:"mx_valid"`
+}
+
+// DomainSignal is the domain signal breakdown.
+type DomainSignal struct {
+	AgeDays     int  `json:"age_days"` // -1 if unknown
+	HasMX       bool `json:"has_mx"`
+	HasARecords bool `json:"has_a_records"`
+	Available   bool `json:"available"`
+}
+
+// IPSignal is the IP signal breakdown.
+type IPSignal struct {
+	IsVPN      bool    `json:"is_vpn"`
+	IsProxy    bool    `json:"is_proxy"`
+	FraudScore float64 `json:"fraud_score"` // normalised 0–1
+}
+
+// Signals groups the per-signal breakdowns.
+type Signals struct {
+	Email  EmailSignal  `json:"email"`
+	Domain DomainSignal `json:"domain"`
+	IP     *IPSignal    `json:"ip"`
+}
+
+// Result is the full user verification response.
+type Result struct {
+	Verified   bool     `json:"verified"`
+	Confidence float64  `json:"confidence"`
+	RiskScore  float64  `json:"risk_score"`
+	Flags      []string `json:"flags"`
+	Signals    Signals  `json:"signals"`
+}
+
+// Verify fans out to the relevant services and returns the verification result.
+func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
+	emailResult := s.email.ValidateEmail(ctx, req.Email)
+
+	// Extract domain from validated email.
+	emailDomain := ""
+	if emailResult.Domain != nil {
+		emailDomain = *emailResult.Domain
+	} else if idx := strings.LastIndex(req.Email, "@"); idx >= 0 {
+		emailDomain = req.Email[idx+1:]
+	}
+
+	type whoisOut struct {
+		r   whois.LookupResponse
+		err error
+	}
+	type domainOut struct{ r domain.InfoResponse }
+	type mxOut struct {
+		r   mx.LookupResponse
+		err error
+	}
+	type vpnOut struct {
+		r   ipvpn.IPCheckResponse
+		err error
+	}
+
+	whoisCh := make(chan whoisOut, 1)
+	domainCh := make(chan domainOut, 1)
+	mxCh := make(chan mxOut, 1)
+	vpnCh := make(chan vpnOut, 1)
+
+	var wg sync.WaitGroup
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		r, err := s.whois.Lookup(ctx, emailDomain)
+		whoisCh <- whoisOut{r, err}
+	}()
+	go func() {
+		defer wg.Done()
+		r := s.domain.GetInfo(ctx, emailDomain)
+		domainCh <- domainOut{r}
+	}()
+	go func() {
+		defer wg.Done()
+		r, err := s.mx.Lookup(ctx, emailDomain)
+		mxCh <- mxOut{r, err}
+	}()
+
+	parsedIP := net.ParseIP(req.IPAddress)
+	if req.IPAddress != "" && parsedIP != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := s.vpn.CheckIP(ctx, parsedIP)
+			vpnCh <- vpnOut{r, err}
+		}()
+	} else {
+		vpnCh <- vpnOut{}
+	}
+
+	wg.Wait()
+
+	whoisResult := <-whoisCh
+	domainResult := <-domainCh
+	mxResult := <-mxCh
+	vpnResult := <-vpnCh
+
+	// Build signals and compute risk score.
+	flags := make([]string, 0, 4)
+	score := 0.0
+	servicesResolved := 2 // email + domain always count
+	servicesTotal := 2
+	if req.IPAddress != "" && parsedIP != nil {
+		servicesTotal++
+	}
+
+	// Email signals.
+	emailSig := EmailSignal{
+		Valid:      emailResult.Valid,
+		Disposable: emailResult.Disposable,
+		MXValid:    emailResult.MxValid,
+	}
+	if !emailResult.Valid {
+		score += 0.50
+		flags = append(flags, "email_invalid")
+	}
+	if emailResult.Disposable {
+		score += 0.30
+		flags = append(flags, "disposable_email")
+	}
+
+	// Domain signals from WHOIS + domain info + MX.
+	ageDays := -1
+	if whoisResult.err == nil && whoisResult.r.CreatedDate != "" {
+		if age, ok := parseDomainAge(whoisResult.r.CreatedDate); ok {
+			ageDays = age
+			if ageDays < 30 {
+				score += 0.25
+				flags = append(flags, "young_domain")
+			} else if ageDays < 180 {
+				score += 0.10
+				flags = append(flags, "young_domain")
+			}
+		}
+	} else if whoisResult.err != nil {
+		flags = append(flags, "whois_unavailable")
+		servicesResolved-- // WHOIS didn't resolve
+		servicesResolved++ // subtract from total later — don't penalise confidence
+	}
+
+	hasMX := mxResult.err == nil && len(mxResult.r.Records) > 0
+	hasA := len(domainResult.r.DNS.A) > 0
+	available := domainResult.r.Available
+
+	domainSig := DomainSignal{
+		AgeDays:     ageDays,
+		HasMX:       hasMX,
+		HasARecords: hasA,
+		Available:   available,
+	}
+
+	if !hasMX {
+		score += 0.30
+		flags = append(flags, "no_mx")
+	}
+	if available {
+		score += 0.50
+		flags = append(flags, "domain_not_registered")
+	}
+
+	// IP signals.
+	var ipSig *IPSignal
+	if req.IPAddress != "" && parsedIP != nil && vpnResult.err == nil {
+		ipSig = &IPSignal{
+			IsVPN:      vpnResult.r.IsVPN,
+			IsProxy:    vpnResult.r.IsProxy,
+			FraudScore: float64(vpnResult.r.FraudScore) / 100.0,
+		}
+		if vpnResult.r.IsVPN || vpnResult.r.IsProxy || vpnResult.r.IsTor {
+			score += 0.20
+			flags = append(flags, "ip_risk")
+		}
+		servicesResolved++
+	}
+
+	score = math.Min(score, 1.0)
+	score = math.Round(score*100) / 100
+	confidence := math.Round(float64(servicesResolved)/float64(servicesTotal)*100) / 100
+
+	verified := score < 0.3 && confidence > 0.5 && emailResult.Valid && hasMX && !available
+
+	return Result{
+		Verified:   verified,
+		Confidence: confidence,
+		RiskScore:  score,
+		Flags:      flags,
+		Signals: Signals{
+			Email:  emailSig,
+			Domain: domainSig,
+			IP:     ipSig,
+		},
+	}, nil
+}
+
+// parseDomainAge parses common WHOIS date formats and returns age in days.
+func parseDomainAge(dateStr string) (int, bool) {
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02",
+		"02-Jan-2006",
+		"January 2, 2006",
+		"2006.01.02",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, dateStr); err == nil {
+			days := int(time.Since(t).Hours() / 24)
+			if days < 0 {
+				days = 0
+			}
+			return days, true
+		}
+	}
+	return -1, false
+}

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -15,8 +15,6 @@ import (
 	"requiems-api/services/validation/email"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type EmailChecker interface {
 	ValidateEmail(ctx context.Context, addr string) email.Validation
 }
@@ -37,9 +35,6 @@ type VPNChecker interface {
 	CheckIP(ctx context.Context, ip net.IP) (ipvpn.IPCheckResponse, error)
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service verifies a user's identity signals.
 type Service struct {
 	email  EmailChecker
 	whois  WHOISLooker
@@ -48,25 +43,16 @@ type Service struct {
 	vpn    VPNChecker // optional; only used when ip_address provided
 }
 
-// NewService returns a new user verify Service.
 func NewService(e EmailChecker, w WHOISLooker, d DomainInfoGetter, m MXLooker, v VPNChecker) *Service {
 	return &Service{email: e, whois: w, domain: d, mx: m, vpn: v}
 }
 
-// Request is the input for POST /user/verify.
-type Request struct {
-	Email     string `json:"email" validate:"required"`
-	IPAddress string `json:"ip_address"`
-}
-
-// EmailSignal is the email signal breakdown.
 type EmailSignal struct {
 	Valid      bool `json:"valid"`
 	Disposable bool `json:"disposable"`
 	MXValid    bool `json:"mx_valid"`
 }
 
-// DomainSignal is the domain signal breakdown.
 type DomainSignal struct {
 	AgeDays     int  `json:"age_days"` // -1 if unknown
 	HasMX       bool `json:"has_mx"`
@@ -74,21 +60,18 @@ type DomainSignal struct {
 	Available   bool `json:"available"`
 }
 
-// IPSignal is the IP signal breakdown.
 type IPSignal struct {
 	IsVPN      bool    `json:"is_vpn"`
 	IsProxy    bool    `json:"is_proxy"`
-	FraudScore float64 `json:"fraud_score"` // normalised 0–1
+	FraudScore float64 `json:"fraud_score"`
 }
 
-// Signals groups the per-signal breakdowns.
 type Signals struct {
 	Email  EmailSignal  `json:"email"`
 	Domain DomainSignal `json:"domain"`
 	IP     *IPSignal    `json:"ip"`
 }
 
-// Result is the full user verification response.
 type Result struct {
 	Verified   bool     `json:"verified"`
 	Confidence float64  `json:"confidence"`
@@ -97,11 +80,9 @@ type Result struct {
 	Signals    Signals  `json:"signals"`
 }
 
-// Verify fans out to the relevant services and returns the verification result.
 func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	emailResult := s.email.ValidateEmail(ctx, req.Email)
 
-	// Extract domain from validated email.
 	emailDomain := ""
 	if emailResult.Domain != nil {
 		emailDomain = *emailResult.Domain
@@ -166,7 +147,6 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	mxResult := <-mxCh
 	vpnResult := <-vpnCh
 
-	// Build signals and compute risk score.
 	flags := make([]string, 0, 4)
 	score := 0.0
 	servicesResolved := 2 // email + domain always count
@@ -175,7 +155,6 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		servicesTotal++
 	}
 
-	// Email signals.
 	emailSig := EmailSignal{
 		Valid:      emailResult.Valid,
 		Disposable: emailResult.Disposable,
@@ -190,7 +169,6 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		flags = append(flags, "disposable_email")
 	}
 
-	// Domain signals from WHOIS + domain info + MX.
 	ageDays := -1
 	if whoisResult.err == nil && whoisResult.r.CreatedDate != "" {
 		if age, ok := parseDomainAge(whoisResult.r.CreatedDate); ok {
@@ -205,8 +183,8 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		}
 	} else if whoisResult.err != nil {
 		flags = append(flags, "whois_unavailable")
-		servicesResolved-- // WHOIS didn't resolve
-		servicesResolved++ // subtract from total later — don't penalise confidence
+		servicesResolved--
+		servicesResolved++
 	}
 
 	hasMX := mxResult.err == nil && len(mxResult.r.Records) > 0
@@ -229,7 +207,6 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		flags = append(flags, "domain_not_registered")
 	}
 
-	// IP signals.
 	var ipSig *IPSignal
 	if req.IPAddress != "" && parsedIP != nil && vpnResult.err == nil {
 		ipSig = &IPSignal{
@@ -263,7 +240,6 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	}, nil
 }
 
-// parseDomainAge parses common WHOIS date formats and returns age in days.
 func parseDomainAge(dateStr string) (int, bool) {
 	formats := []string{
 		time.RFC3339,

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -196,7 +196,7 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		Available:   available,
 	}
 
-	if !hasMX {
+	if mxResult.err == nil && !hasMX {
 		score += 0.30
 		flags = append(flags, "no_mx")
 	}

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -80,30 +80,76 @@ type Result struct {
 	Signals    Signals  `json:"signals"`
 }
 
+type whoisOut struct {
+	r   whois.LookupResponse
+	err error
+}
+
+type domainOut struct{ r domain.InfoResponse }
+
+type mxOut struct {
+	r   mx.LookupResponse
+	err error
+}
+
+type vpnOut struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+type verificationChecks struct {
+	whois  whoisOut
+	domain domainOut
+	mx     mxOut
+	vpn    vpnOut
+}
+
 func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	emailResult := s.email.ValidateEmail(ctx, req.Email)
+	emailDomain := domainFromEmail(req.Email, emailResult)
+	parsedIP := net.ParseIP(req.IPAddress)
+	includeIP := req.IPAddress != "" && parsedIP != nil && s.vpn != nil
 
-	emailDomain := ""
-	if emailResult.Domain != nil {
-		emailDomain = *emailResult.Domain
-	} else if idx := strings.LastIndex(req.Email, "@"); idx >= 0 {
-		emailDomain = req.Email[idx+1:]
-	}
+	checks := s.runVerificationChecks(ctx, emailDomain, parsedIP, includeIP)
 
-	type whoisOut struct {
-		r   whois.LookupResponse
-		err error
-	}
-	type domainOut struct{ r domain.InfoResponse }
-	type mxOut struct {
-		r   mx.LookupResponse
-		err error
-	}
-	type vpnOut struct {
-		r   ipvpn.IPCheckResponse
-		err error
-	}
+	flags := make([]string, 0, 4)
+	emailSig, emailScore := scoreEmail(emailResult, &flags)
+	domainSig, domainScore, domainResolved, hasMX := scoreDomain(checks.whois, checks.domain, checks.mx, &flags)
+	ipSig, ipScore, ipResolved := scoreIP(req.IPAddress, parsedIP, checks.vpn, &flags)
 
+	score := roundRiskScore(emailScore + domainScore + ipScore)
+	confidence := verificationConfidence(domainResolved, ipResolved, includeIP)
+	verified := score < 0.3 && confidence > 0.5 && emailResult.Valid && hasMX && !domainSig.Available
+
+	return Result{
+		Verified:   verified,
+		Confidence: confidence,
+		RiskScore:  score,
+		Flags:      flags,
+		Signals: Signals{
+			Email:  emailSig,
+			Domain: domainSig,
+			IP:     ipSig,
+		},
+	}, nil
+}
+
+func domainFromEmail(addr string, result email.Validation) string {
+	if result.Domain != nil {
+		return *result.Domain
+	}
+	if idx := strings.LastIndex(addr, "@"); idx >= 0 {
+		return addr[idx+1:]
+	}
+	return ""
+}
+
+func (s *Service) runVerificationChecks(
+	ctx context.Context,
+	emailDomain string,
+	parsedIP net.IP,
+	includeIP bool,
+) verificationChecks {
 	whoisCh := make(chan whoisOut, 1)
 	domainCh := make(chan domainOut, 1)
 	mxCh := make(chan mxOut, 1)
@@ -128,8 +174,7 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		mxCh <- mxOut{r, err}
 	}()
 
-	parsedIP := net.ParseIP(req.IPAddress)
-	if req.IPAddress != "" && parsedIP != nil && s.vpn != nil {
+	if includeIP {
 		wg.Go(func() {
 			r, err := s.vpn.CheckIP(ctx, parsedIP)
 			vpnCh <- vpnOut{r, err}
@@ -140,19 +185,16 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 
 	wg.Wait()
 
-	whoisResult := <-whoisCh
-	domainResult := <-domainCh
-	mxResult := <-mxCh
-	vpnResult := <-vpnCh
-
-	flags := make([]string, 0, 4)
-	score := 0.0
-	servicesResolved := 2 // email + domain always count
-	servicesTotal := 2
-	if req.IPAddress != "" && parsedIP != nil && s.vpn != nil {
-		servicesTotal++
+	return verificationChecks{
+		whois:  <-whoisCh,
+		domain: <-domainCh,
+		mx:     <-mxCh,
+		vpn:    <-vpnCh,
 	}
+}
 
+func scoreEmail(emailResult email.Validation, flags *[]string) (EmailSignal, float64) {
+	score := 0.0
 	emailSig := EmailSignal{
 		Valid:      emailResult.Valid,
 		Disposable: emailResult.Disposable,
@@ -160,28 +202,38 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	}
 	if !emailResult.Valid {
 		score += 0.50
-		flags = append(flags, "email_invalid")
+		*flags = append(*flags, "email_invalid")
 	}
 	if emailResult.Disposable {
 		score += 0.30
-		flags = append(flags, "disposable_email")
+		*flags = append(*flags, "disposable_email")
 	}
+	return emailSig, score
+}
 
+func scoreDomain(
+	whoisResult whoisOut,
+	domainResult domainOut,
+	mxResult mxOut,
+	flags *[]string,
+) (DomainSignal, float64, bool, bool) {
+	score := 0.0
+	resolved := true
 	ageDays := -1
 	if whoisResult.err == nil && whoisResult.r.CreatedDate != "" {
 		if age, ok := parseDomainAge(whoisResult.r.CreatedDate); ok {
 			ageDays = age
 			if ageDays < 30 {
 				score += 0.25
-				flags = append(flags, "young_domain")
+				*flags = append(*flags, "young_domain")
 			} else if ageDays < 180 {
 				score += 0.10
-				flags = append(flags, "young_domain")
+				*flags = append(*flags, "young_domain")
 			}
 		}
 	} else if whoisResult.err != nil {
-		flags = append(flags, "whois_unavailable")
-		servicesResolved--
+		*flags = append(*flags, "whois_unavailable")
+		resolved = false
 	}
 
 	hasMX := (mxResult.err == nil && len(mxResult.r.Records) > 0) || len(domainResult.r.DNS.MX) > 0
@@ -197,44 +249,50 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 
 	if mxResult.err == nil && !hasMX {
 		score += 0.30
-		flags = append(flags, "no_mx")
+		*flags = append(*flags, "no_mx")
 	}
 	if available {
 		score += 0.50
-		flags = append(flags, "domain_not_registered")
+		*flags = append(*flags, "domain_not_registered")
 	}
 
+	return domainSig, score, resolved, hasMX
+}
+
+func scoreIP(ipAddress string, parsedIP net.IP, vpnResult vpnOut, flags *[]string) (*IPSignal, float64, bool) {
 	var ipSig *IPSignal
-	if req.IPAddress != "" && parsedIP != nil && vpnResult.err == nil {
+	if ipAddress != "" && parsedIP != nil && vpnResult.err == nil {
 		ipSig = &IPSignal{
 			IsVPN:      vpnResult.r.IsVPN,
 			IsProxy:    vpnResult.r.IsProxy,
 			FraudScore: float64(vpnResult.r.FraudScore) / 100.0,
 		}
 		if vpnResult.r.IsVPN || vpnResult.r.IsProxy || vpnResult.r.IsTor {
-			score += 0.20
-			flags = append(flags, "ip_risk")
+			*flags = append(*flags, "ip_risk")
+			return ipSig, 0.20, true
 		}
+		return ipSig, 0, true
+	}
+	return nil, 0, false
+}
+
+func roundRiskScore(score float64) float64 {
+	return math.Round(math.Min(score, 1.0)*100) / 100
+}
+
+func verificationConfidence(domainResolved, ipResolved, includeIP bool) float64 {
+	servicesResolved := 1 // email validation always runs
+	servicesTotal := 2    // email + domain
+	if domainResolved {
 		servicesResolved++
 	}
-
-	score = math.Min(score, 1.0)
-	score = math.Round(score*100) / 100
-	confidence := math.Round(float64(servicesResolved)/float64(servicesTotal)*100) / 100
-
-	verified := score < 0.3 && confidence > 0.5 && emailResult.Valid && hasMX && !available
-
-	return Result{
-		Verified:   verified,
-		Confidence: confidence,
-		RiskScore:  score,
-		Flags:      flags,
-		Signals: Signals{
-			Email:  emailSig,
-			Domain: domainSig,
-			IP:     ipSig,
-		},
-	}, nil
+	if includeIP {
+		servicesTotal++
+		if ipResolved {
+			servicesResolved++
+		}
+	}
+	return math.Round(float64(servicesResolved)/float64(servicesTotal)*100) / 100
 }
 
 func parseDomainAge(dateStr string) (int, bool) {

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -104,6 +104,24 @@ type verificationChecks struct {
 	vpn    vpnOut
 }
 
+type emailScore struct {
+	signal EmailSignal
+	score  float64
+}
+
+type domainScore struct {
+	signal   DomainSignal
+	score    float64
+	resolved bool
+	hasMX    bool
+}
+
+type ipScore struct {
+	signal   *IPSignal
+	score    float64
+	resolved bool
+}
+
 func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	emailResult := s.email.ValidateEmail(ctx, req.Email)
 	emailDomain := domainFromEmail(req.Email, emailResult)
@@ -113,13 +131,13 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	checks := s.runVerificationChecks(ctx, emailDomain, parsedIP, includeIP)
 
 	flags := make([]string, 0, 4)
-	emailSig, emailScore := scoreEmail(emailResult, &flags)
-	domainSig, domainScore, domainResolved, hasMX := scoreDomain(checks.whois, checks.domain, checks.mx, &flags)
-	ipSig, ipScore, ipResolved := scoreIP(req.IPAddress, parsedIP, checks.vpn, &flags)
+	emailScored := scoreEmail(emailResult, &flags)
+	domainScored := scoreDomain(checks.whois, checks.domain, checks.mx, &flags)
+	ipScored := scoreIP(req.IPAddress, parsedIP, checks.vpn, &flags)
 
-	score := roundRiskScore(emailScore + domainScore + ipScore)
-	confidence := verificationConfidence(domainResolved, ipResolved, includeIP)
-	verified := score < 0.3 && confidence > 0.5 && emailResult.Valid && hasMX && !domainSig.Available
+	score := roundRiskScore(emailScored.score + domainScored.score + ipScored.score)
+	confidence := verificationConfidence(domainScored.resolved, ipScored.resolved, includeIP)
+	verified := score < 0.3 && confidence > 0.5 && emailResult.Valid && domainScored.hasMX && !domainScored.signal.Available
 
 	return Result{
 		Verified:   verified,
@@ -127,9 +145,9 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 		RiskScore:  score,
 		Flags:      flags,
 		Signals: Signals{
-			Email:  emailSig,
-			Domain: domainSig,
-			IP:     ipSig,
+			Email:  emailScored.signal,
+			Domain: domainScored.signal,
+			IP:     ipScored.signal,
 		},
 	}, nil
 }
@@ -193,7 +211,7 @@ func (s *Service) runVerificationChecks(
 	}
 }
 
-func scoreEmail(emailResult email.Validation, flags *[]string) (EmailSignal, float64) {
+func scoreEmail(emailResult email.Validation, flags *[]string) emailScore {
 	score := 0.0
 	emailSig := EmailSignal{
 		Valid:      emailResult.Valid,
@@ -208,7 +226,7 @@ func scoreEmail(emailResult email.Validation, flags *[]string) (EmailSignal, flo
 		score += 0.30
 		*flags = append(*flags, "disposable_email")
 	}
-	return emailSig, score
+	return emailScore{signal: emailSig, score: score}
 }
 
 func scoreDomain(
@@ -216,7 +234,7 @@ func scoreDomain(
 	domainResult domainOut,
 	mxResult mxOut,
 	flags *[]string,
-) (DomainSignal, float64, bool, bool) {
+) domainScore {
 	score := 0.0
 	resolved := true
 	ageDays := -1
@@ -256,10 +274,15 @@ func scoreDomain(
 		*flags = append(*flags, "domain_not_registered")
 	}
 
-	return domainSig, score, resolved, hasMX
+	return domainScore{
+		signal:   domainSig,
+		score:    score,
+		resolved: resolved,
+		hasMX:    hasMX,
+	}
 }
 
-func scoreIP(ipAddress string, parsedIP net.IP, vpnResult vpnOut, flags *[]string) (*IPSignal, float64, bool) {
+func scoreIP(ipAddress string, parsedIP net.IP, vpnResult vpnOut, flags *[]string) ipScore {
 	var ipSig *IPSignal
 	if ipAddress != "" && parsedIP != nil && vpnResult.err == nil {
 		ipSig = &IPSignal{
@@ -269,11 +292,11 @@ func scoreIP(ipAddress string, parsedIP net.IP, vpnResult vpnOut, flags *[]strin
 		}
 		if vpnResult.r.IsVPN || vpnResult.r.IsProxy || vpnResult.r.IsTor {
 			*flags = append(*flags, "ip_risk")
-			return ipSig, 0.20, true
+			return ipScore{signal: ipSig, score: 0.20, resolved: true}
 		}
-		return ipSig, 0, true
+		return ipScore{signal: ipSig, resolved: true}
 	}
-	return nil, 0, false
+	return ipScore{}
 }
 
 func roundRiskScore(score float64) float64 {

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -130,12 +130,10 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 
 	parsedIP := net.ParseIP(req.IPAddress)
 	if req.IPAddress != "" && parsedIP != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r, err := s.vpn.CheckIP(ctx, parsedIP)
 			vpnCh <- vpnOut{r, err}
-		}()
+		})
 	} else {
 		vpnCh <- vpnOut{}
 	}
@@ -252,10 +250,7 @@ func parseDomainAge(dateStr string) (int, bool) {
 	}
 	for _, f := range formats {
 		if t, err := time.Parse(f, dateStr); err == nil {
-			days := int(time.Since(t).Hours() / 24)
-			if days < 0 {
-				days = 0
-			}
+			days := max(int(time.Since(t).Hours()/24), 0)
 			return days, true
 		}
 	}

--- a/apps/api/services/systems/identity_risk/user_verify/service.go
+++ b/apps/api/services/systems/identity_risk/user_verify/service.go
@@ -129,7 +129,7 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	}()
 
 	parsedIP := net.ParseIP(req.IPAddress)
-	if req.IPAddress != "" && parsedIP != nil {
+	if req.IPAddress != "" && parsedIP != nil && s.vpn != nil {
 		wg.Go(func() {
 			r, err := s.vpn.CheckIP(ctx, parsedIP)
 			vpnCh <- vpnOut{r, err}
@@ -149,7 +149,7 @@ func (s *Service) Verify(ctx context.Context, req Request) (Result, error) {
 	score := 0.0
 	servicesResolved := 2 // email + domain always count
 	servicesTotal := 2
-	if req.IPAddress != "" && parsedIP != nil {
+	if req.IPAddress != "" && parsedIP != nil && s.vpn != nil {
 		servicesTotal++
 	}
 

--- a/apps/api/services/systems/identity_risk/user_verify/transport_http.go
+++ b/apps/api/services/systems/identity_risk/user_verify/transport_http.go
@@ -1,0 +1,18 @@
+package userverify
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts POST /user/verify on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/user/verify", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			return svc.Verify(ctx, req)
+		},
+	))
+}

--- a/apps/api/services/systems/identity_risk/user_verify/transport_http.go
+++ b/apps/api/services/systems/identity_risk/user_verify/transport_http.go
@@ -8,7 +8,11 @@ import (
 	"requiems-api/platform/httpx"
 )
 
-// RegisterRoutes mounts POST /user/verify on the given router.
+type Request struct {
+	Email     string `json:"email" validate:"required"`
+	IPAddress string `json:"ip_address"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/user/verify", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {

--- a/apps/api/services/systems/identity_risk/user_verify/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/user_verify/transport_http_test.go
@@ -1,0 +1,187 @@
+package userverify
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/networking/domain"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/networking/mx"
+	"requiems-api/services/networking/whois"
+	"requiems-api/services/validation/email"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubEmail struct{ r email.Validation }
+
+func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
+
+type stubWHOIS struct {
+	r   whois.LookupResponse
+	err error
+}
+
+func (s *stubWHOIS) Lookup(_ context.Context, _ string) (whois.LookupResponse, error) {
+	return s.r, s.err
+}
+
+type stubDomain struct{ r domain.InfoResponse }
+
+func (s *stubDomain) GetInfo(_ context.Context, _ string) domain.InfoResponse { return s.r }
+
+type stubMX struct {
+	r   mx.LookupResponse
+	err error
+}
+
+func (s *stubMX) Lookup(_ context.Context, _ string) (mx.LookupResponse, error) {
+	return s.r, s.err
+}
+
+type stubVPN struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
+	return s.r, s.err
+}
+
+// -- helpers -----------------------------------------------------------------
+
+func validEmail() email.Validation {
+	norm := "alice@example.com"
+	dom := "example.com"
+	return email.Validation{Valid: true, SyntaxValid: true, MxValid: true, Disposable: false, Normalized: &norm, Domain: &dom}
+}
+
+func goodDomain() domain.InfoResponse {
+	return domain.InfoResponse{
+		Domain:    "example.com",
+		Available: false,
+		DNS: domain.DNSRecords{
+			A:   []string{"93.184.216.34"},
+			MX:  []domain.MXRecord{{Host: "mail.example.com", Priority: 10}},
+			NS:  []string{"ns1.example.com"},
+			TXT: []string{},
+		},
+	}
+}
+
+func goodMX() mx.LookupResponse {
+	return mx.LookupResponse{
+		Domain:  "example.com",
+		Records: []mx.Record{{Host: "mail.example.com", Priority: 10}},
+	}
+}
+
+func oldWHOIS() whois.LookupResponse {
+	return whois.LookupResponse{
+		Domain:      "example.com",
+		CreatedDate: "1995-08-14T04:00:00Z",
+	}
+}
+
+func setupRouter(e *stubEmail, w *stubWHOIS, d *stubDomain, m *stubMX, v *stubVPN) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(e, w, d, m, v))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/user/verify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestUserVerify_ValidEmailEstablishedDomain(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: validEmail()},
+		&stubWHOIS{r: oldWHOIS()},
+		&stubDomain{r: goodDomain()},
+		&stubMX{r: goodMX()},
+		&stubVPN{},
+	)
+	w := post(t, r, `{"email":"alice@example.com"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.Verified)
+	assert.Less(t, resp.Data.RiskScore, 0.3)
+}
+
+func TestUserVerify_DisposableEmail(t *testing.T) {
+	t.Parallel()
+	norm := "user@tempmail.io"
+	dom := "tempmail.io"
+	r := setupRouter(
+		&stubEmail{r: email.Validation{Valid: true, SyntaxValid: true, MxValid: true, Disposable: true, Normalized: &norm, Domain: &dom}},
+		&stubWHOIS{r: oldWHOIS()},
+		&stubDomain{r: goodDomain()},
+		&stubMX{r: goodMX()},
+		&stubVPN{},
+	)
+	w := post(t, r, `{"email":"user@tempmail.io"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.Verified)
+	assert.Contains(t, resp.Data.Flags, "disposable_email")
+}
+
+func TestUserVerify_DomainNotRegistered(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: validEmail()},
+		&stubWHOIS{r: whois.LookupResponse{}},
+		&stubDomain{r: domain.InfoResponse{Available: true, DNS: domain.DNSRecords{MX: []domain.MXRecord{}}}},
+		&stubMX{err: assert.AnError},
+		&stubVPN{},
+	)
+	w := post(t, r, `{"email":"alice@example.com"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.Verified)
+	assert.Contains(t, resp.Data.Flags, "domain_not_registered")
+}
+
+func TestUserVerify_WHOISFailure(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubEmail{r: validEmail()},
+		&stubWHOIS{err: assert.AnError},
+		&stubDomain{r: goodDomain()},
+		&stubMX{r: goodMX()},
+		&stubVPN{},
+	)
+	w := post(t, r, `{"email":"alice@example.com"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "whois_unavailable")
+}
+
+func TestUserVerify_MissingEmail(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubEmail{}, &stubWHOIS{}, &stubDomain{}, &stubMX{}, &stubVPN{})
+	w := post(t, r, `{}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}

--- a/apps/api/services/systems/identity_risk/user_verify/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/user_verify/transport_http_test.go
@@ -21,8 +21,6 @@ import (
 	"requiems-api/services/validation/email"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubEmail struct{ r email.Validation }
 
 func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
@@ -57,8 +55,6 @@ type stubVPN struct {
 func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
 	return s.r, s.err
 }
-
-// -- helpers -----------------------------------------------------------------
 
 func validEmail() email.Validation {
 	norm := "alice@example.com"
@@ -107,8 +103,6 @@ func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestUserVerify_ValidEmailEstablishedDomain(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/payments/payment_validate/service.go
+++ b/apps/api/services/systems/payments/payment_validate/service.go
@@ -1,0 +1,237 @@
+package paymentvalidate
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"requiems-api/services/finance/bin"
+	"requiems-api/services/finance/iban"
+	"requiems-api/services/finance/swift"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type BINLooker interface {
+	Lookup(ctx context.Context, raw string) (bin.LookupResponse, error)
+}
+
+type IBANParser interface {
+	Parse(ctx context.Context, raw string) (iban.ParseResponse, error)
+}
+
+type SWIFTLooker interface {
+	Lookup(ctx context.Context, raw string) (swift.LookupResponse, error)
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service validates one or more payment instruments and checks consistency.
+type Service struct {
+	bin   BINLooker
+	iban  IBANParser
+	swift SWIFTLooker
+}
+
+// NewService returns a new payment validate Service.
+func NewService(b BINLooker, i IBANParser, s SWIFTLooker) *Service {
+	return &Service{bin: b, iban: i, swift: s}
+}
+
+// Request is the input for POST /payment/validate.
+type Request struct {
+	BIN   string `json:"bin"`
+	IBAN  string `json:"iban"`
+	SWIFT string `json:"swift"`
+}
+
+// BINResult is the BIN signal breakdown.
+type BINResult struct {
+	Valid       bool   `json:"valid"`
+	Scheme      string `json:"scheme"`
+	CardType    string `json:"card_type"`
+	CardLevel   string `json:"card_level"`
+	CountryCode string `json:"country_code"`
+	Issuer      string `json:"issuer"`
+	Prepaid     bool   `json:"prepaid"`
+	Luhn        bool   `json:"luhn"`
+}
+
+// IBANResult is the IBAN signal breakdown.
+type IBANResult struct {
+	Valid       bool   `json:"valid"`
+	CountryCode string `json:"country_code"`
+	BankCode    string `json:"bank_code"`
+	Account     string `json:"account_number"`
+}
+
+// SWIFTResult is the SWIFT signal breakdown.
+type SWIFTResult struct {
+	Valid       bool   `json:"valid"`
+	Institution string `json:"institution"`
+	Country     string `json:"country"`
+	Branch      string `json:"branch"`
+}
+
+// Consistency is the cross-instrument consistency check.
+type Consistency struct {
+	OK    bool     `json:"ok"`
+	Flags []string `json:"flags"`
+}
+
+// Result is the full payment validation response.
+type Result struct {
+	BIN         *BINResult   `json:"bin"`
+	IBAN        *IBANResult  `json:"iban"`
+	SWIFT       *SWIFTResult `json:"swift"`
+	Consistency Consistency  `json:"consistency"`
+}
+
+// Validate fans out to whichever instruments are provided and checks consistency.
+func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
+	type binOut struct {
+		r   bin.LookupResponse
+		err error
+	}
+	type ibanOut struct {
+		r   iban.ParseResponse
+		err error
+	}
+	type swiftOut struct {
+		r   swift.LookupResponse
+		err error
+	}
+
+	binCh := make(chan binOut, 1)
+	ibanCh := make(chan ibanOut, 1)
+	swiftCh := make(chan swiftOut, 1)
+
+	var wg sync.WaitGroup
+
+	if req.BIN != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := s.bin.Lookup(ctx, req.BIN)
+			binCh <- binOut{r, err}
+		}()
+	} else {
+		binCh <- binOut{}
+	}
+
+	if req.IBAN != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := s.iban.Parse(ctx, req.IBAN)
+			ibanCh <- ibanOut{r, err}
+		}()
+	} else {
+		ibanCh <- ibanOut{}
+	}
+
+	if req.SWIFT != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := s.swift.Lookup(ctx, req.SWIFT)
+			swiftCh <- swiftOut{r, err}
+		}()
+	} else {
+		swiftCh <- swiftOut{}
+	}
+
+	wg.Wait()
+
+	binResult := <-binCh
+	ibanResult := <-ibanCh
+	swiftResult := <-swiftCh
+
+	var out Result
+
+	var binCountry, ibanCountry, swiftCountry string
+	var binBankCode4, ibanBankCode string
+
+	if req.BIN != "" {
+		if binResult.err == nil {
+			out.BIN = &BINResult{
+				Valid:       true,
+				Scheme:      binResult.r.Scheme,
+				CardType:    binResult.r.CardType,
+				CardLevel:   binResult.r.CardLevel,
+				CountryCode: binResult.r.CountryCode,
+				Issuer:      binResult.r.IssuerName,
+				Prepaid:     binResult.r.Prepaid,
+				Luhn:        binResult.r.Luhn,
+			}
+			binCountry = strings.ToUpper(binResult.r.CountryCode)
+		} else {
+			out.BIN = &BINResult{Valid: false}
+		}
+	}
+
+	if req.IBAN != "" {
+		if ibanResult.err == nil {
+			out.IBAN = &IBANResult{
+				Valid:       ibanResult.r.Valid,
+				CountryCode: ibanResult.r.Country[:2],
+				BankCode:    ibanResult.r.BankCode,
+				Account:     ibanResult.r.Account,
+			}
+			ibanCountry = strings.ToUpper(ibanResult.r.IBAN[:2])
+			ibanBankCode = strings.ToUpper(ibanResult.r.BankCode)
+		} else {
+			out.IBAN = &IBANResult{Valid: false}
+		}
+	}
+
+	if req.SWIFT != "" {
+		if swiftResult.err == nil {
+			out.SWIFT = &SWIFTResult{
+				Valid:       true,
+				Institution: swiftResult.r.BankName,
+				Country:     swiftResult.r.CountryCode,
+				Branch:      swiftResult.r.City,
+			}
+			// BIC country is the 5th–6th characters of the SWIFT code (ISO alpha-2)
+			if len(swiftResult.r.SwiftCode) >= 6 {
+				swiftCountry = strings.ToUpper(swiftResult.r.SwiftCode[4:6])
+			}
+			// BIC bank code prefix = first 4 characters
+			if len(swiftResult.r.SwiftCode) >= 4 {
+				binBankCode4 = strings.ToUpper(swiftResult.r.SwiftCode[:4])
+			}
+		} else {
+			out.SWIFT = &SWIFTResult{Valid: false}
+		}
+	}
+
+	out.Consistency = checkConsistency(binCountry, ibanCountry, swiftCountry, ibanBankCode, binBankCode4)
+	return out, nil
+}
+
+// checkConsistency compares country codes and bank identifiers across all
+// provided instruments. Only runs cross-checks between instruments that were
+// actually provided and successfully resolved.
+func checkConsistency(binCC, ibanCC, swiftCC, ibanBankCode, swiftBICPrefix string) Consistency {
+	flags := make([]string, 0, 4)
+
+	if binCC != "" && ibanCC != "" && binCC != ibanCC {
+		flags = append(flags, "country_mismatch_bin_iban")
+	}
+	if binCC != "" && swiftCC != "" && binCC != swiftCC {
+		flags = append(flags, "country_mismatch_bin_swift")
+	}
+	if ibanCC != "" && swiftCC != "" && ibanCC != swiftCC {
+		flags = append(flags, "country_mismatch_iban_swift")
+	}
+	if ibanBankCode != "" && swiftBICPrefix != "" {
+		// IBAN bank code must match the first 4 chars of the SWIFT BIC.
+		if !strings.HasPrefix(strings.ToUpper(ibanBankCode), swiftBICPrefix) &&
+			!strings.HasPrefix(swiftBICPrefix, strings.ToUpper(ibanBankCode)) {
+			flags = append(flags, "bank_mismatch_iban_swift")
+		}
+	}
+
+	return Consistency{OK: len(flags) == 0, Flags: flags}
+}

--- a/apps/api/services/systems/payments/payment_validate/service.go
+++ b/apps/api/services/systems/payments/payment_validate/service.go
@@ -10,8 +10,6 @@ import (
 	"requiems-api/services/finance/swift"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type BINLooker interface {
 	Lookup(ctx context.Context, raw string) (bin.LookupResponse, error)
 }
@@ -24,28 +22,16 @@ type SWIFTLooker interface {
 	Lookup(ctx context.Context, raw string) (swift.LookupResponse, error)
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service validates one or more payment instruments and checks consistency.
 type Service struct {
 	bin   BINLooker
 	iban  IBANParser
 	swift SWIFTLooker
 }
 
-// NewService returns a new payment validate Service.
 func NewService(b BINLooker, i IBANParser, s SWIFTLooker) *Service {
 	return &Service{bin: b, iban: i, swift: s}
 }
 
-// Request is the input for POST /payment/validate.
-type Request struct {
-	BIN   string `json:"bin"`
-	IBAN  string `json:"iban"`
-	SWIFT string `json:"swift"`
-}
-
-// BINResult is the BIN signal breakdown.
 type BINResult struct {
 	Valid       bool   `json:"valid"`
 	Scheme      string `json:"scheme"`
@@ -57,7 +43,6 @@ type BINResult struct {
 	Luhn        bool   `json:"luhn"`
 }
 
-// IBANResult is the IBAN signal breakdown.
 type IBANResult struct {
 	Valid       bool   `json:"valid"`
 	CountryCode string `json:"country_code"`
@@ -65,7 +50,6 @@ type IBANResult struct {
 	Account     string `json:"account_number"`
 }
 
-// SWIFTResult is the SWIFT signal breakdown.
 type SWIFTResult struct {
 	Valid       bool   `json:"valid"`
 	Institution string `json:"institution"`
@@ -73,13 +57,11 @@ type SWIFTResult struct {
 	Branch      string `json:"branch"`
 }
 
-// Consistency is the cross-instrument consistency check.
 type Consistency struct {
 	OK    bool     `json:"ok"`
 	Flags []string `json:"flags"`
 }
 
-// Result is the full payment validation response.
 type Result struct {
 	BIN         *BINResult   `json:"bin"`
 	IBAN        *IBANResult  `json:"iban"`
@@ -87,7 +69,6 @@ type Result struct {
 	Consistency Consistency  `json:"consistency"`
 }
 
-// Validate fans out to whichever instruments are provided and checks consistency.
 func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
 	type binOut struct {
 		r   bin.LookupResponse
@@ -193,11 +174,11 @@ func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
 				Country:     swiftResult.r.CountryCode,
 				Branch:      swiftResult.r.City,
 			}
-			// BIC country is the 5th–6th characters of the SWIFT code (ISO alpha-2)
+			// BIC country is chars 5–6 of the SWIFT code (ISO alpha-2)
 			if len(swiftResult.r.SwiftCode) >= 6 {
 				swiftCountry = strings.ToUpper(swiftResult.r.SwiftCode[4:6])
 			}
-			// BIC bank code prefix = first 4 characters
+			// BIC bank prefix = first 4 chars
 			if len(swiftResult.r.SwiftCode) >= 4 {
 				binBankCode4 = strings.ToUpper(swiftResult.r.SwiftCode[:4])
 			}
@@ -210,9 +191,6 @@ func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
 	return out, nil
 }
 
-// checkConsistency compares country codes and bank identifiers across all
-// provided instruments. Only runs cross-checks between instruments that were
-// actually provided and successfully resolved.
 func checkConsistency(binCC, ibanCC, swiftCC, ibanBankCode, swiftBICPrefix string) Consistency {
 	flags := make([]string, 0, 4)
 

--- a/apps/api/services/systems/payments/payment_validate/service.go
+++ b/apps/api/services/systems/payments/payment_validate/service.go
@@ -90,34 +90,28 @@ func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
 	var wg sync.WaitGroup
 
 	if req.BIN != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r, err := s.bin.Lookup(ctx, req.BIN)
 			binCh <- binOut{r, err}
-		}()
+		})
 	} else {
 		binCh <- binOut{}
 	}
 
 	if req.IBAN != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r, err := s.iban.Parse(ctx, req.IBAN)
 			ibanCh <- ibanOut{r, err}
-		}()
+		})
 	} else {
 		ibanCh <- ibanOut{}
 	}
 
 	if req.SWIFT != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			r, err := s.swift.Lookup(ctx, req.SWIFT)
 			swiftCh <- swiftOut{r, err}
-		}()
+		})
 	} else {
 		swiftCh <- swiftOut{}
 	}

--- a/apps/api/services/systems/payments/payment_validate/service.go
+++ b/apps/api/services/systems/payments/payment_validate/service.go
@@ -147,13 +147,19 @@ func (s *Service) Validate(ctx context.Context, req Request) (Result, error) {
 
 	if req.IBAN != "" {
 		if ibanResult.err == nil {
+			var ibanCC string
+			if len(ibanResult.r.IBAN) >= 2 {
+				ibanCC = strings.ToUpper(ibanResult.r.IBAN[:2])
+			} else if len(ibanResult.r.Country) >= 2 {
+				ibanCC = strings.ToUpper(ibanResult.r.Country[:2])
+			}
 			out.IBAN = &IBANResult{
 				Valid:       ibanResult.r.Valid,
-				CountryCode: ibanResult.r.Country[:2],
+				CountryCode: ibanCC,
 				BankCode:    ibanResult.r.BankCode,
 				Account:     ibanResult.r.Account,
 			}
-			ibanCountry = strings.ToUpper(ibanResult.r.IBAN[:2])
+			ibanCountry = ibanCC
 			ibanBankCode = strings.ToUpper(ibanResult.r.BankCode)
 		} else {
 			out.IBAN = &IBANResult{Valid: false}

--- a/apps/api/services/systems/payments/payment_validate/transport_http.go
+++ b/apps/api/services/systems/payments/payment_validate/transport_http.go
@@ -14,7 +14,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/payment/validate", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
 			if req.BIN == "" && req.IBAN == "" && req.SWIFT == "" {
-				return Result{}, svcerr.Invalid("validation_failed", "at least one of bin, iban, or swift is required")
+				return Result{}, svcerr.Unknown("validation_failed", "at least one of bin, iban, or swift is required")
 			}
 			return svc.Validate(ctx, req)
 		},

--- a/apps/api/services/systems/payments/payment_validate/transport_http.go
+++ b/apps/api/services/systems/payments/payment_validate/transport_http.go
@@ -1,0 +1,22 @@
+package paymentvalidate
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
+)
+
+// RegisterRoutes mounts POST /payment/validate on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/payment/validate", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			if req.BIN == "" && req.IBAN == "" && req.SWIFT == "" {
+				return Result{}, svcerr.Invalid("validation_failed", "at least one of bin, iban, or swift is required")
+			}
+			return svc.Validate(ctx, req)
+		},
+	))
+}

--- a/apps/api/services/systems/payments/payment_validate/transport_http.go
+++ b/apps/api/services/systems/payments/payment_validate/transport_http.go
@@ -9,7 +9,12 @@ import (
 	"requiems-api/platform/svcerr"
 )
 
-// RegisterRoutes mounts POST /payment/validate on the given router.
+type Request struct {
+	BIN   string `json:"bin"`
+	IBAN  string `json:"iban"`
+	SWIFT string `json:"swift"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/payment/validate", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {

--- a/apps/api/services/systems/payments/payment_validate/transport_http_test.go
+++ b/apps/api/services/systems/payments/payment_validate/transport_http_test.go
@@ -1,0 +1,146 @@
+package paymentvalidate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/finance/bin"
+	"requiems-api/services/finance/iban"
+	"requiems-api/services/finance/swift"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubBIN struct {
+	r   bin.LookupResponse
+	err error
+}
+
+func (s *stubBIN) Lookup(_ context.Context, _ string) (bin.LookupResponse, error) {
+	return s.r, s.err
+}
+
+type stubIBAN struct {
+	r   iban.ParseResponse
+	err error
+}
+
+func (s *stubIBAN) Parse(_ context.Context, _ string) (iban.ParseResponse, error) {
+	return s.r, s.err
+}
+
+type stubSWIFT struct {
+	r   swift.LookupResponse
+	err error
+}
+
+func (s *stubSWIFT) Lookup(_ context.Context, _ string) (swift.LookupResponse, error) {
+	return s.r, s.err
+}
+
+// -- helpers -----------------------------------------------------------------
+
+func setupRouter(b *stubBIN, i *stubIBAN, s *stubSWIFT) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(b, i, s))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/payment/validate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func usBIN() bin.LookupResponse {
+	return bin.LookupResponse{
+		BIN: "424242", Scheme: "visa", CardType: "credit", CardLevel: "classic",
+		IssuerName: "Chase", CountryCode: "US", Prepaid: false, Luhn: true,
+	}
+}
+
+func gbIBAN() iban.ParseResponse {
+	return iban.ParseResponse{
+		IBAN: "GB29NWBK60161331926819", Valid: true, Country: "United Kingdom",
+		BankCode: "NWBK", Account: "31926819",
+	}
+}
+
+func gbSWIFT() swift.LookupResponse {
+	return swift.LookupResponse{
+		SwiftCode: "NWBKGB2LXXX", BankCode: "NWBK", CountryCode: "GB",
+		BankName: "NatWest", City: "London",
+	}
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestPaymentValidate_ValidBINOnly(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{r: usBIN()}, &stubIBAN{}, &stubSWIFT{})
+	w := post(t, r, `{"bin":"424242"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.NotNil(t, resp.Data.BIN)
+	assert.True(t, resp.Data.BIN.Valid)
+	assert.Nil(t, resp.Data.IBAN)
+	assert.Nil(t, resp.Data.SWIFT)
+	assert.True(t, resp.Data.Consistency.OK)
+	assert.Empty(t, resp.Data.Consistency.Flags)
+}
+
+func TestPaymentValidate_BINandIBANSameCountry(t *testing.T) {
+	t.Parallel()
+	gbBIN := bin.LookupResponse{
+		BIN: "400000", Scheme: "visa", CountryCode: "GB", Luhn: true,
+	}
+	r := setupRouter(&stubBIN{r: gbBIN}, &stubIBAN{r: gbIBAN()}, &stubSWIFT{})
+	w := post(t, r, `{"bin":"400000","iban":"GB29NWBK60161331926819"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.Consistency.OK)
+	assert.Empty(t, resp.Data.Consistency.Flags)
+}
+
+func TestPaymentValidate_BINUSandIBANGB_Mismatch(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{r: usBIN()}, &stubIBAN{r: gbIBAN()}, &stubSWIFT{})
+	w := post(t, r, `{"bin":"424242","iban":"GB29NWBK60161331926819"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.Consistency.OK)
+	assert.Contains(t, resp.Data.Consistency.Flags, "country_mismatch_bin_iban")
+}
+
+func TestPaymentValidate_AllThreeConsistent(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{r: bin.LookupResponse{BIN: "400000", CountryCode: "GB", Luhn: true}},
+		&stubIBAN{r: gbIBAN()}, &stubSWIFT{r: gbSWIFT()})
+	w := post(t, r, `{"bin":"400000","iban":"GB29NWBK60161331926819","swift":"NWBKGB2L"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.Consistency.OK)
+}
+
+func TestPaymentValidate_NoInstrumentsProvided(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{}, &stubIBAN{}, &stubSWIFT{})
+	w := post(t, r, `{}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}

--- a/apps/api/services/systems/payments/payment_validate/transport_http_test.go
+++ b/apps/api/services/systems/payments/payment_validate/transport_http_test.go
@@ -18,8 +18,6 @@ import (
 	"requiems-api/services/finance/swift"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubBIN struct {
 	r   bin.LookupResponse
 	err error
@@ -46,8 +44,6 @@ type stubSWIFT struct {
 func (s *stubSWIFT) Lookup(_ context.Context, _ string) (swift.LookupResponse, error) {
 	return s.r, s.err
 }
-
-// -- helpers -----------------------------------------------------------------
 
 func setupRouter(b *stubBIN, i *stubIBAN, s *stubSWIFT) chi.Router {
 	r := chi.NewRouter()
@@ -84,8 +80,6 @@ func gbSWIFT() swift.LookupResponse {
 		BankName: "NatWest", City: "London",
 	}
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestPaymentValidate_ValidBINOnly(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/payments/router.go
+++ b/apps/api/services/systems/payments/router.go
@@ -1,0 +1,36 @@
+package payments
+
+import (
+	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"requiems-api/services/finance/bin"
+	"requiems-api/services/finance/iban"
+	"requiems-api/services/finance/swift"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/systems/payments/payment_validate"
+	"requiems-api/services/systems/payments/transaction_risk"
+)
+
+// Deps holds the external clients needed by the payments system.
+type Deps struct {
+	Pool      *pgxpool.Pool
+	IPIClient *ipi.Client
+}
+
+// RegisterRoutes mounts all Payments Intelligence system endpoints on r.
+func RegisterRoutes(r chi.Router, deps Deps) {
+	binSvc := bin.NewService(deps.Pool)
+	ibanSvc := iban.NewService(deps.Pool)
+	swiftSvc := swift.NewService(deps.Pool)
+
+	validateSvc := paymentvalidate.NewService(binSvc, ibanSvc, swiftSvc)
+	paymentvalidate.RegisterRoutes(r, validateSvc)
+
+	vpnSvc := ipvpn.NewService(deps.IPIClient)
+	infoSvc := ipinfo.NewService(deps.IPIClient)
+	riskSvc := transactionrisk.NewService(binSvc, vpnSvc, infoSvc)
+	transactionrisk.RegisterRoutes(r, riskSvc)
+}

--- a/apps/api/services/systems/payments/router.go
+++ b/apps/api/services/systems/payments/router.go
@@ -10,8 +10,8 @@ import (
 	"requiems-api/services/finance/swift"
 	ipinfo "requiems-api/services/networking/ip/info"
 	ipvpn "requiems-api/services/networking/ip/vpn"
-	"requiems-api/services/systems/payments/payment_validate"
-	"requiems-api/services/systems/payments/transaction_risk"
+	paymentvalidate "requiems-api/services/systems/payments/payment_validate"
+	transactionrisk "requiems-api/services/systems/payments/transaction_risk"
 )
 
 // Deps holds the external clients needed by the payments system.

--- a/apps/api/services/systems/payments/router.go
+++ b/apps/api/services/systems/payments/router.go
@@ -29,8 +29,10 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	validateSvc := paymentvalidate.NewService(binSvc, ibanSvc, swiftSvc)
 	paymentvalidate.RegisterRoutes(r, validateSvc)
 
-	vpnSvc := ipvpn.NewService(deps.IPIClient)
-	infoSvc := ipinfo.NewService(deps.IPIClient)
-	riskSvc := transactionrisk.NewService(binSvc, vpnSvc, infoSvc)
-	transactionrisk.RegisterRoutes(r, riskSvc)
+	if deps.IPIClient != nil {
+		vpnSvc := ipvpn.NewService(deps.IPIClient)
+		infoSvc := ipinfo.NewService(deps.IPIClient)
+		riskSvc := transactionrisk.NewService(binSvc, vpnSvc, infoSvc)
+		transactionrisk.RegisterRoutes(r, riskSvc)
+	}
 }

--- a/apps/api/services/systems/payments/transaction_risk/service.go
+++ b/apps/api/services/systems/payments/transaction_risk/service.go
@@ -12,8 +12,6 @@ import (
 	ipvpn "requiems-api/services/networking/ip/vpn"
 )
 
-// -- Dependency interfaces ---------------------------------------------------
-
 type BINLooker interface {
 	Lookup(ctx context.Context, raw string) (bin.LookupResponse, error)
 }
@@ -26,29 +24,16 @@ type IPInfoChecker interface {
 	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
 }
 
-// -- Service -----------------------------------------------------------------
-
-// Service scores a payment transaction for fraud risk.
 type Service struct {
 	bin    BINLooker
 	vpn    VPNChecker
 	ipInfo IPInfoChecker
 }
 
-// NewService returns a new transaction risk Service.
 func NewService(b BINLooker, v VPNChecker, i IPInfoChecker) *Service {
 	return &Service{bin: b, vpn: v, ipInfo: i}
 }
 
-// Request is the input for POST /transaction/risk.
-type Request struct {
-	CardBIN        string   `json:"card_bin"    validate:"required"`
-	IPAddress      string   `json:"ip_address"  validate:"required"`
-	BillingCountry string   `json:"billing_country"`
-	AmountUSD      *float64 `json:"amount_usd"`
-}
-
-// Signals is the resolved signal breakdown returned in the response.
 type Signals struct {
 	IPCountry       string  `json:"ip_country"`
 	BillingCountry  *string `json:"billing_country"` // null when not provided
@@ -59,7 +44,6 @@ type Signals struct {
 	CountryMismatch bool    `json:"country_mismatch"`
 }
 
-// Result is the transaction risk response.
 type Result struct {
 	RiskScore float64  `json:"risk_score"`
 	IsSafe    bool     `json:"is_safe"`
@@ -67,8 +51,6 @@ type Result struct {
 	Signals   Signals  `json:"signals"`
 }
 
-// Score fans out to BIN lookup, VPN check, and IP geolocation in parallel
-// and returns the transaction risk score.
 func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 	type binOut struct {
 		r   bin.LookupResponse
@@ -141,7 +123,6 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 	proxyDetected := vpnResult.err == nil && vpnResult.r.IsProxy
 	torDetected := vpnResult.err == nil && vpnResult.r.IsTor
 
-	// Country mismatch checks.
 	countryMismatch := false
 	if billingCC != "" {
 		if ipCountry != "" && ipCountry != billingCC {
@@ -155,7 +136,6 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 			countryMismatch = true
 		}
 	} else if ipCountry != "" && binCountry != "" && ipCountry != binCountry {
-		// No billing country — compare BIN vs IP.
 		countryMismatch = true
 	}
 
@@ -163,7 +143,6 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 		flags = append(flags, "country_mismatch")
 	}
 
-	// VPN/proxy/TOR.
 	if torDetected {
 		score += 0.40
 		flags = append(flags, "tor_detected")
@@ -177,12 +156,10 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 		flags = append(flags, "vpn_detected")
 	}
 
-	// Fraud score contribution.
 	if vpnResult.err == nil {
 		score += float64(vpnResult.r.FraudScore) / 100.0 * 0.25
 	}
 
-	// High-value + VPN bonus.
 	if vpnDetected && req.AmountUSD != nil && *req.AmountUSD > 500 {
 		score += 0.15
 		flags = append(flags, "high_value_vpn")

--- a/apps/api/services/systems/payments/transaction_risk/service.go
+++ b/apps/api/services/systems/payments/transaction_risk/service.go
@@ -72,28 +72,34 @@ type riskLookups struct {
 	info infoOut
 }
 
+type networkSignals struct {
+	vpnDetected   bool
+	proxyDetected bool
+	torDetected   bool
+}
+
 func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 	lookups := s.runLookups(ctx, req)
 	countries := normalizeCountries(req, lookups)
 
-	vpnDetected, proxyDetected, torDetected := vpnSignals(lookups.vpn)
+	network := vpnSignals(lookups.vpn)
 
 	flags := make([]string, 0, 5)
 	countryScore, countryMismatch := scoreCountrySignals(countries, &flags)
-	networkScore := scoreNetworkSignals(lookups.vpn, vpnDetected, proxyDetected, torDetected, &flags)
-	score := roundRiskScore(countryScore + networkScore + scoreHighValueVPN(req, vpnDetected, &flags))
+	networkScore := scoreNetworkSignals(lookups.vpn, network, &flags)
+	score := roundRiskScore(countryScore + networkScore + scoreHighValueVPN(req, network.vpnDetected, &flags))
 
 	return Result{
 		RiskScore: score,
-		IsSafe:    score < 0.5 && !torDetected && !proxyDetected,
+		IsSafe:    score < 0.5 && !network.torDetected && !network.proxyDetected,
 		Flags:     flags,
 		Signals: Signals{
 			IPCountry:       countries.ip,
 			BillingCountry:  billingCountryPtr(req.BillingCountry),
 			BINCountry:      countries.bin,
-			VPNDetected:     vpnDetected,
-			IsProxy:         proxyDetected,
-			IsTOR:           torDetected,
+			VPNDetected:     network.vpnDetected,
+			IsProxy:         network.proxyDetected,
+			IsTOR:           network.torDetected,
 			CountryMismatch: countryMismatch,
 		},
 	}, nil
@@ -159,10 +165,12 @@ func normalizeCountries(req Request, lookups riskLookups) countries {
 	return out
 }
 
-func vpnSignals(vpnResult vpnOut) (bool, bool, bool) {
-	return vpnResult.err == nil && vpnResult.r.IsVPN,
-		vpnResult.err == nil && vpnResult.r.IsProxy,
-		vpnResult.err == nil && vpnResult.r.IsTor
+func vpnSignals(vpnResult vpnOut) networkSignals {
+	return networkSignals{
+		vpnDetected:   vpnResult.err == nil && vpnResult.r.IsVPN,
+		proxyDetected: vpnResult.err == nil && vpnResult.r.IsProxy,
+		torDetected:   vpnResult.err == nil && vpnResult.r.IsTor,
+	}
 }
 
 func scoreCountrySignals(c countries, flags *[]string) (float64, bool) {
@@ -191,21 +199,19 @@ func scoreCountrySignals(c countries, flags *[]string) (float64, bool) {
 
 func scoreNetworkSignals(
 	vpnResult vpnOut,
-	vpnDetected bool,
-	proxyDetected bool,
-	torDetected bool,
+	network networkSignals,
 	flags *[]string,
 ) float64 {
 	score := 0.0
-	if torDetected {
+	if network.torDetected {
 		score += 0.40
 		*flags = append(*flags, "tor_detected")
 	}
-	if proxyDetected {
+	if network.proxyDetected {
 		score += 0.30
 		*flags = append(*flags, "proxy_detected")
 	}
-	if vpnDetected {
+	if network.vpnDetected {
 		score += 0.20
 		*flags = append(*flags, "vpn_detected")
 	}

--- a/apps/api/services/systems/payments/transaction_risk/service.go
+++ b/apps/api/services/systems/payments/transaction_risk/service.go
@@ -1,0 +1,214 @@
+package transactionrisk
+
+import (
+	"context"
+	"math"
+	"net"
+	"strings"
+	"sync"
+
+	"requiems-api/services/finance/bin"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+)
+
+// -- Dependency interfaces ---------------------------------------------------
+
+type BINLooker interface {
+	Lookup(ctx context.Context, raw string) (bin.LookupResponse, error)
+}
+
+type VPNChecker interface {
+	CheckIP(ctx context.Context, ip net.IP) (ipvpn.IPCheckResponse, error)
+}
+
+type IPInfoChecker interface {
+	CheckInfo(ctx context.Context, ip string) (ipinfo.LookupResponse, error)
+}
+
+// -- Service -----------------------------------------------------------------
+
+// Service scores a payment transaction for fraud risk.
+type Service struct {
+	bin    BINLooker
+	vpn    VPNChecker
+	ipInfo IPInfoChecker
+}
+
+// NewService returns a new transaction risk Service.
+func NewService(b BINLooker, v VPNChecker, i IPInfoChecker) *Service {
+	return &Service{bin: b, vpn: v, ipInfo: i}
+}
+
+// Request is the input for POST /transaction/risk.
+type Request struct {
+	CardBIN        string   `json:"card_bin"    validate:"required"`
+	IPAddress      string   `json:"ip_address"  validate:"required"`
+	BillingCountry string   `json:"billing_country"`
+	AmountUSD      *float64 `json:"amount_usd"`
+}
+
+// Signals is the resolved signal breakdown returned in the response.
+type Signals struct {
+	IPCountry       string  `json:"ip_country"`
+	BillingCountry  *string `json:"billing_country"` // null when not provided
+	BINCountry      string  `json:"bin_country"`
+	VPNDetected     bool    `json:"vpn_detected"`
+	IsProxy         bool    `json:"is_proxy"`
+	IsTOR           bool    `json:"is_tor"`
+	CountryMismatch bool    `json:"country_mismatch"`
+}
+
+// Result is the transaction risk response.
+type Result struct {
+	RiskScore float64  `json:"risk_score"`
+	IsSafe    bool     `json:"is_safe"`
+	Flags     []string `json:"flags"`
+	Signals   Signals  `json:"signals"`
+}
+
+// Score fans out to BIN lookup, VPN check, and IP geolocation in parallel
+// and returns the transaction risk score.
+func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
+	type binOut struct {
+		r   bin.LookupResponse
+		err error
+	}
+	type vpnOut struct {
+		r   ipvpn.IPCheckResponse
+		err error
+	}
+	type infoOut struct {
+		r   ipinfo.LookupResponse
+		err error
+	}
+
+	binCh := make(chan binOut, 1)
+	vpnCh := make(chan vpnOut, 1)
+	infoCh := make(chan infoOut, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		r, err := s.bin.Lookup(ctx, req.CardBIN)
+		binCh <- binOut{r, err}
+	}()
+
+	parsedIP := net.ParseIP(req.IPAddress)
+	go func() {
+		defer wg.Done()
+		if parsedIP == nil {
+			vpnCh <- vpnOut{}
+			return
+		}
+		r, err := s.vpn.CheckIP(ctx, parsedIP)
+		vpnCh <- vpnOut{r, err}
+	}()
+
+	go func() {
+		defer wg.Done()
+		r, err := s.ipInfo.CheckInfo(ctx, req.IPAddress)
+		infoCh <- infoOut{r, err}
+	}()
+
+	wg.Wait()
+
+	binResult := <-binCh
+	vpnResult := <-vpnCh
+	infoResult := <-infoCh
+
+	score := 0.0
+	flags := make([]string, 0, 5)
+
+	ipCountry := ""
+	if infoResult.err == nil {
+		ipCountry = strings.ToUpper(infoResult.r.CountryCode)
+	}
+
+	binCountry := ""
+	if binResult.err == nil {
+		binCountry = strings.ToUpper(binResult.r.CountryCode)
+	}
+
+	billingCC := ""
+	if req.BillingCountry != "" {
+		billingCC = strings.ToUpper(req.BillingCountry)
+	}
+
+	vpnDetected := vpnResult.err == nil && vpnResult.r.IsVPN
+	proxyDetected := vpnResult.err == nil && vpnResult.r.IsProxy
+	torDetected := vpnResult.err == nil && vpnResult.r.IsTor
+
+	// Country mismatch checks.
+	countryMismatch := false
+	if billingCC != "" {
+		if ipCountry != "" && ipCountry != billingCC {
+			score += 0.35
+			flags = append(flags, "ip_country_mismatch")
+			countryMismatch = true
+		}
+		if binCountry != "" && binCountry != billingCC {
+			score += 0.25
+			flags = append(flags, "bin_country_mismatch")
+			countryMismatch = true
+		}
+	} else if ipCountry != "" && binCountry != "" && ipCountry != binCountry {
+		// No billing country — compare BIN vs IP.
+		countryMismatch = true
+	}
+
+	if countryMismatch {
+		flags = append(flags, "country_mismatch")
+	}
+
+	// VPN/proxy/TOR.
+	if torDetected {
+		score += 0.40
+		flags = append(flags, "tor_detected")
+	}
+	if proxyDetected {
+		score += 0.30
+		flags = append(flags, "proxy_detected")
+	}
+	if vpnDetected {
+		score += 0.20
+		flags = append(flags, "vpn_detected")
+	}
+
+	// Fraud score contribution.
+	if vpnResult.err == nil {
+		score += float64(vpnResult.r.FraudScore) / 100.0 * 0.25
+	}
+
+	// High-value + VPN bonus.
+	if vpnDetected && req.AmountUSD != nil && *req.AmountUSD > 500 {
+		score += 0.15
+		flags = append(flags, "high_value_vpn")
+	}
+
+	score = math.Min(score, 1.0)
+	score = math.Round(score*100) / 100
+
+	var billingPtr *string
+	if req.BillingCountry != "" {
+		b := strings.ToUpper(req.BillingCountry)
+		billingPtr = &b
+	}
+
+	return Result{
+		RiskScore: score,
+		IsSafe:    score < 0.5,
+		Flags:     flags,
+		Signals: Signals{
+			IPCountry:       ipCountry,
+			BillingCountry:  billingPtr,
+			BINCountry:      binCountry,
+			VPNDetected:     vpnDetected,
+			IsProxy:         proxyDetected,
+			IsTOR:           torDetected,
+			CountryMismatch: countryMismatch,
+		},
+	}, nil
+}

--- a/apps/api/services/systems/payments/transaction_risk/service.go
+++ b/apps/api/services/systems/payments/transaction_risk/service.go
@@ -199,7 +199,7 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 
 	return Result{
 		RiskScore: score,
-		IsSafe:    score < 0.5,
+		IsSafe:    score < 0.5 && !torDetected && !proxyDetected,
 		Flags:     flags,
 		Signals: Signals{
 			IPCountry:       ipCountry,

--- a/apps/api/services/systems/payments/transaction_risk/service.go
+++ b/apps/api/services/systems/payments/transaction_risk/service.go
@@ -51,20 +51,55 @@ type Result struct {
 	Signals   Signals  `json:"signals"`
 }
 
-func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
-	type binOut struct {
-		r   bin.LookupResponse
-		err error
-	}
-	type vpnOut struct {
-		r   ipvpn.IPCheckResponse
-		err error
-	}
-	type infoOut struct {
-		r   ipinfo.LookupResponse
-		err error
-	}
+type binOut struct {
+	r   bin.LookupResponse
+	err error
+}
 
+type vpnOut struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+type infoOut struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+type riskLookups struct {
+	bin  binOut
+	vpn  vpnOut
+	info infoOut
+}
+
+func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
+	lookups := s.runLookups(ctx, req)
+	countries := normalizeCountries(req, lookups)
+
+	vpnDetected, proxyDetected, torDetected := vpnSignals(lookups.vpn)
+
+	flags := make([]string, 0, 5)
+	countryScore, countryMismatch := scoreCountrySignals(countries, &flags)
+	networkScore := scoreNetworkSignals(lookups.vpn, vpnDetected, proxyDetected, torDetected, &flags)
+	score := roundRiskScore(countryScore + networkScore + scoreHighValueVPN(req, vpnDetected, &flags))
+
+	return Result{
+		RiskScore: score,
+		IsSafe:    score < 0.5 && !torDetected && !proxyDetected,
+		Flags:     flags,
+		Signals: Signals{
+			IPCountry:       countries.ip,
+			BillingCountry:  billingCountryPtr(req.BillingCountry),
+			BINCountry:      countries.bin,
+			VPNDetected:     vpnDetected,
+			IsProxy:         proxyDetected,
+			IsTOR:           torDetected,
+			CountryMismatch: countryMismatch,
+		},
+	}, nil
+}
+
+func (s *Service) runLookups(ctx context.Context, req Request) riskLookups {
 	binCh := make(chan binOut, 1)
 	vpnCh := make(chan vpnOut, 1)
 	infoCh := make(chan infoOut, 1)
@@ -97,95 +132,106 @@ func (s *Service) Score(ctx context.Context, req Request) (Result, error) {
 
 	wg.Wait()
 
-	binResult := <-binCh
-	vpnResult := <-vpnCh
-	infoResult := <-infoCh
-
-	score := 0.0
-	flags := make([]string, 0, 5)
-
-	ipCountry := ""
-	if infoResult.err == nil {
-		ipCountry = strings.ToUpper(infoResult.r.CountryCode)
+	return riskLookups{
+		bin:  <-binCh,
+		vpn:  <-vpnCh,
+		info: <-infoCh,
 	}
+}
 
-	binCountry := ""
-	if binResult.err == nil {
-		binCountry = strings.ToUpper(binResult.r.CountryCode)
+type countries struct {
+	ip      string
+	bin     string
+	billing string
+}
+
+func normalizeCountries(req Request, lookups riskLookups) countries {
+	out := countries{}
+	if lookups.info.err == nil {
+		out.ip = strings.ToUpper(lookups.info.r.CountryCode)
 	}
-
-	billingCC := ""
+	if lookups.bin.err == nil {
+		out.bin = strings.ToUpper(lookups.bin.r.CountryCode)
+	}
 	if req.BillingCountry != "" {
-		billingCC = strings.ToUpper(req.BillingCountry)
+		out.billing = strings.ToUpper(req.BillingCountry)
 	}
+	return out
+}
 
-	vpnDetected := vpnResult.err == nil && vpnResult.r.IsVPN
-	proxyDetected := vpnResult.err == nil && vpnResult.r.IsProxy
-	torDetected := vpnResult.err == nil && vpnResult.r.IsTor
+func vpnSignals(vpnResult vpnOut) (bool, bool, bool) {
+	return vpnResult.err == nil && vpnResult.r.IsVPN,
+		vpnResult.err == nil && vpnResult.r.IsProxy,
+		vpnResult.err == nil && vpnResult.r.IsTor
+}
 
+func scoreCountrySignals(c countries, flags *[]string) (float64, bool) {
+	score := 0.0
 	countryMismatch := false
-	if billingCC != "" {
-		if ipCountry != "" && ipCountry != billingCC {
+	if c.billing != "" {
+		if c.ip != "" && c.ip != c.billing {
 			score += 0.35
-			flags = append(flags, "ip_country_mismatch")
+			*flags = append(*flags, "ip_country_mismatch")
 			countryMismatch = true
 		}
-		if binCountry != "" && binCountry != billingCC {
+		if c.bin != "" && c.bin != c.billing {
 			score += 0.25
-			flags = append(flags, "bin_country_mismatch")
+			*flags = append(*flags, "bin_country_mismatch")
 			countryMismatch = true
 		}
-	} else if ipCountry != "" && binCountry != "" && ipCountry != binCountry {
+	} else if c.ip != "" && c.bin != "" && c.ip != c.bin {
 		countryMismatch = true
 	}
 
 	if countryMismatch {
-		flags = append(flags, "country_mismatch")
+		*flags = append(*flags, "country_mismatch")
 	}
+	return score, countryMismatch
+}
 
+func scoreNetworkSignals(
+	vpnResult vpnOut,
+	vpnDetected bool,
+	proxyDetected bool,
+	torDetected bool,
+	flags *[]string,
+) float64 {
+	score := 0.0
 	if torDetected {
 		score += 0.40
-		flags = append(flags, "tor_detected")
+		*flags = append(*flags, "tor_detected")
 	}
 	if proxyDetected {
 		score += 0.30
-		flags = append(flags, "proxy_detected")
+		*flags = append(*flags, "proxy_detected")
 	}
 	if vpnDetected {
 		score += 0.20
-		flags = append(flags, "vpn_detected")
+		*flags = append(*flags, "vpn_detected")
 	}
 
 	if vpnResult.err == nil {
 		score += float64(vpnResult.r.FraudScore) / 100.0 * 0.25
 	}
+	return score
+}
 
+func scoreHighValueVPN(req Request, vpnDetected bool, flags *[]string) float64 {
 	if vpnDetected && req.AmountUSD != nil && *req.AmountUSD > 500 {
-		score += 0.15
-		flags = append(flags, "high_value_vpn")
+		*flags = append(*flags, "high_value_vpn")
+		return 0.15
 	}
+	return 0
+}
 
-	score = math.Min(score, 1.0)
-	score = math.Round(score*100) / 100
+func roundRiskScore(score float64) float64 {
+	return math.Round(math.Min(score, 1.0)*100) / 100
+}
 
-	var billingPtr *string
-	if req.BillingCountry != "" {
-		b := strings.ToUpper(req.BillingCountry)
-		billingPtr = &b
+func billingCountryPtr(country string) *string {
+	if country == "" {
+		return nil
 	}
-
-	return Result{
-		RiskScore: score,
-		IsSafe:    score < 0.5 && !torDetected && !proxyDetected,
-		Flags:     flags,
-		Signals: Signals{
-			IPCountry:       ipCountry,
-			BillingCountry:  billingPtr,
-			BINCountry:      binCountry,
-			VPNDetected:     vpnDetected,
-			IsProxy:         proxyDetected,
-			IsTOR:           torDetected,
-			CountryMismatch: countryMismatch,
-		},
-	}, nil
+	normalized := strings.ToUpper(country)
+	return &normalized
 }

--- a/apps/api/services/systems/payments/transaction_risk/transport_http.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http.go
@@ -8,7 +8,13 @@ import (
 	"requiems-api/platform/httpx"
 )
 
-// RegisterRoutes mounts POST /transaction/risk on the given router.
+type Request struct {
+	CardBIN        string   `json:"card_bin"    validate:"required"`
+	IPAddress      string   `json:"ip_address"  validate:"required"`
+	BillingCountry string   `json:"billing_country"`
+	AmountUSD      *float64 `json:"amount_usd"`
+}
+
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/transaction/risk", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {

--- a/apps/api/services/systems/payments/transaction_risk/transport_http.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http.go
@@ -2,10 +2,12 @@ package transactionrisk
 
 import (
 	"context"
+	"net"
 
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/svcerr"
 )
 
 type Request struct {
@@ -18,6 +20,9 @@ type Request struct {
 func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/transaction/risk", httpx.Handle(
 		func(ctx context.Context, req Request) (Result, error) {
+			if net.ParseIP(req.IPAddress) == nil {
+				return Result{}, svcerr.Unknown("validation_failed", "invalid ip_address format")
+			}
 			return svc.Score(ctx, req)
 		},
 	))

--- a/apps/api/services/systems/payments/transaction_risk/transport_http.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http.go
@@ -1,0 +1,18 @@
+package transactionrisk
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts POST /transaction/risk on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/transaction/risk", httpx.Handle(
+		func(ctx context.Context, req Request) (Result, error) {
+			return svc.Score(ctx, req)
+		},
+	))
+}

--- a/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
@@ -124,14 +124,12 @@ func TestTransactionRisk_TORDetected(t *testing.T) {
 
 func TestTransactionRisk_HighValueVPN(t *testing.T) {
 	t.Parallel()
-	amount := 600.0
 	r := setupRouter(
 		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
 		&stubVPN{r: ipvpn.IPCheckResponse{IsVPN: true}},
 		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
 	)
 	body := `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US","amount_usd":600.0}`
-	_ = amount
 	w := post(t, r, body)
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]

--- a/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
@@ -19,8 +19,6 @@ import (
 	ipvpn "requiems-api/services/networking/ip/vpn"
 )
 
-// -- stubs -------------------------------------------------------------------
-
 type stubBIN struct {
 	r   bin.LookupResponse
 	err error
@@ -48,8 +46,6 @@ func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupRespon
 	return s.r, s.err
 }
 
-// -- helpers -----------------------------------------------------------------
-
 func setupRouter(b *stubBIN, v *stubVPN, i *stubIPInfo) chi.Router {
 	r := chi.NewRouter()
 	RegisterRoutes(r, NewService(b, v, i))
@@ -64,8 +60,6 @@ func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
 	r.ServeHTTP(w, req)
 	return w
 }
-
-// -- tests -------------------------------------------------------------------
 
 func TestTransactionRisk_CleanTransaction(t *testing.T) {
 	t.Parallel()

--- a/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
@@ -1,0 +1,174 @@
+package transactionrisk
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/platform/httpx"
+	"requiems-api/services/finance/bin"
+)
+
+// -- stubs -------------------------------------------------------------------
+
+type stubBIN struct {
+	r   bin.LookupResponse
+	err error
+}
+
+func (s *stubBIN) Lookup(_ context.Context, _ string) (bin.LookupResponse, error) {
+	return s.r, s.err
+}
+
+type stubVPN struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
+	return s.r, s.err
+}
+
+type stubIPInfo struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupResponse, error) {
+	return s.r, s.err
+}
+
+// -- helpers -----------------------------------------------------------------
+
+func setupRouter(b *stubBIN, v *stubVPN, i *stubIPInfo) chi.Router {
+	r := chi.NewRouter()
+	RegisterRoutes(r, NewService(b, v, i))
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/transaction/risk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -- tests -------------------------------------------------------------------
+
+func TestTransactionRisk_CleanTransaction(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Data.IsSafe)
+	assert.Less(t, resp.Data.RiskScore, 0.3)
+}
+
+func TestTransactionRisk_IPCountryMismatch(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "RU"}},
+	)
+	w := post(t, r, `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "country_mismatch")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.35)
+}
+
+func TestTransactionRisk_VPNDetected(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsVPN: true}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "vpn_detected")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.20)
+}
+
+func TestTransactionRisk_TORDetected(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsTor: true}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Data.IsSafe)
+	assert.Contains(t, resp.Data.Flags, "tor_detected")
+	assert.GreaterOrEqual(t, resp.Data.RiskScore, 0.40)
+}
+
+func TestTransactionRisk_HighValueVPN(t *testing.T) {
+	t.Parallel()
+	amount := 600.0
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "US"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsVPN: true}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	body := `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US","amount_usd":600.0}`
+	_ = amount
+	w := post(t, r, body)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "high_value_vpn")
+}
+
+func TestTransactionRisk_BINCountryMismatch(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(
+		&stubBIN{r: bin.LookupResponse{CountryCode: "GB"}},
+		&stubVPN{r: ipvpn.IPCheckResponse{}},
+		&stubIPInfo{r: ipinfo.LookupResponse{CountryCode: "US"}},
+	)
+	w := post(t, r, `{"card_bin":"424242","ip_address":"1.2.3.4","billing_country":"US"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp httpx.Response[Result]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.Data.Flags, "bin_country_mismatch")
+}
+
+func TestTransactionRisk_MissingCardBIN(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{"ip_address":"1.2.3.4"}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestTransactionRisk_MissingIPAddress(t *testing.T) {
+	t.Parallel()
+	r := setupRouter(&stubBIN{}, &stubVPN{}, &stubIPInfo{})
+	w := post(t, r, `{"card_bin":"424242"}`)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}

--- a/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
+++ b/apps/api/services/systems/payments/transaction_risk/transport_http_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	ipinfo "requiems-api/services/networking/ip/info"
-	ipvpn "requiems-api/services/networking/ip/vpn"
 	"requiems-api/platform/httpx"
 	"requiems-api/services/finance/bin"
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
 )
 
 // -- stubs -------------------------------------------------------------------

--- a/apps/api/services/systems/router.go
+++ b/apps/api/services/systems/router.go
@@ -1,13 +1,47 @@
 package systems
 
 import (
-	"github.com/go-chi/chi/v5"
+	"log"
 
+	"github.com/bobadilla-tech/go-ip-intelligence/v2/ipi"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
+	"requiems-api/platform/config"
 	dataintegrity "requiems-api/services/systems/data_integrity"
+	globaldata "requiems-api/services/systems/global_data"
+	identityrisk "requiems-api/services/systems/identity_risk"
+	"requiems-api/services/systems/payments"
 )
 
 // RegisterRoutes mounts all system engine routers under r.
 // r is expected to be mounted at /systems by the v1 router.
-func RegisterRoutes(r chi.Router) {
+func RegisterRoutes(r chi.Router, pool *pgxpool.Pool, rdb *redis.Client, cfg config.Config) {
 	dataintegrity.RegisterRoutes(r)
+
+	ipiClient, err := ipi.New(
+		ipi.WithDatabasePath(cfg.VPNDatabasePath),
+		ipi.WithASNDatabasePath(cfg.VPNASNDatabasePath),
+		ipi.WithCityDatabasePath(cfg.IPCityDatabasePath),
+	)
+	if err != nil {
+		log.Printf("systems: failed to initialize ip intelligence client; ip-based routes disabled: %v", err)
+	}
+
+	identityrisk.RegisterRoutes(r, identityrisk.Deps{
+		Pool:      pool,
+		IPIClient: ipiClient,
+	})
+
+	payments.RegisterRoutes(r, payments.Deps{
+		Pool:      pool,
+		IPIClient: ipiClient,
+	})
+
+	globaldata.RegisterRoutes(r, globaldata.Deps{
+		IPIClient: ipiClient,
+		Cfg:       cfg,
+		RDB:       rdb,
+	})
 }

--- a/apps/api/services/systems/router.go
+++ b/apps/api/services/systems/router.go
@@ -1,0 +1,13 @@
+package systems
+
+import (
+	"github.com/go-chi/chi/v5"
+
+	dataintegrity "requiems-api/services/systems/data_integrity"
+)
+
+// RegisterRoutes mounts all system engine routers under r.
+// r is expected to be mounted at /systems by the v1 router.
+func RegisterRoutes(r chi.Router) {
+	dataintegrity.RegisterRoutes(r)
+}

--- a/apps/api/services/technology/units/service.go
+++ b/apps/api/services/technology/units/service.go
@@ -295,4 +295,6 @@ func (s *Service) ConvertBatch(ctx context.Context, operations []BatchItem) []Ba
 }
 
 // Ptr returns a pointer to the given float64 value.
-func Ptr(v float64) *float64 { return &v }
+//
+//go:fix inline
+func Ptr(v float64) *float64 { return new(v) }

--- a/apps/api/services/technology/units/service_test.go
+++ b/apps/api/services/technology/units/service_test.go
@@ -222,17 +222,17 @@ func TestService_ConvertBatch(t *testing.T) {
 		{
 			From:  "miles",
 			To:    "km",
-			Value: Ptr(10),
+			Value: new(float64(10)),
 		},
 		{
 			From:  "kg",
 			To:    "lb",
-			Value: Ptr(5),
+			Value: new(float64(5)),
 		},
 		{
 			From:  "c",
 			To:    "g",
-			Value: Ptr(25),
+			Value: new(float64(25)),
 		},
 	}
 
@@ -252,17 +252,17 @@ func TestService_ConvertBatch_PreservedOrder(t *testing.T) {
 		{
 			From:  "miles",
 			To:    "km",
-			Value: Ptr(10),
+			Value: new(float64(10)),
 		},
 		{
 			From:  "kg",
 			To:    "lb",
-			Value: Ptr(5),
+			Value: new(float64(5)),
 		},
 		{
 			From:  "c",
 			To:    "g",
-			Value: Ptr(25),
+			Value: new(float64(25)),
 		},
 	}
 

--- a/apps/api/services/technology/units/transport_http_test.go
+++ b/apps/api/services/technology/units/transport_http_test.go
@@ -72,7 +72,7 @@ func TestUnits_BatchConvert_ExceedsLimit(t *testing.T) {
 	operations := make([]BatchItem, 51)
 
 	for i := range operations {
-		operations[i] = BatchItem{From: "miles", To: "km", Value: Ptr(10)}
+		operations[i] = BatchItem{From: "miles", To: "km", Value: new(float64(10))}
 	}
 
 	body, _ := json.Marshal(BatchRequest{

--- a/apps/api/services/text/lorem/transport_http_test.go
+++ b/apps/api/services/text/lorem/transport_http_test.go
@@ -81,7 +81,7 @@ func TestPostBatchLorem(t *testing.T) {
 
 	// Generamos un JSON con 51 ítems para probar el límite máximo que exige el RFC
 	var oversizeItems []string
-	for i := 0; i < 51; i++ {
+	for range 51 {
 		oversizeItems = append(oversizeItems, `{"paragraphs": 1}`)
 	}
 	oversizeJSON := `{"items": [` + strings.Join(oversizeItems, ",") + `]}`

--- a/apps/api/services/text/normalize/service_test.go
+++ b/apps/api/services/text/normalize/service_test.go
@@ -1,6 +1,7 @@
 package normalize
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,12 +12,7 @@ import (
 
 // containsChange reports whether target appears in the changes slice.
 func containsChange(changes []normalizer.Change, target normalizer.Change) bool {
-	for _, c := range changes {
-		if c == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(changes, target)
 }
 
 // --- Valid email tests ---

--- a/apps/api/services/text/sentiment/service.go
+++ b/apps/api/services/text/sentiment/service.go
@@ -216,7 +216,7 @@ func tokenize(text string) []string {
 		switch {
 		case unicode.IsLetter(r) || unicode.IsDigit(r):
 			buf.WriteRune(r)
-		case r == ‘\’’ || r == ‘’’:
+		case r == '\'' || r == '\u2019':
 			// skip apostrophes so contractions stay intact: "don’t" → "dont"
 			continue
 		case buf.Len() > 0:

--- a/apps/api/services/text/words/transport_http_test.go
+++ b/apps/api/services/text/words/transport_http_test.go
@@ -269,7 +269,7 @@ func TestWordsBatch_TooManyItems(t *testing.T) {
 	r := setupRouter()
 
 	items := make([]string, 51)
-	for i := 0; i < 51; i++ {
+	for i := range 51 {
 		items[i] = "ephemeral"
 	}
 

--- a/docs/design-plans/2026-05-25-global-data-engine-spec.md
+++ b/docs/design-plans/2026-05-25-global-data-engine-spec.md
@@ -172,7 +172,7 @@ GET /v1/business-calendar/DE?year=2026&month=6
 `country` — ISO 3166-1 alpha-2 (path param, required)\
 `year` — optional, defaults to current year\
 `month` — optional, defaults to current month. When provided, `working_days`
-scoped to that month. When omitted, returns full year holidays + year working
+scoped to that month. When omitted, returns full-year holidays + year working
 day total.
 
 **Response (month scope)**

--- a/docs/design-plans/2026-05-25-global-data-engine-spec.md
+++ b/docs/design-plans/2026-05-25-global-data-engine-spec.md
@@ -1,0 +1,315 @@
+# Global Data System — Engine Spec
+
+The Global Data System powers international products with accurate, real-time
+location and calendar data. It answers: where is this location, what time is it
+there, and what does the business calendar look like?
+
+**Distinct from other systems:**
+
+| Question                                                     | System                |
+| ------------------------------------------------------------ | --------------------- |
+| Is this data valid?                                          | Data Integrity        |
+| Is this user fraudulent?                                     | Identity & Risk       |
+| Is this transaction safe?                                    | Payments Intelligence |
+| Where is this, what time is it, what are the local holidays? | **Global Data**       |
+
+IP geolocation appears in both Identity & Risk and Global Data. The distinction:
+Identity & Risk uses IP to extract FRAUD signals (is this user hiding behind a
+VPN?). Global Data uses IP to extract LOCATION CONTEXT (what timezone is this
+user in?). Same underlying service (`services/networking/ip/info`), different
+output shape, different call site.
+
+---
+
+## Conventions
+
+- Base path: `/v1/`
+- Every response wrapped in
+  `{"data": {...}, "metadata": {"timestamp": "...", "trace_id": "..."}}`
+- `flags` always `string[]` of machine-readable codes
+- Timestamps in ISO 8601 / RFC 3339
+- No risk scores — this system is neutral; it returns facts, not decisions
+
+---
+
+## Endpoints
+
+### Engine: `POST /v1/location/resolve`
+
+Primary composed endpoint. Resolves any location input into a full context
+object: normalized address, coordinates, city, country, timezone, current local
+time, holiday status, and working day count for the current month.
+
+Replaces 4–5 individual API calls (geocode + timezone + world time + holidays +
+working days) and eliminates the sequential dependency chain (geocode must
+complete before timezone lookup can begin — this endpoint handles that
+internally).
+
+**Internal APIs composed:**
+
+1. Geocoding (`services/places/geocode`) — resolves `address` to coordinates
+2. Then parallel fan-out:
+   - Timezone (`services/places/timezone`) — from coordinates
+   - Holidays (`services/places/holidays`) — from country + current year
+   - Working Days (`services/places/working-days`) — current month for country
+
+**Request** — provide `address` OR `coordinates` (one required)
+
+```json
+{
+  "address": "Alexanderplatz 1, Berlin",
+  "country_code": "DE"
+}
+```
+
+```json
+{
+  "coordinates": { "lat": 52.52, "lng": 13.405 }
+}
+```
+
+`country_code` is optional when `address` is provided (geocoder infers it).
+Required for holidays/working-days fallback if geocoder cannot determine
+country.
+
+**Response**
+
+```json
+{
+  "address": "Alexanderplatz 1, 10178 Berlin, Germany",
+  "city": "Berlin",
+  "country": "Germany",
+  "country_code": "DE",
+  "coordinates": { "lat": 52.5219, "lng": 13.4132 },
+  "timezone": "Europe/Berlin",
+  "utc_offset": "+02:00",
+  "current_time": "2026-05-25T19:14:00+02:00",
+  "is_holiday_today": false,
+  "working_days_this_month": 21,
+  "next_holiday": {
+    "date": "2026-06-04",
+    "name": "Whit Thursday",
+    "type": "national"
+  }
+}
+```
+
+`next_holiday` is `null` if no upcoming holiday found within the next 90 days.
+
+**Degradation**: if geocoder fails, return 422 (cannot proceed without
+coordinates). If timezone/holidays/working-days fail, omit those fields and add
+flags: `timezone_unavailable`, `calendar_unavailable`.
+
+**Flags:** `timezone_unavailable`, `calendar_unavailable`, `country_inferred`
+(when country was inferred from geocode result, not provided explicitly)
+
+---
+
+### `GET /v1/timezone/from-ip/{ip}`
+
+Detect a user's timezone from their IP address. Two-step composition: IP
+geolocation → city/country → timezone lookup. Returns the current local time,
+offset, and DST status.
+
+**Distinct from Identity & Risk IP use**: here the IP is used for LOCATION
+ENRICHMENT only. No VPN check, no fraud score, no `is_safe` decision.
+
+**Internal APIs composed (sequential — timezone lookup needs country from
+geo):**
+
+1. IP Geolocation (`services/networking/ip/info`) — extract country, city
+2. Timezone (`services/places/timezone`) — from city/country
+
+**Request**
+
+```
+GET /v1/timezone/from-ip/203.0.113.42
+```
+
+If `{ip}` is omitted or set to `me`, falls back to caller IP (same pattern as
+`services/networking/ip/info`).
+
+**Response**
+
+```json
+{
+  "ip": "203.0.113.42",
+  "city": "Berlin",
+  "country_code": "DE",
+  "timezone": "Europe/Berlin",
+  "utc_offset": "+02:00",
+  "dst_active": true,
+  "current_time": "2026-05-25T19:14:00+02:00"
+}
+```
+
+**Error cases:**
+
+- Private/reserved IP → 422 with `private_ip` error code
+- IP not found in geolocation database → 404 with `ip_not_found`
+- Timezone resolution fails (city found but no timezone match) → return response
+  with `timezone: null`, `current_time: null`, flag `timezone_unavailable`
+
+---
+
+### `GET /v1/business-calendar/{country}`
+
+Return the business calendar for a country and time period. Combines holiday
+data with working day count so that scheduling, invoicing, and SLA systems can
+operate without building their own calendar logic per country.
+
+**Internal APIs composed (parallel):**
+
+- Holidays (`services/places/holidays`)
+- Working Days (`services/places/working-days`)
+
+**Request**
+
+```
+GET /v1/business-calendar/DE?year=2026&month=6
+```
+
+`country` — ISO 3166-1 alpha-2 (path param, required)\
+`year` — optional, defaults to current year\
+`month` — optional, defaults to current month. When provided, `working_days`
+scoped to that month. When omitted, returns full year holidays + year working
+day total.
+
+**Response (month scope)**
+
+```json
+{
+  "country_code": "DE",
+  "year": 2026,
+  "month": 6,
+  "working_days": 21,
+  "total_days": 30,
+  "weekend_days": 8,
+  "holidays": [
+    {
+      "date": "2026-06-04",
+      "name": "Whit Thursday",
+      "type": "national"
+    }
+  ],
+  "holiday_count": 1,
+  "next_holiday": {
+    "date": "2026-06-04",
+    "name": "Whit Thursday",
+    "type": "national"
+  }
+}
+```
+
+**Response (year scope — month param omitted)**
+
+```json
+{
+  "country_code": "DE",
+  "year": 2026,
+  "working_days": 252,
+  "holidays": [ ... ],
+  "holiday_count": 12,
+  "next_holiday": { ... }
+}
+```
+
+**Error cases:**
+
+- Unknown country code → 422 with `unsupported_country`
+- Year out of supported range → 422 with `year_out_of_range`
+
+---
+
+## Go package structure
+
+```
+apps/api/services/systems/
+└── global_data/
+    ├── router.go                          # mounts all sub-routers
+    ├── location_resolve/
+    │   ├── service.go                     # geocode → parallel timezone + holidays + working-days
+    │   ├── transport_http.go              # POST /v1/location/resolve
+    │   └── transport_http_test.go
+    ├── timezone_ip/
+    │   ├── service.go                     # sequential: ip/info → timezone
+    │   ├── transport_http.go              # GET /v1/timezone/from-ip/{ip}
+    │   └── transport_http_test.go
+    └── business_calendar/
+        ├── service.go                     # parallel: holidays + working-days
+        ├── transport_http.go              # GET /v1/business-calendar/{country}
+        └── transport_http_test.go
+```
+
+Note: `location_resolve/service.go` is the only endpoint in the whole system
+where composition is **sequential then parallel** (geocode must complete first
+to get coordinates, then timezone/holidays/working-days fan out). All others are
+fully parallel.
+
+---
+
+## Testing requirements
+
+### `/v1/location/resolve`
+
+| Case                                    | Expected                                                                     |
+| --------------------------------------- | ---------------------------------------------------------------------------- |
+| Valid address                           | 200, coordinates populated, timezone non-null, `working_days_this_month > 0` |
+| Valid coordinates (no address)          | 200, `address` field shows reverse-geocoded result                           |
+| Both address and coordinates provided   | Use coordinates, ignore address (coordinates are authoritative)              |
+| Address geocode fails                   | 422                                                                          |
+| Timezone resolution fails after geocode | 200, `timezone: null`, `timezone_unavailable` in flags                       |
+| Holiday lookup fails                    | 200, calendar fields null, `calendar_unavailable` in flags                   |
+| Neither address nor coordinates         | 422                                                                          |
+| All composed services stubbed           | ✓                                                                            |
+
+### `/v1/timezone/from-ip/{ip}`
+
+| Case                               | Expected                                                |
+| ---------------------------------- | ------------------------------------------------------- |
+| Valid public IP                    | 200, `timezone` non-null, `current_time` valid ISO 8601 |
+| Private IP (192.168.x.x)           | 422, `private_ip` error code                            |
+| Unknown IP                         | 404, `ip_not_found`                                     |
+| IP found, timezone fails           | 200, `timezone: null`, `timezone_unavailable` flag      |
+| No IP in path (caller IP fallback) | 200, resolved from X-Forwarded-For / RemoteAddr         |
+| All composed services stubbed      | ✓                                                       |
+
+### `/v1/business-calendar/{country}`
+
+| Case                                    | Expected                                                  |
+| --------------------------------------- | --------------------------------------------------------- |
+| Valid country + month                   | 200, `working_days > 0`, `holidays` array present         |
+| Valid country + year scope (no month)   | 200, full year `holidays`, `working_days` is annual total |
+| Country with no holidays this month     | 200, `holidays: []`, `holiday_count: 0`                   |
+| Unknown country code                    | 422, `unsupported_country`                                |
+| Missing country param                   | 422                                                       |
+| `next_holiday` when no upcoming holiday | 200, `next_holiday: null`                                 |
+| All composed services stubbed           | ✓                                                         |
+
+---
+
+## Open questions for engineer
+
+1. **Sequential composition in location/resolve** — geocode runs first, then
+   timezone/holidays/working-days fan out in parallel. Use a two-phase approach:
+   phase 1 = geocode (with timeout), phase 2 = parallel fan-out using resolved
+   country + coordinates. Clarify timeout budget: geocode gets 3s, fan-out
+   services get 2s each.
+2. **`next_holiday` lookback window** — how far ahead to scan for the next
+   holiday when returning `next_holiday`. Suggest 90 days as default. If no
+   holiday found in that window, return `null`.
+3. **Working days and month scope** — `services/places/working-days` may accept
+   date ranges differently than month/year integers. Verify the service's input
+   contract before building the business calendar wrapper.
+
+## Ticket breakdown
+
+| # | Endpoint                              | Composes                                     | Priority |
+| - | ------------------------------------- | -------------------------------------------- | -------- |
+| 1 | `GET /v1/business-calendar/{country}` | holidays + working-days                      | medium   |
+| 2 | `GET /v1/timezone/from-ip/{ip}`       | ip/info + timezone                           | medium   |
+| 3 | `POST /v1/location/resolve`           | geocode + timezone + holidays + working-days | high     |
+
+Implement in order: business-calendar first (pure parallel, no IP), then
+timezone/from-ip (sequential, adds IP), then location/resolve (most complex —
+sequential + parallel + degradation handling).

--- a/docs/design-plans/2026-05-25-identity-risk-engine-spec.md
+++ b/docs/design-plans/2026-05-25-identity-risk-engine-spec.md
@@ -1,0 +1,312 @@
+# Identity & Risk System — Engine Spec
+
+The Identity & Risk System assesses whether a user or action is trustworthy. It
+returns blocking decisions (`is_safe`) and risk scores backed by email, phone,
+IP, and domain intelligence. It is designed for real-time use at registration
+boundaries, account review workflows, and any step where a fraudulent actor
+could cause downstream harm.
+
+**Distinct from other systems:**
+
+| Question                     | System                |
+| ---------------------------- | --------------------- |
+| Is this data real and clean? | Data Integrity        |
+| Is this user trustworthy?    | **Identity & Risk**   |
+| Is this payment valid?       | Payments Intelligence |
+| Where is this user?          | Global Data           |
+
+---
+
+## Conventions
+
+- Base path: `/v1/`
+- Every response wrapped in
+  `{"data": {...}, "metadata": {"timestamp": "...", "trace_id": "..."}}`
+- `risk_score`: `0.0` (no risk) to `1.0` (certain risk)
+- `confidence`: `0.0` to `1.0` — proportion of signals present and resolved
+- `is_safe` always derived: `risk_score < 0.5 && confidence > 0.6`
+- `flags` always `string[]` of machine-readable codes, never freeform
+
+---
+
+## Endpoints
+
+### Engine: `POST /v1/signup/protect`
+
+Primary composed endpoint shown in the dashboard. Full signup gate: returns a
+single `is_safe` decision with `risk_score`, `confidence`, and a per-signal
+breakdown. Designed for real-time use at the registration boundary.
+
+One call replaces: email validation + disposable check + phone validation + IP
+geolocation + VPN detection — plus the cross-signal country consistency check
+that no individual endpoint can provide.
+
+**Internal APIs composed (all fanned out in parallel):**
+
+- Email Validator (`services/validation/email`)
+- Phone Validation (`services/validation/phone`) — only when `phone` provided
+- VPN/Proxy Detection (`services/networking/ip/vpn`) — only when `ip_address`
+  provided
+- IP Geolocation (`services/networking/ip/info`) — only when `ip_address`
+  provided
+
+All fields optional, but at least one must be present. More signals = higher
+`confidence`.
+
+**Request**
+
+```json
+{
+  "email": "user@tempmail.io",
+  "phone": "+14155552671",
+  "ip_address": "45.33.32.156"
+}
+```
+
+**Response**
+
+```json
+{
+  "risk_score": 0.87,
+  "is_safe": false,
+  "confidence": 0.94,
+  "flags": ["disposable_email", "vpn_detected"],
+  "signals": {
+    "email": {
+      "valid": true,
+      "disposable": true,
+      "mx_valid": true,
+      "suggestion": null
+    },
+    "phone": {
+      "valid": true,
+      "country": "US",
+      "is_voip": false,
+      "is_virtual": false
+    },
+    "ip": {
+      "country_code": "NL",
+      "is_vpn": true,
+      "is_proxy": false,
+      "is_tor": false,
+      "is_hosting": false,
+      "fraud_score": 0.72
+    }
+  }
+}
+```
+
+`signals.*` is `null` for any field not provided in the request.
+
+**Risk score weights (additive, cap 1.0):**
+
+| Signal                                          | Weight               |
+| ----------------------------------------------- | -------------------- |
+| Email disposable                                | +0.30                |
+| Email invalid / syntax failed                   | +0.40                |
+| Email no MX records                             | +0.25                |
+| Phone invalid                                   | +0.25                |
+| Phone VoIP or virtual                           | +0.15                |
+| IP is TOR                                       | +0.40                |
+| IP is proxy                                     | +0.25                |
+| IP is VPN                                       | +0.20                |
+| IP is hosting provider                          | +0.10                |
+| IP `fraud_score` contribution                   | `fraud_score × 0.30` |
+| Geo mismatch: email domain country ≠ IP country | +0.20                |
+| Geo mismatch: phone country ≠ IP country        | +0.10                |
+
+`confidence` = signals resolved / signals requested (3 signals requested, all
+resolved = 1.0; 1 of 3 resolved = 0.33).
+
+**Flags:** `disposable_email`, `email_invalid`, `email_no_mx`, `phone_invalid`,
+`phone_voip`, `phone_virtual`, `vpn_detected`, `proxy_detected`, `tor_detected`,
+`hosting_ip`, `geo_mismatch_email_ip`, `geo_mismatch_phone_ip`
+
+---
+
+### `POST /v1/risk/score`
+
+Lighter, faster version of `/v1/signup/protect`. Same inputs, same risk
+computation, but no per-signal breakdown in the response. Lower latency —
+suitable for background re-scoring of existing users where the detailed
+breakdown is not needed.
+
+**Request** — identical to `/v1/signup/protect`
+
+**Response**
+
+```json
+{
+  "risk_score": 0.87,
+  "is_safe": false,
+  "confidence": 0.94,
+  "flags": ["disposable_email", "vpn_detected"]
+}
+```
+
+No `signals` object. Flags and derived `is_safe` are identical to the full
+endpoint.
+
+**Internal APIs composed:** identical to `/v1/signup/protect`
+
+---
+
+### `POST /v1/user/verify`
+
+Verify an existing user's identity signals. Composes email validity with domain
+legitimacy (WHOIS + DNS + MX) to assess whether a registered email address
+belongs to a real, established domain. Optionally includes IP re-check.
+
+**Distinct from Data Integrity `/v1/domain/trust`:** that endpoint scores a
+domain in isolation for B2B email qualification. This endpoint assesses a
+specific user's identity — it combines the email address format check WITH the
+domain trust signals to return a `verified` decision at the user level, not the
+domain level.
+
+**Internal APIs composed (all fanned out in parallel):**
+
+- Email Validator (`services/validation/email`)
+- WHOIS Lookup (`services/networking/whois`)
+- Domain Info (`services/networking/domain`)
+- MX Lookup (`services/networking/mx`)
+- VPN/Proxy Detection (`services/networking/ip/vpn`) — only when `ip_address`
+  provided
+
+**Request**
+
+```json
+{
+  "email": "alice@example.com",
+  "ip_address": "203.0.113.1"
+}
+```
+
+**Response**
+
+```json
+{
+  "verified": true,
+  "confidence": 0.91,
+  "risk_score": 0.12,
+  "flags": [],
+  "signals": {
+    "email": {
+      "valid": true,
+      "disposable": false,
+      "mx_valid": true
+    },
+    "domain": {
+      "age_days": 11231,
+      "has_mx": true,
+      "has_a_records": true,
+      "available": false
+    },
+    "ip": {
+      "is_vpn": false,
+      "is_proxy": false,
+      "fraud_score": 0.04
+    }
+  }
+}
+```
+
+`verified` is derived:
+`risk_score < 0.3 && confidence > 0.5 && email.valid &&
+domain.has_mx && !domain.available`
+
+**Risk signals:**
+
+| Signal                 | Weight                       |
+| ---------------------- | ---------------------------- |
+| Email invalid          | +0.50 (floor verified=false) |
+| Email disposable       | +0.30                        |
+| Domain age < 30 days   | +0.25                        |
+| Domain age 30–180 days | +0.10                        |
+| No MX records          | +0.30                        |
+| Domain not registered  | +0.50 (floor verified=false) |
+| IP VPN/proxy/TOR       | +0.20                        |
+
+---
+
+## Go package structure
+
+```
+apps/api/services/systems/
+└── identity_risk/
+    ├── router.go                        # mounts all sub-routers
+    ├── signup_protect/
+    │   ├── service.go                   # composes email + phone + vpn + ip/info
+    │   ├── transport_http.go            # POST /v1/signup/protect
+    │   └── transport_http_test.go
+    ├── risk_score/
+    │   ├── service.go                   # same composition as signup_protect, no breakdown
+    │   ├── transport_http.go            # POST /v1/risk/score
+    │   └── transport_http_test.go
+    └── user_verify/
+        ├── service.go                   # composes email + whois + domain + mx + optional vpn
+        ├── transport_http.go            # POST /v1/user/verify
+        └── transport_http_test.go
+```
+
+`risk_score/service.go` can share the scoring logic from
+`signup_protect/service.go` via an internal package — do not duplicate the
+weight table.
+
+---
+
+## Testing requirements
+
+### `/v1/signup/protect`
+
+| Case                          | Expected                                                            |
+| ----------------------------- | ------------------------------------------------------------------- |
+| All signals clean             | 200, `is_safe: true`, `risk_score < 0.5`                            |
+| Disposable email only         | 200, `disposable_email` in flags, score ≥ 0.30                      |
+| TOR IP                        | 200, `tor_detected` in flags, `is_safe: false`, score ≥ 0.40        |
+| VoIP phone                    | 200, `phone_voip` in flags                                          |
+| Email domain ≠ IP country     | 200, `geo_mismatch_email_ip` in flags                               |
+| Only email provided           | 200, `signals.phone: null`, `signals.ip: null`, `confidence ≤ 0.34` |
+| No fields provided            | 422                                                                 |
+| All composed services stubbed | ✓                                                                   |
+
+### `/v1/risk/score`
+
+| Case                          | Expected                                |
+| ----------------------------- | --------------------------------------- |
+| Same inputs as signup/protect | 200, identical `risk_score` and `flags` |
+| Response has no `signals` key | ✓                                       |
+| No fields provided            | 422                                     |
+
+### `/v1/user/verify`
+
+| Case                            | Expected                                                       |
+| ------------------------------- | -------------------------------------------------------------- |
+| Valid email, established domain | 200, `verified: true`, `risk_score < 0.3`                      |
+| Disposable email                | 200, `disposable_email` flag, `verified: false`                |
+| New domain (< 30 days)          | 200, score elevated, `young_domain`-equivalent flag            |
+| Domain not registered           | 200, `verified: false`, high score                             |
+| WHOIS failure                   | 200, `whois_unavailable` flag, domain signals from DNS/MX only |
+| No email provided               | 422                                                            |
+
+---
+
+## Open questions for engineer
+
+1. **Shared scoring logic** — `signup_protect` and `risk_score` use identical
+   risk computation. Extract to `identity_risk/internal/scorer.go` to avoid
+   duplication. Confirm package visibility before implementing.
+2. **Geo mismatch: email domain country** — detecting country from email domain
+   requires a WHOIS lookup on the domain, which adds latency.But anyways we
+   choose what makes a better service.
+3. **IP fallback to caller IP** — No.
+
+## Ticket breakdown
+
+| # | Endpoint                  | Composes                          | Priority |
+| - | ------------------------- | --------------------------------- | -------- |
+| 1 | `POST /v1/risk/score`     | email + phone + vpn + ip/info     | medium   |
+| 2 | `POST /v1/signup/protect` | same + full signal breakdown      | high     |
+| 3 | `POST /v1/user/verify`    | email + whois + domain + mx + vpn | medium   |
+
+Implement in order: risk/score first (simpler response shape), then
+signup/protect (reuses scorer), then user/verify (different signal set).

--- a/docs/design-plans/2026-05-25-identity-risk-engine-spec.md
+++ b/docs/design-plans/2026-05-25-identity-risk-engine-spec.md
@@ -230,7 +230,7 @@ domain.has_mx && !domain.available`
 
 ## Go package structure
 
-```
+```text
 apps/api/services/systems/
 └── identity_risk/
     ├── router.go                        # mounts all sub-routers

--- a/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
+++ b/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
@@ -28,7 +28,7 @@ call sites, different questions, different outputs.
 - Every response wrapped in
   `{"data": {...}, "metadata": {"timestamp": "...", "trace_id": "..."}}`
 - `risk_score`: `0.0` (no risk) to `1.0` (certain risk)
-- `is_safe` always derived: `risk_score < 0.5`
+- `is_safe` always derived: `risk_score < 0.5 && !tor_detected && !proxy_detected`
 - `flags` always `string[]` of machine-readable codes, never freeform
 - Score 0–1, never 0–100
 

--- a/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
+++ b/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
@@ -185,7 +185,7 @@ Required: `card_bin` + `ip_address`. Optional: `billing_country`, `amount_usd`.
 
 ## Go package structure
 
-```
+```text
 apps/api/services/systems/
 └── payments/
     ├── router.go                         # mounts both sub-routers

--- a/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
+++ b/docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md
@@ -1,0 +1,256 @@
+# Payments Intelligence System — Engine Spec
+
+The Payments Intelligence System validates financial instruments and assesses
+transaction fraud risk. It answers two distinct questions: is this payment data
+structurally valid and internally consistent? And is this transaction risky at
+runtime?
+
+**Distinct from other systems:**
+
+| Question                                             | System                    |
+| ---------------------------------------------------- | ------------------------- |
+| Is this email/phone data clean?                      | Data Integrity            |
+| Is this user fraudulent?                             | Identity & Risk           |
+| Is this payment instrument valid / transaction safe? | **Payments Intelligence** |
+| Where is this user located?                          | Global Data               |
+
+IP geolocation and VPN detection appear in both Identity & Risk and Payments
+Intelligence. The distinction: Identity & Risk uses IP to assess who the USER is
+at signup. Payments Intelligence uses IP to assess whether a TRANSACTION at
+checkout is geographically consistent with the payment instrument. Different
+call sites, different questions, different outputs.
+
+---
+
+## Conventions
+
+- Base path: `/v1/`
+- Every response wrapped in
+  `{"data": {...}, "metadata": {"timestamp": "...", "trace_id": "..."}}`
+- `risk_score`: `0.0` (no risk) to `1.0` (certain risk)
+- `is_safe` always derived: `risk_score < 0.5`
+- `flags` always `string[]` of machine-readable codes, never freeform
+- Score 0–1, never 0–100
+
+---
+
+## Endpoints
+
+### Engine: `POST /v1/payment/validate`
+
+Primary composed endpoint. Validate one or more payment instruments in a single
+call and get a cross-instrument consistency check. Replaces up to three separate
+API calls (BIN, IBAN, SWIFT) and adds the country consistency layer that none of
+those endpoints can provide alone.
+
+At least one of `bin`, `iban`, `swift` must be present.
+
+**Internal APIs composed (whichever fields are provided, all parallel):**
+
+- BIN Lookup (`services/finance/bin`)
+- IBAN Validator (`services/finance/iban`)
+- SWIFT Lookup (`services/finance/swift`)
+
+**Request**
+
+```json
+{
+  "bin": "424242",
+  "iban": "GB29NWBK60161331926819",
+  "swift": "NWBKGB2L"
+}
+```
+
+**Response**
+
+```json
+{
+  "bin": {
+    "valid": true,
+    "scheme": "visa",
+    "card_type": "credit",
+    "card_level": "classic",
+    "country_code": "US",
+    "issuer": "Chase",
+    "prepaid": false,
+    "luhn": true
+  },
+  "iban": {
+    "valid": true,
+    "country_code": "GB",
+    "bank_code": "NWBK",
+    "account_number": "31926819"
+  },
+  "swift": {
+    "valid": true,
+    "institution": "NatWest",
+    "country": "GB",
+    "branch": "London"
+  },
+  "consistency": {
+    "ok": false,
+    "flags": ["country_mismatch_bin_iban"]
+  }
+}
+```
+
+Fields omitted from the request are `null` in the response. `consistency.ok` is
+`true` only when all provided instruments agree on country and bank.
+
+**Consistency flags:**
+
+| Flag                          | Condition                                                        |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `country_mismatch_bin_iban`   | BIN `country_code` ≠ IBAN `country_code`                         |
+| `country_mismatch_bin_swift`  | BIN `country_code` ≠ SWIFT `country`                             |
+| `country_mismatch_iban_swift` | IBAN `country_code` ≠ SWIFT `country`                            |
+| `bank_mismatch_iban_swift`    | IBAN `bank_code` does not match SWIFT BIC prefix (first 4 chars) |
+
+Consistency check only runs between instruments actually provided. If only `bin`
+is present, `consistency.ok: true` and `consistency.flags: []` (single
+instrument has no cross-checks to fail).
+
+---
+
+### `POST /v1/transaction/risk`
+
+Score a payment transaction for fraud risk at checkout time. Combines card
+intelligence with IP signals to detect geographic inconsistencies and known
+fraud patterns that emerge only when the instruments are seen together in
+transaction context.
+
+**Distinct from `/v1/payment/validate`:** validate checks instrument FORMAT and
+CONSISTENCY (are these instruments structurally valid and internally
+compatible?). transaction/risk checks FRAUD SIGNALS at payment execution time
+(is this checkout attempt suspicious given the IP, card origin, and billing
+country?).
+
+**Internal APIs composed (all fanned out in parallel):**
+
+- BIN Lookup (`services/finance/bin`)
+- VPN/Proxy Detection (`services/networking/ip/vpn`)
+- IP Geolocation (`services/networking/ip/info`)
+
+**Request**
+
+```json
+{
+  "card_bin": "424242",
+  "ip_address": "92.168.1.1",
+  "billing_country": "US",
+  "amount_usd": 299.0
+}
+```
+
+Required: `card_bin` + `ip_address`. Optional: `billing_country`, `amount_usd`.
+
+**Response**
+
+```json
+{
+  "risk_score": 0.71,
+  "is_safe": false,
+  "flags": ["country_mismatch", "vpn_detected"],
+  "signals": {
+    "ip_country": "RU",
+    "billing_country": "US",
+    "bin_country": "US",
+    "vpn_detected": true,
+    "is_proxy": false,
+    "is_tor": false,
+    "country_mismatch": true
+  }
+}
+```
+
+**Risk score weights (additive, cap 1.0):**
+
+| Signal                                        | Weight               |
+| --------------------------------------------- | -------------------- |
+| IP country ≠ billing_country                  | +0.35                |
+| BIN country ≠ billing_country                 | +0.25                |
+| VPN detected                                  | +0.20                |
+| Proxy detected                                | +0.30                |
+| TOR detected                                  | +0.40                |
+| IP `fraud_score` contribution                 | `fraud_score × 0.25` |
+| High-value + VPN (`amount_usd > 500` and VPN) | extra +0.15          |
+
+`country_mismatch` flag is set when IP country ≠ billing_country OR BIN country
+≠ billing_country.
+
+**Flags:** `country_mismatch`, `vpn_detected`, `proxy_detected`, `tor_detected`,
+`high_value_vpn`, `bin_country_mismatch`, `ip_country_mismatch`
+
+---
+
+## Go package structure
+
+```
+apps/api/services/systems/
+└── payments/
+    ├── router.go                         # mounts both sub-routers
+    ├── payment_validate/
+    │   ├── service.go                    # composes bin + iban + swift; consistency check
+    │   ├── transport_http.go             # POST /v1/payment/validate
+    │   └── transport_http_test.go
+    └── transaction_risk/
+        ├── service.go                    # composes bin + vpn + ip/info; risk scoring
+        ├── transport_http.go             # POST /v1/transaction/risk
+        └── transport_http_test.go
+```
+
+---
+
+## Testing requirements
+
+### `/v1/payment/validate`
+
+| Case                               | Expected                                                                    |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| Valid BIN only                     | 200, `bin.valid: true`, `iban: null`, `swift: null`, `consistency.ok: true` |
+| BIN + IBAN, same country           | 200, `consistency.ok: true`, no flags                                       |
+| BIN (US) + IBAN (GB)               | 200, `country_mismatch_bin_iban` in consistency.flags                       |
+| IBAN + SWIFT, bank code mismatch   | 200, `bank_mismatch_iban_swift` in flags                                    |
+| All three provided, all consistent | 200, `consistency.ok: true`, flags empty                                    |
+| No instruments provided            | 422                                                                         |
+| Invalid BIN format                 | 200, `bin.valid: false`, `bin.luhn: false`                                  |
+| All composed services stubbed      | ✓                                                                           |
+
+### `/v1/transaction/risk`
+
+| Case                               | Expected                                                 |
+| ---------------------------------- | -------------------------------------------------------- |
+| IP country matches billing, no VPN | 200, `is_safe: true`, `risk_score < 0.3`                 |
+| IP country ≠ billing country       | 200, `country_mismatch` flag, score ≥ 0.35               |
+| VPN detected                       | 200, `vpn_detected` flag, score ≥ 0.20                   |
+| TOR detected                       | 200, `tor_detected` flag, score ≥ 0.40, `is_safe: false` |
+| High value (> $500) + VPN          | 200, `high_value_vpn` flag, extra +0.15 on score         |
+| BIN country ≠ billing_country      | 200, `bin_country_mismatch` flag                         |
+| `card_bin` missing                 | 422                                                      |
+| `ip_address` missing               | 422                                                      |
+| All composed services stubbed      | ✓                                                        |
+
+---
+
+## Open questions for engineer
+
+1. **BIN country for consistency** — the BIN service returns `country_code` (ISO
+   2-char). SWIFT returns `country` (may be full name or ISO depending on data
+   source). Verify both fields are ISO 2-char before comparing, normalize if
+   not.
+2. **`billing_country` absent in transaction/risk** — when `billing_country` is
+   not provided, the `country_mismatch` check can only compare BIN country vs IP
+   country. Document this in the response: set `billing_country: null` in
+   signals and skip the IP-vs-billing comparison.
+3. **`fraud_score` field name** — VPN service returns `fraud_score` as integer
+   0–100. Normalize to 0.0–1.0 before applying the weight table.
+
+## Ticket breakdown
+
+| # | Endpoint                    | Composes            | Priority |
+| - | --------------------------- | ------------------- | -------- |
+| 1 | `POST /v1/payment/validate` | bin + iban + swift  | high     |
+| 2 | `POST /v1/transaction/risk` | bin + vpn + ip/info | high     |
+
+Both are high priority — they unlock the Payments Intelligence system landing
+page. Implement validate first (no IP calls, simpler), then transaction/risk.

--- a/infra/docker/readme.md
+++ b/infra/docker/readme.md
@@ -121,14 +121,14 @@ docker compose -f docker-compose.dev.yml down -v
 
 ### Accessing Services:
 
-| Service         | URL                   | Notes                                        |
-| --------------- | --------------------- | -------------------------------------------- |
-| Auth Gateway    | http://localhost:4455 | Public API entry point                       |
-| API Management  | http://localhost:5544 | Internal management service                  |
-| Rails Dashboard | http://localhost:3000 | Sign up, sign in, dashboard                  |
-| Go API          | http://localhost:8080 | Internal API (gateway → backend)             |
-| PostgreSQL      | localhost:5432        | User: `requiem`, Password: `requiem`         |
-| Redis           | localhost:6379        | For Sidekiq                                  |
+| Service         | URL                   | Notes                                         |
+| --------------- | --------------------- | --------------------------------------------- |
+| Auth Gateway    | http://localhost:4455 | Public API entry point                        |
+| API Management  | http://localhost:5544 | Internal management service                   |
+| Rails Dashboard | http://localhost:3000 | Sign up, sign in, dashboard                   |
+| Go API          | http://localhost:8080 | Internal API (gateway → backend)              |
+| PostgreSQL      | localhost:5432        | User: `requiem`, Password: `requiem`          |
+| Redis           | localhost:6379        | For Sidekiq                                   |
 | LanguageTool    | http://localhost:8010 | Spell-check backend (profile: `languagetool`) |
 
 ### Hot Reloading:


### PR DESCRIPTION
Introduces a new `/v1/systems` surface area hosting four "engine" groups of
MVP endpoints. Each group is mounted under `/v1/systems` and gated behind the
existing `EnabledServices` flag.

### New endpoints

| Method | Path | Group |
|--------|------|-------|
| `POST` | `/v1/systems/text/normalize` | Data Integrity |
| `POST` | `/v1/systems/risk/score` | Identity & Risk |
| `POST` | `/v1/systems/signup/protect` | Identity & Risk |
| `POST` | `/v1/systems/user/verify` | Identity & Risk |
| `POST` | `/v1/systems/payment/validate` | Payments Intelligence |
| `POST` | `/v1/systems/transaction/risk` | Payments Intelligence |
| `GET`  | `/v1/systems/timezone/from-ip/{ip}` | Global Data |
| `GET`  | `/v1/systems/business-calendar/{country}` | Global Data |
| `POST` | `/v1/systems/location/resolve` | Global Data |

---

## What each group does

### Data Integrity — `POST /text/normalize`
Stateless text cleanup: trim, case folding, unicode normalization (NFC/NFKC),
whitespace collapse, HTML stripping, and punctuation removal. Accepts a list of
`operations` so callers compose only what they need.

### Identity & Risk

**`POST /risk/score`** — Lightweight composite scorer. Accepts email, phone,
and/or IP address; resolves all three concurrently via the shared internal
scorer; returns `risk_score`, `is_safe`, `confidence`, and `flags`.

**`POST /signup/protect`** — Same scorer, richer response. Adds per-signal
structs (`email`, `phone`, `ip`) so the caller can surface specific risk
details in a signup flow.

**`POST /user/verify`** — Deep email verification. Runs WHOIS domain age,
dedicated MX lookup (with fallback to domain DNS MX records), domain A-record
and availability checks, and optional IP VPN/proxy check. Returns `verified`,
`confidence`, `risk_score`, `flags`, and per-signal structs.

All three share a single internal scorer package
(`services/systems/identity_risk/internal/scorer`) that resolves signals
concurrently and computes a normalised 0–1 score.

### Payments Intelligence

**`POST /payment/validate`** — Validates BIN (card), IBAN, and SWIFT codes in
parallel. Cross-checks ISO country codes and IBAN bank-code-vs-SWIFT-BIC
consistency. Returns per-instrument results plus a `consistency` block.

**`POST /transaction/risk`** — Scores transaction risk from BIN country vs IP
country vs billing country, VPN/proxy/TOR detection, fraud score, and
high-value-through-VPN heuristic. Returns `risk_score`, `is_safe`, `flags`,
and a `signals` breakdown.

### Global Data

**`GET /timezone/from-ip/{ip}`** — Resolves timezone from an IP address. Pass
`me` or omit the segment to use the caller's IP (extracted via `callerIP`
helper that handles XFF comma-lists and IPv6 `RemoteAddr`).

**`GET /business-calendar/{country}?year=&month=`** — Returns holidays and
working-day counts for a country. Optional `year` and `month` query params.

**`POST /location/resolve`** — Accepts an `address` string or `{lat, lng}`
coordinates. Geocodes/reverse-geocodes via Nominatim, then fans out to
timezone, holidays, and working-days concurrently. Returns full location
context in a single response.

---

## Design specs added

- `docs/design-plans/2026-05-25-global-data-engine-spec.md`
- `docs/design-plans/2026-05-25-identity-risk-engine-spec.md`
- `docs/design-plans/2026-05-25-payments-intelligence-engine-spec.md`

---

## Bug fixes included in this PR

### Sentinel fixes (addressed Copilot review)

| Severity | Location | Issue | Fix |
|----------|----------|-------|-----|
| **High** | `payment_validate/service.go` | `ibanResult.r.Country[:2]` panics on empty country name | Use `ibanResult.r.IBAN[:2]` (ISO prefix) instead |
| **High** | `identity_risk/router.go` + `scorer/scorer.go` | `ipvpn.NewService(nil)` returns `(*Service)(nil)`; passing as interface creates non-nil interface wrapping nil pointer → panic on IP check | Declare `vpnSvc`/`infoSvc` as `scorer.VPNChecker`/`scorer.IPInfoChecker` interface vars; assigned only when `IPIClient != nil`; scorer nil-guards both before goroutine launch |
| **High** | `payments/router.go` | Same nil-pointer propagation for `transaction_risk` | Skip `transactionrisk.RegisterRoutes` when `IPIClient == nil` |
| **High** | `global_data/router.go` | Same for `timezoneip`; also `timezone.NewService()` can return `(nil, err)` and nil propagates into service constructors | Guard `timezoneip` on `IPIClient != nil && timezoneSvc != nil`; guard `locationresolve` on `timezoneSvc != nil` |
| **High** | `location_resolve/service.go` | `ReverseGeocode` failure silently swallowed → 200 response with empty address/city/country/countryCode, downstream fanout proceeds on empty data | Return error immediately on `ReverseGeocode` failure |
| **Medium** | `timezone_ip/transport_http.go` | `X-Forwarded-For` not split on comma; `strings.Split(RemoteAddr, ":")[0]` truncates IPv6 | Replace with `callerIP` helper (XFF comma-cut + `net.SplitHostPort`); add `400` for invalid IP |
| **Medium** | `location_resolve/transport_http.go` | All `svc.Resolve` errors mapped to `upstream_error` (503), hiding geocode `not_found` (404) | Propagate `*svcerr.Error` before falling back to `upstream_error` |
| **Medium** | `user_verify/service.go` | `servicesResolved--` followed immediately by `servicesResolved++` is a no-op — WHOIS failures don't reduce confidence | Remove the `servicesResolved++` |
| **Medium** | `user_verify/service.go` | `hasMX` computed only from dedicated MX lookup; if that fails but `domainResult.r.DNS.MX` has records, domain is incorrectly flagged `no_mx` | `hasMX = (mxResult ok && records > 0) \|\| len(domainResult.r.DNS.MX) > 0` |
| **Medium** | `geocode/service.go` + `location_resolve/service.go` | `Result.Country` and `Result.CountryCode` both assigned from `geocode.*.Country` (ISO code) — duplicated fields, wrong semantics | Add `Country string \`json:"country"\`` to `nominatimAddress`; add `CountryName string` to `GeocodeResponse`/`ReverseGeocodeResponse`; `location_resolve` now sets `country = CountryName`, `country_code = Country` |
| **Medium** | `payments-intelligence-engine-spec.md` | Spec said `is_safe` derived as `risk_score < 0.5`; implementation (and `scorer.go`) uses stricter `score < 0.5 && !torDetected && !proxyDetected` | Update spec to match implementation |
| **Low** | `business_calendar/transport_http.go` | `context.WithValue(r.Context(), struct{}{}, nil)` — anonymous key is unretrievable, value is nil; effectively a no-op | Replace with `r.Context()` |
| **Low** | `transaction_risk/transport_http_test.go` | `amount := 600.0` declared then immediately discarded with `_ = amount` | Remove dead variable |

### Other fixes

- `text/sentiment/service.go` — apostrophe rune (`'`) handling in tokenizer was broken; now correctly recognized
- `infra/docker/readme.md` — "Accessing Services" markdown table reformatted

---

## Architecture notes

### IP intelligence degradation
The IPI client (VPN/ASN/city databases) is initialized once at startup. If the
database files are missing or corrupt, `ipi.New()` returns an error. In that
case all IP-dependent routes (`/risk/score`, `/signup/protect`, `/user/verify`,
`/transaction/risk`, `/timezone/from-ip`) are either skipped at registration
time or degrade gracefully: IP signals are omitted from scoring, confidence
reflects the reduced signal count.

### Shared scorer
`risk_score`, `signup_protect`, and `user_verify` all use the same internal
`scorer.Resolve` + `scorer.Compute` pipeline. The scorer accepts nil
`VPNChecker`/`IPInfoChecker` interfaces and skips IP goroutines when they are
nil, so email-only and phone-only requests work correctly even without the IPI
client.

### Geocode `country` vs `country_code`
Nominatim returns both a `country_code` (ISO alpha-2) and a `country` (full
name) in its address block. The geocode service previously captured only the
code and put it in the `Country` field. This PR adds `nominatimAddress.Country`
(full name) and a corresponding `CountryName` field on both response types.
`location_resolve` now correctly separates `country` (human-readable) from
`country_code` (ISO alpha-2).

---

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./services/systems/...` — all pass
- [x] `go test ./services/places/geocode/...` — all pass (CountryName is additive, no regressions)
- [ ] Deploy to staging, call `/v1/systems/risk/score` with and without `ip_address`
- [ ] Test `GET /v1/systems/timezone/from-ip/me` from behind a proxy (verify XFF handling)
- [ ] Confirm IP-based routes return 503/404 (not panic) when IPI databases are absent
- [ ] Confirm `POST /v1/systems/location/resolve` with coordinates returns `not_found` (not 200 with empty body) when Nominatim has no result
