### PR TITLE
Feat/domain trust endpoint

### DIFF
--- a/apps/api/platform/middleware/urlparam.go
+++ b/apps/api/platform/middleware/urlparam.go
@@ -17,7 +17,7 @@ func ValidateURLParam(paramName string, pattern *regexp.Regexp, errorMsg string)
 			paramVal := chi.URLParam(r, paramName)
 
 			if !pattern.MatchString(paramVal) {
-				httpx.Error(w, http.StatusUnprocessableEntity, "validation_error", errorMsg)
+				httpx.Error(w, http.StatusUnprocessableEntity, "validation_failed", errorMsg)
 				return
 			}
 

--- a/apps/api/platform/middleware/urlparam.go
+++ b/apps/api/platform/middleware/urlparam.go
@@ -17,7 +17,7 @@ func ValidateURLParam(paramName string, pattern *regexp.Regexp, errorMsg string)
 			paramVal := chi.URLParam(r, paramName)
 
 			if !pattern.MatchString(paramVal) {
-				httpx.Error(w, http.StatusBadRequest, "bad_request", errorMsg)
+				httpx.Error(w, http.StatusUnprocessableEntity, "validation_error", errorMsg)
 				return
 			}
 

--- a/apps/api/platform/middleware/urlparam_test.go
+++ b/apps/api/platform/middleware/urlparam_test.go
@@ -38,7 +38,7 @@ func TestValidateURLParam(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
-	t.Run("invalid param returns 400", func(t *testing.T) {
+	t.Run("invalid param returns 422", func(t *testing.T) {
 		t.Parallel()
 
 		req := httptest.NewRequest(http.MethodGet, "/bad-param!", http.NoBody)
@@ -46,6 +46,6 @@ func TestValidateURLParam(t *testing.T) {
 
 		setupRouter().ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 	})
 }

--- a/apps/api/services/networking/domain/transport_http_test.go
+++ b/apps/api/services/networking/domain/transport_http_test.go
@@ -42,7 +42,7 @@ func TestDomain_InvalidFormat(t *testing.T) {
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
-			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 		})
 	}
 }

--- a/apps/api/services/networking/whois/transport_http_test.go
+++ b/apps/api/services/networking/whois/transport_http_test.go
@@ -105,7 +105,7 @@ func TestWhois_InvalidDomainFormat(t *testing.T) {
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
-			assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for %q, got %d: %s", tt.domain, w.Code, w.Body.String())
+			assert.Equal(t, http.StatusUnprocessableEntity, w.Code, "expected 422 for %q, got %d: %s", tt.domain, w.Code, w.Body.String())
 		})
 	}
 }

--- a/apps/api/services/systems/data_integrity/domain_trust/service.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/service.go
@@ -19,9 +19,9 @@ type WhoIs struct {
 	Status    []string `json:"status"`
 }
 
-// Dns holds the result of the DNS health check for a domain.
+// DNS holds the result of the DNS health check for a domain.
 // Used to determine whether the domain is operational and resolves correctly.
-type Dns struct {
+type DNS struct {
 	HasARecords  bool `json:"has_a_records"`
 	HasMxRecords bool `json:"has_mx_records"`
 	HasNsRecords bool `json:"has_ns_records"`
@@ -42,7 +42,7 @@ type Response struct {
 	TrustScore float64     `json:"trust_score"`
 	TrustLevel string      `json:"trust_level"`
 	WhoIs      *WhoIs      `json:"who_is,omitempty"`
-	Dns        Dns         `json:"dns"`
+	Dns        DNS         `json:"dns"`
 	MxRecords  []MxRecords `json:"mx_records"`
 	Flags      []string    `json:"flags"`
 }
@@ -64,27 +64,27 @@ type Service struct {
 }
 
 // NewService returns a new Service.
-func NewService(whois WhoIsService, domain DomainService) *Service {
+func NewService(whoIsSvc WhoIsService, domainSvc DomainService) *Service {
 	return &Service{
-		whoIs:  whois,
-		domain: domain,
+		whoIs:  whoIsSvc,
+		domain: domainSvc,
 	}
 }
 
 // Evaluate analyzes a domain and returns a trust assessment based on DNS, WHOIS,
 // and MX record data. The trust score starts at 1.0 and is reduced by penalties
 // depending on the issues found during evaluation.
-func (s *Service) Evaluate(ctx context.Context, domain string) Response {
+func (s *Service) Evaluate(ctx context.Context, domainName string) Response {
 
 	// initialize response with default values.
 	var result Response
-	result.Domain = domain
+	result.Domain = domainName
 	result.TrustScore = 1.0
 	result.Flags = []string{}
 	result.MxRecords = []MxRecords{}
 
 	// fetch DNS and availability info for the domain.
-	domainResult := s.domain.GetInfo(ctx, domain)
+	domainResult := s.domain.GetInfo(ctx, domainName)
 
 	result.Dns.Available = domainResult.Available
 
@@ -128,7 +128,7 @@ func (s *Service) Evaluate(ctx context.Context, domain string) Response {
 	}
 
 	// fetch WHOIS registration data for the domain.
-	whoisResult, whoisErr := s.whoIs.Lookup(ctx, domain)
+	whoisResult, whoisErr := s.whoIs.Lookup(ctx, domainName)
 
 	// if WHOIS lookup fails, flag it and skip all WHOIS-based evaluations.
 	if whoisErr != nil {

--- a/apps/api/services/systems/data_integrity/domain_trust/service.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/service.go
@@ -42,7 +42,7 @@ type Response struct {
 	TrustScore float64     `json:"trust_score"`
 	TrustLevel string      `json:"trust_level"`
 	WhoIs      *WhoIs      `json:"who_is,omitempty"`
-	Dns        DNS         `json:"dns"`
+	DNS        DNS         `json:"dns"`
 	MxRecords  []MxRecords `json:"mx_records"`
 	Flags      []string    `json:"flags"`
 }
@@ -86,7 +86,7 @@ func (s *Service) Evaluate(ctx context.Context, domainName string) Response {
 	// fetch DNS and availability info for the domain.
 	domainResult := s.domain.GetInfo(ctx, domainName)
 
-	result.Dns.Available = domainResult.Available
+	result.DNS.Available = domainResult.Available
 
 	// if the domain is not registered, return immediately with a zero trust score.
 	if domainResult.Available {
@@ -101,7 +101,7 @@ func (s *Service) Evaluate(ctx context.Context, domainName string) Response {
 		result.TrustScore -= 0.2
 		result.Flags = append(result.Flags, "no_a_records")
 	} else {
-		result.Dns.HasARecords = true
+		result.DNS.HasARecords = true
 	}
 
 	// penalize if no MX records are found — domain cannot receive emails.
@@ -109,7 +109,7 @@ func (s *Service) Evaluate(ctx context.Context, domainName string) Response {
 		result.TrustScore -= 0.35
 		result.Flags = append(result.Flags, "no_mx")
 	} else {
-		result.Dns.HasMxRecords = true
+		result.DNS.HasMxRecords = true
 
 		// map each MX record to the response structure.
 		for _, mx := range domainResult.DNS.MX {
@@ -124,7 +124,7 @@ func (s *Service) Evaluate(ctx context.Context, domainName string) Response {
 	if len(domainResult.DNS.NS) == 0 {
 		result.Flags = append(result.Flags, "no_ns_records")
 	} else {
-		result.Dns.HasNsRecords = true
+		result.DNS.HasNsRecords = true
 	}
 
 	// fetch WHOIS registration data for the domain.

--- a/apps/api/services/systems/data_integrity/domain_trust/service.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/service.go
@@ -1,0 +1,200 @@
+package domaintrust
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"requiems-api/services/networking/domain"
+	"requiems-api/services/networking/whois"
+)
+
+// WhoIs holds registration metadata for a domain retrieved from WHOIS lookup.
+// This field may be omitted from the response if WHOIS is unavailable for TLD.
+type WhoIs struct {
+	Registrar string   `json:"registrar"`
+	CreatedAt string   `json:"created_at"`
+	ExpiresAt string   `json:"expires_at"`
+	AgeDays   int      `json:"age_days"`
+	Status    []string `json:"status"`
+}
+
+// Dns holds the result of the DNS health check for a domain.
+// Used to determine whether the domain is operational and resolves correctly.
+type Dns struct {
+	HasARecords  bool `json:"has_a_records"`
+	HasMxRecords bool `json:"has_mx_records"`
+	HasNsRecords bool `json:"has_ns_records"`
+	Available    bool `json:"available"`
+}
+
+// MxRecords represents a single mail exchange record for the domain.
+// Multiple MX records may be present, each with a different priority.
+type MxRecords struct {
+	HostName string `json:"host_name"`
+	Priority uint16 `json:"priority"`
+}
+
+// Response is the top-level structure returned by GET /v1/domain/trust/{domain}.
+// It composes results from the WHOIS, DNS, and MX services into a single trust assessment.
+type Response struct {
+	Domain     string      `json:"domain"`
+	TrustScore float64     `json:"trust_score"`
+	TrustLevel string      `json:"trust_level"`
+	WhoIs      *WhoIs      `json:"who_is,omitempty"`
+	Dns        Dns         `json:"dns"`
+	MxRecords  []MxRecords `json:"mx_records"`
+	Flags      []string    `json:"flags"`
+}
+
+// WhoIsService defines the contract for retrieving WHOIS registration data for a domain.
+type WhoIsService interface {
+	Lookup(_ context.Context, domain string) (whois.LookupResponse, error)
+}
+
+// DomainService defines the contract for retrieving DNS information for a domain.
+type DomainService interface {
+	GetInfo(ctx context.Context, domainName string) domain.InfoResponse
+}
+
+// Service evaluates domains.
+type Service struct {
+	whoIs  WhoIsService
+	domain DomainService
+}
+
+// NewService returns a new Service.
+func NewService(whois WhoIsService, domain DomainService) *Service {
+	return &Service{
+		whoIs:  whois,
+		domain: domain,
+	}
+}
+
+// Evaluate analyzes a domain and returns a trust assessment based on DNS, WHOIS,
+// and MX record data. The trust score starts at 1.0 and is reduced by penalties
+// depending on the issues found during evaluation.
+func (s *Service) Evaluate(ctx context.Context, domain string) Response {
+
+	// initialize response with default values.
+	var result Response
+	result.Domain = domain
+	result.TrustScore = 1.0
+	result.Flags = []string{}
+	result.MxRecords = []MxRecords{}
+
+	// fetch DNS and availability info for the domain.
+	domainResult := s.domain.GetInfo(ctx, domain)
+
+	result.Dns.Available = domainResult.Available
+
+	// if the domain is not registered, return immediately with a zero trust score.
+	if domainResult.Available {
+		result.TrustScore = 0.0
+		result.TrustLevel = "low"
+		result.Flags = append(result.Flags, "domain_not_registered")
+		return result
+	}
+
+	// penalize if no A records are found — domain may not resolve to any server.
+	if len(domainResult.DNS.A) == 0 {
+		result.TrustScore -= 0.2
+		result.Flags = append(result.Flags, "no_a_records")
+	} else {
+		result.Dns.HasARecords = true
+	}
+
+	// penalize if no MX records are found — domain cannot receive emails.
+	if len(domainResult.DNS.MX) == 0 {
+		result.TrustScore -= 0.35
+		result.Flags = append(result.Flags, "no_mx")
+	} else {
+		result.Dns.HasMxRecords = true
+
+		// map each MX record to the response structure.
+		for _, mx := range domainResult.DNS.MX {
+			result.MxRecords = append(result.MxRecords, MxRecords{
+				HostName: mx.Host,
+				Priority: mx.Priority,
+			})
+		}
+	}
+
+	// flag if no NS records are found — domain may lack proper nameserver delegation.
+	if len(domainResult.DNS.NS) == 0 {
+		result.Flags = append(result.Flags, "no_ns_records")
+	} else {
+		result.Dns.HasNsRecords = true
+	}
+
+	// fetch WHOIS registration data for the domain.
+	whoisResult, whoisErr := s.whoIs.Lookup(ctx, domain)
+
+	// if WHOIS lookup fails, flag it and skip all WHOIS-based evaluations.
+	if whoisErr != nil {
+		result.Flags = append(result.Flags, "whois_unavailable")
+	} else {
+		// populate WHOIS metadata from the lookup result.
+		result.WhoIs = &WhoIs{}
+		result.WhoIs.Registrar = whoisResult.Registrar
+		result.WhoIs.CreatedAt = whoisResult.CreatedDate
+		result.WhoIs.ExpiresAt = whoisResult.ExpiryDate
+
+		expiresAt, expiresErr := time.Parse(time.RFC3339, whoisResult.ExpiryDate)
+
+		// penalize if the domain is expiring within 14 days.
+		if expiresErr == nil {
+			if daysUntilExpiry(expiresAt) < 14 {
+				result.TrustScore -= 0.15
+				result.Flags = append(result.Flags, "expiring_soon")
+			}
+		}
+
+		// calculate domain age and apply penalties based on how long it has been registered.
+		// if an error occurs, neither age calculation nor penalties are applied.
+		createdAt, err := time.Parse(time.RFC3339, whoisResult.CreatedDate)
+		if err == nil {
+			result.WhoIs.AgeDays = ageDays(createdAt)
+
+			// heavily penalize very new domains (under 30 days) — high risk of being fraudulent.
+			if result.WhoIs.AgeDays < 30 {
+				result.TrustScore -= 0.5
+				result.Flags = append(result.Flags, "new_domain")
+			}
+
+			// moderately penalize young domains (30–180 days) — still building trust.
+			if result.WhoIs.AgeDays >= 30 && result.WhoIs.AgeDays <= 180 {
+				result.TrustScore -= 0.25
+				result.Flags = append(result.Flags, "young_domain")
+			}
+		}
+
+		result.WhoIs.Status = whoisResult.Status
+	}
+
+	// ensure trust score never goes below zero.
+	result.TrustScore = math.Max(result.TrustScore, 0.0)
+
+	// assign a human-readable trust level based on the final score.
+	switch {
+	case result.TrustScore >= 0.75:
+		result.TrustLevel = "high"
+	case result.TrustScore >= 0.4:
+		result.TrustLevel = "medium"
+	default:
+		result.TrustLevel = "low"
+
+	}
+
+	return result
+}
+
+// ageDays returns the number of days elapsed since the domain was created.
+func ageDays(createdAt time.Time) int {
+	return int(time.Since(createdAt).Hours() / 24)
+}
+
+// daysUntilExpiry returns the number of days remaining until the domain expires.
+func daysUntilExpiry(expiresAt time.Time) int {
+	return int(time.Until(expiresAt).Hours() / 24)
+}

--- a/apps/api/services/systems/data_integrity/domain_trust/transport_http.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/transport_http.go
@@ -1,0 +1,32 @@
+package domaintrust
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/platform/middleware"
+)
+
+type EvaluateService interface {
+	Evaluate(ctx context.Context, domain string) Response
+}
+
+// domainRe accepts standard hostnames such as "example.com" or "sub.example.co.uk".
+// Each label is 1–63 chars (alphanumeric or hyphens, not starting/ending with a
+// hyphen), and there must be at least one dot separating the labels.
+var domainRe = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+
+func RegisterRoutes(r chi.Router, svc EvaluateService) {
+	r.Group(func(validated chi.Router) {
+		validated.Use(middleware.ValidateURLParam("domain", domainRe, "invalid domain: must be a valid hostname such as example.com"))
+
+		validated.Get("/domain/trust/{domain}", func(w http.ResponseWriter, r *http.Request) {
+			d := chi.URLParam(r, "domain")
+			httpx.JSON(w, http.StatusOK, svc.Evaluate(r.Context(), d))
+		})
+	})
+}

--- a/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
@@ -50,9 +50,9 @@ type mockWhoIsService struct {
 	expiryDate  string
 }
 
-func (m *mockWhoIsService) Lookup(_ context.Context, domain string) (whois.LookupResponse, error) {
+func (m *mockWhoIsService) Lookup(_ context.Context, domainName string) (whois.LookupResponse, error) {
 	return whois.LookupResponse{
-		Domain:      domain,
+		Domain:      domainName,
 		Registrar:   "Mock Registrar",
 		NameServers: []string{"ns1.example.com", "ns2.example.com"},
 		Status:      []string{"clientTransferProhibited"},
@@ -63,10 +63,10 @@ func (m *mockWhoIsService) Lookup(_ context.Context, domain string) (whois.Looku
 	}, nil
 }
 
-func Get(t *testing.T, r chi.Router, domain string) *httptest.ResponseRecorder {
+func Get(t *testing.T, r chi.Router, domainName string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodGet, "/domain/trust/"+domain, http.NoBody)
+	req := httptest.NewRequest(http.MethodGet, "/domain/trust/"+domainName, http.NoBody)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
@@ -168,5 +168,5 @@ func TestDomainTrust_InvalidFormat(t *testing.T) {
 	r := setupRouter(&mockWhoIsService{}, &mockDomainService{})
 	w := Get(t, r, "not_a_valid_domain")
 
-	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }

--- a/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/domain_trust/transport_http_test.go
@@ -1,0 +1,172 @@
+package domaintrust
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/networking/domain"
+	"requiems-api/services/networking/whois"
+)
+
+func setupRouter(whoIsSvc WhoIsService, domainSvc DomainService) chi.Router {
+	r := chi.NewRouter()
+	svc := NewService(whoIsSvc, domainSvc)
+	RegisterRoutes(r, svc)
+	return r
+}
+
+type mockDomainService struct {
+	available bool
+	noMx      bool
+}
+
+func (m *mockDomainService) GetInfo(ctx context.Context, domainName string) domain.InfoResponse {
+	mx := []domain.MXRecord{{Host: "mail.example.com", Priority: 10}}
+	if m.noMx {
+		mx = []domain.MXRecord{}
+	}
+
+	return domain.InfoResponse{
+		Available: m.available,
+		DNS: domain.DNSRecords{
+			A:  []string{"1.2.3.4"},
+			MX: mx,
+			NS: []string{"ns1.example.com"},
+		},
+	}
+}
+
+type mockWhoIsService struct {
+	createdDate string
+	expiryDate  string
+}
+
+func (m *mockWhoIsService) Lookup(_ context.Context, domain string) (whois.LookupResponse, error) {
+	return whois.LookupResponse{
+		Domain:      domain,
+		Registrar:   "Mock Registrar",
+		NameServers: []string{"ns1.example.com", "ns2.example.com"},
+		Status:      []string{"clientTransferProhibited"},
+		CreatedDate: m.createdDate,
+		UpdatedDate: m.createdDate,
+		ExpiryDate:  m.expiryDate,
+		DNSSec:      false,
+	}, nil
+}
+
+func Get(t *testing.T, r chi.Router, domain string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/domain/trust/"+domain, http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestDomainTrust_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	whoIsSvc := whois.NewService()
+	domainSvc := domain.NewService()
+
+	r := setupRouter(whoIsSvc, domainSvc)
+
+	w := Get(t, r, "google.com")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "high", resp.Data.TrustLevel)
+	assert.Empty(t, resp.Data.Flags)
+
+}
+
+func TestDomainTrust_AgeDomain(t *testing.T) {
+	t.Parallel()
+
+	mockDomain := &mockDomainService{available: false}
+
+	// new domain
+	mockWhoIs := &mockWhoIsService{
+		createdDate: time.Now().AddDate(0, 0, -10).Format(time.RFC3339), // 10 días
+		expiryDate:  time.Now().AddDate(1, 0, 0).Format(time.RFC3339),
+	}
+
+	r := setupRouter(mockWhoIs, mockDomain)
+
+	w := Get(t, r, "newdomain.com")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp.Data.Flags, "new_domain")
+	assert.LessOrEqual(t, resp.Data.TrustScore, 0.5)
+	assert.Equal(t, "medium", resp.Data.TrustLevel)
+
+}
+
+func TestDomainTrust_NoMX(t *testing.T) {
+	t.Parallel()
+
+	mockDomain := &mockDomainService{
+		available: false,
+		noMx:      true,
+	}
+	mockWhoIs := &mockWhoIsService{
+		createdDate: time.Now().AddDate(-2, 0, 0).Format(time.RFC3339),
+		expiryDate:  time.Now().AddDate(1, 0, 0).Format(time.RFC3339),
+	}
+
+	r := setupRouter(mockWhoIs, mockDomain)
+	w := Get(t, r, "nomx.com")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Contains(t, resp.Data.Flags, "no_mx")
+	assert.LessOrEqual(t, resp.Data.TrustScore, 0.65)
+	assert.Empty(t, resp.Data.MxRecords)
+}
+
+func TestDomainTrust_NotRegistered(t *testing.T) {
+	t.Parallel()
+
+	mockDomain := &mockDomainService{available: true}
+	mockWhoIs := &mockWhoIsService{}
+
+	r := setupRouter(mockWhoIs, mockDomain)
+	w := Get(t, r, "notregistered.com")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Contains(t, resp.Data.Flags, "domain_not_registered")
+	assert.Equal(t, 0.0, resp.Data.TrustScore)
+	assert.Equal(t, "low", resp.Data.TrustLevel)
+}
+
+func TestDomainTrust_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter(&mockWhoIsService{}, &mockDomainService{})
+	w := Get(t, r, "not_a_valid_domain")
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/apps/api/services/systems/data_integrity/router.go
+++ b/apps/api/services/systems/data_integrity/router.go
@@ -3,7 +3,10 @@ package dataintegrity
 import (
 	"github.com/go-chi/chi/v5"
 
+	"requiems-api/services/networking/domain"
+	"requiems-api/services/networking/whois"
 	contentmoderate "requiems-api/services/systems/data_integrity/content_moderate"
+	domaintrust "requiems-api/services/systems/data_integrity/domain_trust"
 	textnormalize "requiems-api/services/systems/data_integrity/text_normalize"
 	"requiems-api/services/text/detectlanguage"
 	"requiems-api/services/text/sentiment"
@@ -18,4 +21,9 @@ func RegisterRoutes(r chi.Router) {
 	sentimentSvc := sentiment.NewService()
 	contentmoderateSvc := contentmoderate.NewService(detectlanguageSvc, profanitySvc, sentimentSvc)
 	contentmoderate.RegisterRoutes(r, contentmoderateSvc)
+
+	domainSvc := domain.NewService()
+	whoIsSvc := whois.NewService()
+	domainTrustSvc := domaintrust.NewService(whoIsSvc, domainSvc)
+	domaintrust.RegisterRoutes(r, domainTrustSvc)
 }

--- a/apps/api/services/technology/counter/handler_test.go
+++ b/apps/api/services/technology/counter/handler_test.go
@@ -63,7 +63,7 @@ func TestIncrementHandler(t *testing.T) {
 		assert.Equal(t, int64(5), got.Value)
 	})
 
-	t.Run("returns 400 for invalid namespace from URL param validation", func(t *testing.T) {
+	t.Run("returns 422 for invalid namespace from URL param validation", func(t *testing.T) {
 		t.Parallel()
 		svc := &mockService{
 			incrementFn: func(_ context.Context, ns string) (int64, error) {
@@ -76,7 +76,7 @@ func TestIncrementHandler(t *testing.T) {
 
 		newTestRouter(svc).ServeHTTP(w, req)
 
-		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, http.StatusUnprocessableEntity, w.Code)
 	})
 
 	t.Run("returns 500 for internal server error", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestGetHandler(t *testing.T) {
 		assert.Equal(t, int64(42), got.Value)
 	})
 
-	t.Run("returns 400 for invalid namespace from URL param validation", func(t *testing.T) {
+	t.Run("returns 422 for invalid namespace from URL param validation", func(t *testing.T) {
 		t.Parallel()
 		svc := &mockService{
 			getFn: func(_ context.Context, ns string) (int64, error) {
@@ -135,7 +135,7 @@ func TestGetHandler(t *testing.T) {
 
 		newTestRouter(svc).ServeHTTP(w, req)
 
-		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Equal(t, http.StatusUnprocessableEntity, w.Code)
 	})
 
 	t.Run("returns 500 for internal server error", func(t *testing.T) {

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -335,7 +335,7 @@ endpoints:
         description: Mail server priority. Lower value means higher priority.
       - name: flags
         type: array
-        description: List of signal flags raised during evaluation. Possible values are "new_domain", "young_domain", "no_mx", "no_a_records", "expiring_soon", "whois_unavailable", "domain_not_registered". Only "domain_not_registered" is returned when the domain is not registered.
+        description: List of signal flags raised during evaluation. Possible values are "new_domain", "young_domain", "no_mx", "no_a_records", "no_ns_records", "expiring_soon", "whois_unavailable", "domain_not_registered". Only "domain_not_registered" is returned when the domain is not registered.
     errors:
       - code: bad_request
         status: 400

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -235,6 +235,169 @@ endpoints:
         data = JSON.parse(response.body)['data']
         puts data['normalized']  # hello, world!
 
+  - name: Domain Trust
+    method: GET
+    path: /v1/systems/domain/trust/{domain}
+    description: Evaluate the trustworthiness of a domain by analyzing DNS records, WHOIS registration data, and MX configuration — in a single call.
+    parameters:
+      - name: domain
+        type: string
+        required: true
+        location: path
+        description: The domain name to evaluate for trust. Must be a valid domain format (e.g. github.com).
+        example: "github.com"
+    response_example: |
+      {
+        "data": {
+          "domain": "github.com",
+          "trust_score": 1,
+          "trust_level": "high",
+          "who_is": {
+            "registrar": "MarkMonitor Inc.",
+            "created_at": "2007-10-09T18:20:50Z",
+            "expires_at": "2026-10-09T18:20:50Z",
+            "age_days": 6814,
+            "status": [
+              "clientDeleteProhibited",
+              "clientTransferProhibited",
+              "clientUpdateProhibited"
+            ]
+          },
+          "dns": {
+            "has_a_records": true,
+            "has_mx_records": true,
+            "has_ns_records": true,
+            "available": false
+          },
+          "mx_records": [
+            {
+              "host_name": "github-com.mail.protection.outlook.com.",
+              "priority": 0
+            }
+          ],
+          "flags": []
+        },
+        "metadata": {
+          "timestamp": "2026-06-05T21:01:18Z"
+        }
+      }
+    response_fields:
+      - name: domain
+        type: string
+        description: The domain name that was evaluated.
+      - name: trust_score
+        type: float
+        description: Computed trust score between 0.0 and 1.0. Starts at 1.0 with penalties applied based on domain signals.
+      - name: trust_level
+        type: string
+        description: Coarse trust label derived from the score. Possible values are "high" (>= 0.75), "medium" (0.4 - 0.74), or "low" (< 0.4).
+      - name: who_is
+        type: object
+        description: WHOIS registration data for the domain. Omitted from the response if WHOIS is unavailable for the TLD or if the domain is not registered.
+      - name: who_is.registrar
+        type: string
+        description: The registrar where the domain was registered.
+      - name: who_is.created_at
+        type: string
+        description: The date the domain was first registered in RFC3339 format.
+      - name: who_is.expires_at
+        type: string
+        description: The date the domain registration expires in RFC3339 format.
+      - name: who_is.age_days
+        type: integer
+        description: Number of days since the domain was registered.
+      - name: who_is.status
+        type: array
+        description: WHOIS status codes indicating the domain transfer and update permissions.
+      - name: dns
+        type: object
+        description: DNS health check results for the domain. Fields default to false if the domain is not registered.
+      - name: dns.has_a_records
+        type: boolean
+        description: True if the domain has at least one A record pointing to an IP address.
+      - name: dns.has_mx_records
+        type: boolean
+        description: True if the domain has MX records configured for receiving email.
+      - name: dns.has_ns_records
+        type: boolean
+        description: True if the domain has NS records indicating it is delegated to a nameserver.
+      - name: dns.available
+        type: boolean
+        description: True if the domain is unregistered and available for purchase. When true, trust_score is 0.0 and evaluation stops immediately.
+      - name: mx_records
+        type: array
+        description: List of MX records found for the domain. Empty array if none exist or if the domain is not registered.
+      - name: mx_records[].host_name
+        type: string
+        description: The hostname of the mail server.
+      - name: mx_records[].priority
+        type: integer
+        description: Mail server priority. Lower value means higher priority.
+      - name: flags
+        type: array
+        description: List of signal flags raised during evaluation. Possible values are "new_domain", "young_domain", "no_mx", "no_a_records", "expiring_soon", "whois_unavailable", "domain_not_registered". Only "domain_not_registered" is returned when the domain is not registered.
+    errors:
+      - code: bad_request
+        status: 400
+        description: Invalid or malformed domain value in the request path.  
+    code_examples:
+      curl: |
+        curl -X GET https://api.requiems.xyz/v1/systems/domain/trust/github.com \
+          -H "requiems-api-key: YOUR_API_KEY"
+      python: |
+        import requests
+
+        response = requests.get(
+          "https://api.requiems.xyz/v1/systems/domain/trust/github.com",
+          headers={"requiems-api-key": "YOUR_API_KEY"}
+        )
+        data = response.json()["data"]
+
+        print(f"Domain: {data['domain']}")
+        print(f"Trust Score: {data['trust_score']} ({data['trust_level']})")
+
+        if data["flags"]:
+          print("Flags:", data["flags"])
+        else:
+          print("No issues found.")
+
+        if data["who_is"]:
+          print(f"Registrar: {data['who_is']['registrar']}")
+          print(f"Age: {data['who_is']['age_days']} days")
+      javascript: |
+        const { data } = await fetch('https://api.requiems.xyz/v1/systems/domain/trust/github.com', {
+          headers: { 'requiems-api-key': 'YOUR_API_KEY' }
+        }).then(r => r.json());
+
+        console.log(`Domain: ${data.domain}`);
+        console.log(`Trust Score: ${data.trust_score} (${data.trust_level})`);
+
+        if (data.flags.length > 0) {
+          console.warn('Flags:', data.flags);
+        } else {
+          console.log('No issues found.');
+        }
+
+        if (data.who_is) {
+          console.log(`Registrar: ${data.who_is.registrar}`);
+          console.log(`Age: ${data.who_is.age_days} days`);
+        }
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/systems/domain/trust/github.com')
+        request = Net::HTTP::Get.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |h| h.request(request) }
+        data = JSON.parse(response.body)['data']
+
+        puts "Domain: #{data['domain']}"
+        puts "Trust Score: #{data['trust_score']} (#{data['trust_level']})"
+        puts data['flags'].empty? ? "No issues found." : "Flags: #{data['flags'].inspect}"
+        puts "Registrar: #{data['who_is']['registrar']}, Age: #{data['who_is']['age_days']} days" if data['who_is']
+
 performance:
   p50_ms: 18
   p95_ms: 52


### PR DESCRIPTION
## Endpoint

- Adds `GET /v1/domain/trust/{domain}` that returns a single trust assessment by composing WHOIS and DNS services
- Runs `DomainService.GetInfo` first — if the domain is unregistered, returns immediately with `trust_score: 0.0` and stops evaluation
- Penalizes missing A records (`-0.2`), missing MX records (`-0.35`), new domain under 30 days (`-0.5`), young domain 30–180 days (`-0.25`), and expiry within 14 days (`-0.15`)
- Trust score starts at `1.0`, floors at `0.0`, and maps to `high` (>= 0.75), `medium` (0.4–0.74), or `low` (< 0.4)
- WHOIS unavailability is treated as a data gap — adds `whois_unavailable` flag instead of failing the request

## Tests

- Add handler tests for happy path, new domain, no MX records, unregistered domain, and invalid format
- Happy path runs against real services using `google.com`
- Remaining cases use mocked WHOIS and DNS services for deterministic results

## Docs

- Add endpoint documentation covering request parameters, response fields, trust score penalties, and flag descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Domain Trust evaluation API that returns a trust score, trust level, WHOIS/DNS/MX details, and evaluation flags for a given domain.

* **Tests**
  * Added HTTP tests covering happy path, age-related scoring, missing MX, unregistered domains, and invalid domain format.

* **Documentation**
  * Added API docs for the Domain Trust endpoint with request/response schema and multi-language code examples.

* **Bug Fixes**
  * Validation of domain path parameters now responds with HTTP 422 for malformed input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->