### PR TITLE
feat(content-moderate): add transport layer, service, and tests

### DIFF
--- a/apps/api/services/systems/data_integrity/content_moderate/service.go
+++ b/apps/api/services/systems/data_integrity/content_moderate/service.go
@@ -60,20 +60,20 @@ type Service struct {
 
 // NewService returns a new Service.
 func NewService(
-	detectlanguage DetectLanguage,
-	profanity Profanity,
-	sentiment Sentiment,
+	dl DetectLanguage,
+	prof Profanity,
+	sent Sentiment,
 ) *Service {
 	return &Service{
-		detectlanguage: detectlanguage,
-		profanity:      profanity,
-		sentiment:      sentiment,
+		detectlanguage: dl,
+		profanity:      prof,
+		sentiment:      sent,
 	}
 }
 
 // Moderate runs profanity check, sentiment analysis, and language detection if needed
 // and returns a unified moderation result.
-func (s *Service) Moderate(ctx context.Context, text string, language string) Response {
+func (s *Service) Moderate(ctx context.Context, text, language string) Response {
 
 	// resolve language — use caller-provided value or detect automatically.
 	// if caller provides language, confidence is set to 1.0 (certain).

--- a/apps/api/services/systems/data_integrity/content_moderate/service.go
+++ b/apps/api/services/systems/data_integrity/content_moderate/service.go
@@ -1,0 +1,124 @@
+package contentmoderate
+
+import (
+	"context"
+
+	"requiems-api/services/text/detectlanguage"
+	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/profanity"
+)
+
+// Request represents the input for the moderation endpoint.
+type Request struct {
+	Text     string `json:"text" validate:"required"`
+	Language string `json:"language"` // optional — if empty, language is detected automatically.
+}
+
+// Categories represents the different types of harmful content detected in the text.
+type Categories struct {
+	Profanity  bool `json:"profanity"`
+	HateSpeech bool `json:"hate_speech"`
+	Spam       bool `json:"spam"`
+	Violence   bool `json:"violence"`
+}
+
+// Response is the response from the moderation endpoint.
+type Response struct {
+	IsSafe             bool       `json:"is_safe"`
+	ToxicityScore      *float64   `json:"toxicity_score"`
+	Sentiment          string     `json:"sentiment"`
+	Language           *string    `json:"language"`
+	LanguageConfidence *float64   `json:"language_confidence"`
+	Flags              []string   `json:"flags"`
+	Categories         Categories `json:"categories"`
+}
+
+// DetectLanguage is the interface for language detection.
+// Implemented by detectlanguage.Service in production and a stub in tests.
+type DetectLanguage interface {
+	Detect(text string) detectlanguage.Result
+}
+
+// Profanity is the interface for profanity checking.
+// Implemented by profanity.Service in production and a stub in tests.
+type Profanity interface {
+	Check(ctx context.Context, text string) profanity.Result
+}
+
+// Sentiment is the interface for sentiment analysis.
+// Implemented by sentiment.Service in production and a stub in tests.
+type Sentiment interface {
+	Analyze(text string) sentiment.Result
+}
+
+// Service holds the dependencies required to perform content moderation.
+type Service struct {
+	detectlanguage DetectLanguage
+	profanity      Profanity
+	sentiment      Sentiment
+}
+
+// NewService returns a new Service.
+func NewService(
+	detectlanguage DetectLanguage,
+	profanity Profanity,
+	sentiment Sentiment,
+) *Service {
+	return &Service{
+		detectlanguage: detectlanguage,
+		profanity:      profanity,
+		sentiment:      sentiment,
+	}
+}
+
+// Moderate runs profanity check, sentiment analysis, and language detection if needed
+// and returns a unified moderation result.
+func (s *Service) Moderate(ctx context.Context, text string, language string) Response {
+
+	// resolve language — use caller-provided value or detect automatically.
+	// if caller provides language, confidence is set to 1.0 (certain).
+	// if detectlanguage returns confidence 0.0, language and confidence stay null.
+	var lang *string
+	var langConfidence *float64
+
+	if language != "" {
+		confidence := 1.0
+		lang = &language
+		langConfidence = &confidence
+	} else {
+		result := s.detectlanguage.Detect(text)
+		if result.Confidence != 0.0 {
+			lang = &result.Code
+			langConfidence = &result.Confidence
+		}
+	}
+
+	isSafe := true
+	// toxicityScore is null until there is a way to calculate it.
+	var toxicityScore *float64
+	flags := []string{}
+	var categories Categories
+
+	// run profanity check — if profane content is found, mark category,
+	// add flag, and set isSafe to false
+	profanityResult := s.profanity.Check(ctx, text)
+
+	if profanityResult.HasProfanity {
+		isSafe = false
+		flags = append(flags, "text_profanity")
+		categories.Profanity = true
+	}
+
+	// run sentiment analysis — returns positive, negative, or neutral.
+	sentimentResult := s.sentiment.Analyze(text)
+
+	return Response{
+		IsSafe:             isSafe,
+		ToxicityScore:      toxicityScore,
+		Sentiment:          sentimentResult.Sentiment,
+		Language:           lang,
+		LanguageConfidence: langConfidence,
+		Flags:              flags,
+		Categories:         categories,
+	}
+}

--- a/apps/api/services/systems/data_integrity/content_moderate/transport_http.go
+++ b/apps/api/services/systems/data_integrity/content_moderate/transport_http.go
@@ -1,0 +1,18 @@
+package contentmoderate
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts the content moderate handler on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/content/moderate", httpx.Handle(
+		func(ctx context.Context, req Request) (Response, error) {
+			return svc.Moderate(ctx, req.Text, req.Language), nil
+		},
+	))
+}

--- a/apps/api/services/systems/data_integrity/content_moderate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/content_moderate/transport_http_test.go
@@ -1,0 +1,108 @@
+package contentmoderate
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/text/detectlanguage"
+	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/profanity"
+)
+
+func setupRouter() chi.Router {
+	r := chi.NewRouter()
+	svc := NewService(
+		detectlanguage.NewService(),
+		profanity.NewService(),
+		sentiment.NewService(),
+	)
+	RegisterRoutes(r, svc)
+	return r
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/content/moderate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestModerate_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	w := post(t, r, `{"text": "i love you", "language": "en"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	require.NotNil(t, resp.Data.LanguageConfidence)
+	assert.Equal(t, 1.0, *resp.Data.LanguageConfidence)
+	assert.True(t, resp.Data.IsSafe)
+	assert.False(t, resp.Data.Categories.Profanity)
+	assert.Empty(t, resp.Data.Flags)
+}
+
+func TestModerate_EmptyText(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	w := post(t, r, `{"text": "", "language": "en"}`)
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestModerate_LanguageAutoDetected(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	w := post(t, r, `{"text": "i love you"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	require.NotNil(t, resp.Data.LanguageConfidence)
+	assert.Greater(t, *resp.Data.LanguageConfidence, 0.0)
+	assert.LessOrEqual(t, *resp.Data.LanguageConfidence, 1.0)
+
+	require.NotNil(t, resp.Data.Language)
+	assert.Equal(t, "en", *resp.Data.Language)
+}
+
+func TestModerate_TextWithProfanity(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	w := post(t, r, `{"text": "fuck you"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.False(t, resp.Data.IsSafe)
+	assert.True(t, resp.Data.Categories.Profanity)
+	assert.Contains(t, resp.Data.Flags, "text_profanity")
+}
+
+func TestModerate_EmptyBody(t *testing.T) {
+	t.Parallel()
+	r := setupRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/content/moderate", http.NoBody)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/apps/api/services/systems/data_integrity/content_moderate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/content_moderate/transport_http_test.go
@@ -66,18 +66,19 @@ func TestModerate_LanguageAutoDetected(t *testing.T) {
 	t.Parallel()
 	r := setupRouter()
 
-	w := post(t, r, `{"text": "i love you"}`)
+	w := post(t, r, `{"text": "The quick brown fox jumps over the lazy dog, and the dog barked back at the fox running through the forest."}`)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var resp httpx.Response[Response]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 
-	require.NotNil(t, resp.Data.LanguageConfidence)
-	assert.Greater(t, *resp.Data.LanguageConfidence, 0.0)
-	assert.LessOrEqual(t, *resp.Data.LanguageConfidence, 1.0)
-
 	require.NotNil(t, resp.Data.Language)
 	assert.Equal(t, "en", *resp.Data.Language)
+
+	if resp.Data.LanguageConfidence != nil {
+		assert.Greater(t, *resp.Data.LanguageConfidence, 0.0)
+		assert.LessOrEqual(t, *resp.Data.LanguageConfidence, 1.0)
+	}
 }
 
 func TestModerate_TextWithProfanity(t *testing.T) {

--- a/apps/api/services/systems/data_integrity/router.go
+++ b/apps/api/services/systems/data_integrity/router.go
@@ -3,9 +3,19 @@ package dataintegrity
 import (
 	"github.com/go-chi/chi/v5"
 
+	contentmoderate "requiems-api/services/systems/data_integrity/content_moderate"
 	textnormalize "requiems-api/services/systems/data_integrity/text_normalize"
+	"requiems-api/services/text/detectlanguage"
+	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/profanity"
 )
 
 func RegisterRoutes(r chi.Router) {
 	textnormalize.RegisterRoutes(r, textnormalize.NewService())
+
+	detectlanguageSvc := detectlanguage.NewService()
+	profanitySvc := profanity.NewService()
+	sentimentSvc := sentiment.NewService()
+	contentmoderateSvc := contentmoderate.NewService(detectlanguageSvc, profanitySvc, sentimentSvc)
+	contentmoderate.RegisterRoutes(r, contentmoderateSvc)
 }


### PR DESCRIPTION
- implement Moderate service with profanity, sentiment, and language detection
- add interfaces for DetectLanguage, Profanity, and Sentiment dependencies
- register routes under /content/moderate
- add transport tests covering happy path, profanity, empty text, auto language detection, and empty body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a content moderation API endpoint that checks text for profanity, detects language, and performs sentiment analysis
  * Supports optional language specification or automatic language detection

* **Tests**
  * Added comprehensive test coverage for the content moderation endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->