### PR TITLE
feat: implement base64 batch

### DIFF
--- a/apps/api/services/technology/base64/service.go
+++ b/apps/api/services/technology/base64/service.go
@@ -53,42 +53,23 @@ type BatchRequest struct {
 	Variant string   `json:"variant" validate:"omitempty,oneof=standard url"`
 }
 
-// BatchResult is the response for batch operations.
-type BatchResult struct {
-	Results []string `json:"results"`
-	Total   int      `json:"total"`
-}
-
-func (s *Service) EncodeBatch(values []string, variant string) BatchResult {
-	results := make([]string, len(values))
-
+func (s *Service) EncodeBatch(values []string, variant string) []Result {
+	results := make([]Result, len(values))
 	for i, value := range values {
-		results[i] = s.Encode(value, variant).Result
+		results[i] = s.Encode(value, variant)
 	}
-
-	return BatchResult{
-		Results: results,
-		Total:   len(results),
-	}
+	return results
 }
 
-func (s *Service) DecodeBatch(values []string, variant string) BatchResult {
-	results := make([]string, len(values))
-
+func (s *Service) DecodeBatch(values []string, variant string) []Result {
+	results := make([]Result, len(values))
 	for i, value := range values {
 		res, err := s.Decode(value, variant)
-
-		// Partial success per batch API standard.
 		if err != nil {
-			results[i] = ""
+			results[i] = Result{}
 			continue
 		}
-
-		results[i] = res.Result
+		results[i] = res
 	}
-
-	return BatchResult{
-		Results: results,
-		Total:   len(results),
-	}
+	return results
 }

--- a/apps/api/services/technology/base64/service.go
+++ b/apps/api/services/technology/base64/service.go
@@ -47,3 +47,48 @@ func (s *Service) Decode(value, variant string) (Result, error) {
 
 	return Result{Result: string(decoded)}, nil
 }
+
+type BatchRequest struct {
+	Values  []string `json:"values" validate:"required,min=1,max=50,dive,required"`
+	Variant string   `json:"variant" validate:"omitempty,oneof=standard url"`
+}
+
+// BatchResult is the response for batch operations.
+type BatchResult struct {
+	Results []string `json:"results"`
+	Total   int      `json:"total"`
+}
+
+func (s *Service) EncodeBatch(values []string, variant string) BatchResult {
+	results := make([]string, len(values))
+
+	for i, value := range values {
+		results[i] = s.Encode(value, variant).Result
+	}
+
+	return BatchResult{
+		Results: results,
+		Total:   len(results),
+	}
+}
+
+func (s *Service) DecodeBatch(values []string, variant string) BatchResult {
+	results := make([]string, len(values))
+
+	for i, value := range values {
+		res, err := s.Decode(value, variant)
+
+		// Partial success per batch API standard.
+		if err != nil {
+			results[i] = ""
+			continue
+		}
+
+		results[i] = res.Result
+	}
+
+	return BatchResult{
+		Results: results,
+		Total:   len(results),
+	}
+}

--- a/apps/api/services/technology/base64/service_test.go
+++ b/apps/api/services/technology/base64/service_test.go
@@ -139,28 +139,23 @@ func TestService_EncodeBatch(t *testing.T) {
 		name    string
 		values  []string
 		variant string
-		want    []string
+		want    []Result
 	}{
 		{
 			name:   "standard encoding",
 			values: []string{"Hello", "World"},
-			want: []string{
-				"SGVsbG8=",
-				"V29ybGQ=",
-			},
+			want:   []Result{{Result: "SGVsbG8="}, {Result: "V29ybGQ="}},
 		},
 		{
 			name:    "url encoding",
 			values:  []string{"\xfb\xff\xfe"},
 			variant: "url",
-			want: []string{
-				"-__-",
-			},
+			want:    []Result{{Result: "-__-"}},
 		},
 		{
 			name:   "empty batch",
 			values: []string{},
-			want:   []string{},
+			want:   []Result{},
 		},
 	}
 
@@ -172,8 +167,7 @@ func TestService_EncodeBatch(t *testing.T) {
 
 			got := svc.EncodeBatch(tt.values, tt.variant)
 
-			assert.Equal(t, tt.want, got.Results)
-			assert.Equal(t, len(tt.want), got.Total)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -187,26 +181,18 @@ func TestService_DecodeBatch(t *testing.T) {
 		name    string
 		values  []string
 		variant string
-		want    []string
+		want    []Result
 	}{
 		{
-			name: "standard decoding",
-			values: []string{
-				"SGVsbG8=",
-				"V29ybGQ=",
-			},
-			want: []string{
-				"Hello",
-				"World",
-			},
+			name:   "standard decoding",
+			values: []string{"SGVsbG8=", "V29ybGQ="},
+			want:   []Result{{Result: "Hello"}, {Result: "World"}},
 		},
 		{
 			name:    "url decoding",
 			values:  []string{"-__-"},
 			variant: "url",
-			want: []string{
-				"\xfb\xff\xfe",
-			},
+			want:    []Result{{Result: "\xfb\xff\xfe"}},
 		},
 		{
 			name: "partial failure",
@@ -215,16 +201,12 @@ func TestService_DecodeBatch(t *testing.T) {
 				"not-valid-base64!!!",
 				"V29ybGQ=",
 			},
-			want: []string{
-				"Hello",
-				"",
-				"World",
-			},
+			want: []Result{{Result: "Hello"}, {Result: ""}, {Result: "World"}},
 		},
 		{
 			name:   "empty batch",
 			values: []string{},
-			want:   []string{},
+			want:   []Result{},
 		},
 	}
 
@@ -236,27 +218,7 @@ func TestService_DecodeBatch(t *testing.T) {
 
 			got := svc.DecodeBatch(tt.values, tt.variant)
 
-			assert.Equal(t, tt.want, got.Results)
-			assert.Equal(t, len(tt.want), got.Total)
+			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-func TestService_DecodeBatch_PartialFailure(t *testing.T) {
-	t.Parallel()
-
-	svc := NewService()
-
-	got := svc.DecodeBatch([]string{
-		"SGVsbG8=",
-		"not-valid-base64!!!",
-		"V29ybGQ=",
-	}, "")
-
-	assert.Equal(t, []string{
-		"Hello",
-		"",
-		"World",
-	}, got.Results)
-
-	assert.Equal(t, 3, got.Total)
 }

--- a/apps/api/services/technology/base64/service_test.go
+++ b/apps/api/services/technology/base64/service_test.go
@@ -129,3 +129,134 @@ func TestService_Decode(t *testing.T) {
 		})
 	}
 }
+
+func TestService_EncodeBatch(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+
+	tests := []struct {
+		name    string
+		values  []string
+		variant string
+		want    []string
+	}{
+		{
+			name:   "standard encoding",
+			values: []string{"Hello", "World"},
+			want: []string{
+				"SGVsbG8=",
+				"V29ybGQ=",
+			},
+		},
+		{
+			name:    "url encoding",
+			values:  []string{"\xfb\xff\xfe"},
+			variant: "url",
+			want: []string{
+				"-__-",
+			},
+		},
+		{
+			name:   "empty batch",
+			values: []string{},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := svc.EncodeBatch(tt.values, tt.variant)
+
+			assert.Equal(t, tt.want, got.Results)
+			assert.Equal(t, len(tt.want), got.Total)
+		})
+	}
+}
+
+func TestService_DecodeBatch(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+
+	tests := []struct {
+		name    string
+		values  []string
+		variant string
+		want    []string
+	}{
+		{
+			name: "standard decoding",
+			values: []string{
+				"SGVsbG8=",
+				"V29ybGQ=",
+			},
+			want: []string{
+				"Hello",
+				"World",
+			},
+		},
+		{
+			name:    "url decoding",
+			values:  []string{"-__-"},
+			variant: "url",
+			want: []string{
+				"\xfb\xff\xfe",
+			},
+		},
+		{
+			name: "partial failure",
+			values: []string{
+				"SGVsbG8=",
+				"not-valid-base64!!!",
+				"V29ybGQ=",
+			},
+			want: []string{
+				"Hello",
+				"",
+				"World",
+			},
+		},
+		{
+			name:   "empty batch",
+			values: []string{},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := svc.DecodeBatch(tt.values, tt.variant)
+
+			assert.Equal(t, tt.want, got.Results)
+			assert.Equal(t, len(tt.want), got.Total)
+		})
+	}
+}
+func TestService_DecodeBatch_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService()
+
+	got := svc.DecodeBatch([]string{
+		"SGVsbG8=",
+		"not-valid-base64!!!",
+		"V29ybGQ=",
+	}, "")
+
+	assert.Equal(t, []string{
+		"Hello",
+		"",
+		"World",
+	}, got.Results)
+
+	assert.Equal(t, 3, got.Total)
+}

--- a/apps/api/services/technology/base64/transport_http.go
+++ b/apps/api/services/technology/base64/transport_http.go
@@ -34,4 +34,38 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 			return svc.Decode(req.Value, req.Variant)
 		},
 	))
+	r.Post("/base64/encode/batch", httpx.HandleBatch(
+		func(_ context.Context, req BatchRequest) (httpx.BatchResponse[Result], error) {
+			results := make([]Result, len(req.Values))
+
+			for i, value := range req.Values {
+				results[i] = svc.Encode(value, req.Variant)
+			}
+
+			return httpx.BatchResponse[Result]{
+				Results: results,
+			}, nil
+		},
+	))
+
+	r.Post("/base64/decode/batch", httpx.HandleBatch(
+		func(_ context.Context, req BatchRequest) (httpx.BatchResponse[Result], error) {
+			results := make([]Result, len(req.Values))
+
+			for i, value := range req.Values {
+				res, err := svc.Decode(value, req.Variant)
+
+				if err != nil {
+					results[i] = Result{}
+					continue
+				}
+
+				results[i] = res
+			}
+
+			return httpx.BatchResponse[Result]{
+				Results: results,
+			}, nil
+		},
+	))
 }

--- a/apps/api/services/technology/base64/transport_http.go
+++ b/apps/api/services/technology/base64/transport_http.go
@@ -36,36 +36,13 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	))
 	r.Post("/base64/encode/batch", httpx.HandleBatch(
 		func(_ context.Context, req BatchRequest) (httpx.BatchResponse[Result], error) {
-			results := make([]Result, len(req.Values))
-
-			for i, value := range req.Values {
-				results[i] = svc.Encode(value, req.Variant)
-			}
-
-			return httpx.BatchResponse[Result]{
-				Results: results,
-			}, nil
+			return httpx.BatchResponse[Result]{Results: svc.EncodeBatch(req.Values, req.Variant)}, nil
 		},
 	))
 
 	r.Post("/base64/decode/batch", httpx.HandleBatch(
 		func(_ context.Context, req BatchRequest) (httpx.BatchResponse[Result], error) {
-			results := make([]Result, len(req.Values))
-
-			for i, value := range req.Values {
-				res, err := svc.Decode(value, req.Variant)
-
-				if err != nil {
-					results[i] = Result{}
-					continue
-				}
-
-				results[i] = res
-			}
-
-			return httpx.BatchResponse[Result]{
-				Results: results,
-			}, nil
+			return httpx.BatchResponse[Result]{Results: svc.DecodeBatch(req.Values, req.Variant)}, nil
 		},
 	))
 }

--- a/apps/api/services/technology/base64/transport_http_test.go
+++ b/apps/api/services/technology/base64/transport_http_test.go
@@ -2,6 +2,7 @@
 package base64 //nolint:revive // name matches feature dir; stdlib stays encoding/base64 with import aliases in app code
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -157,4 +158,240 @@ func TestDecode_ServiceError(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 	assertJSON(t, w)
+}
+
+// ── /base64/encode/batch ──────────────────────────────────────────────────────
+
+func TestEncodeBatch_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/encode/batch",
+		strings.NewReader(`{
+			"values":["Hello","World"]
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assertJSON(t, w)
+
+	var resp httpx.Response[httpx.BatchResponse[Result]]
+
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Data.Results, 2)
+
+	assert.Equal(t, "SGVsbG8=", resp.Data.Results[0].Result)
+	assert.Equal(t, "V29ybGQ=", resp.Data.Results[1].Result)
+
+	assert.Equal(t, 2, resp.Data.Total)
+	assert.Equal(t, "2", w.Header().Get("X-Usage-Count"))
+}
+
+// TestEncodeBatch_InvalidVariant verifies that the endpoint rejects a batch
+// request when "variant" contains a value other than "standard" or "url".
+func TestEncodeBatch_InvalidVariant(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/encode/batch",
+		strings.NewReader(`{
+			"values":["Hello"],
+			"variant":"invalid"
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assertJSON(t, w)
+}
+
+// TestEncodeBatch_EmptyValues verifies that the endpoint rejects a batch
+// request when the values list is empty.
+func TestEncodeBatch_EmptyValues(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/encode/batch",
+		strings.NewReader(`{
+			"values":[]
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assertJSON(t, w)
+}
+
+// TestEncodeBatch_TooManyValues verifies that the endpoint rejects a batch
+// request containing more than the allowed 50 values.
+func TestEncodeBatch_TooManyValues(t *testing.T) {
+	t.Parallel()
+
+	values := make([]string, 51)
+
+	for i := range values {
+		values[i] = "hello"
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"values": values,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/encode/batch",
+		bytes.NewReader(body),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assertJSON(t, w)
+}
+
+// ── /base64/decode/batch ──────────────────────────────────────────────────────
+
+func TestDecodeBatch_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/decode/batch",
+		strings.NewReader(`{
+			"values":["SGVsbG8=","V29ybGQ="]
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assertJSON(t, w)
+
+	var resp httpx.Response[httpx.BatchResponse[Result]]
+
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Data.Results, 2)
+
+	assert.Equal(t, "Hello", resp.Data.Results[0].Result)
+	assert.Equal(t, "World", resp.Data.Results[1].Result)
+
+	assert.Equal(t, 2, resp.Data.Total)
+	assert.Equal(t, "2", w.Header().Get("X-Usage-Count"))
+}
+
+// TestDecodeBatch_InvalidVariant verifies that the endpoint rejects a batch
+// request when "variant" contains a value other than "standard" or "url".
+func TestDecodeBatch_InvalidVariant(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/decode/batch",
+		strings.NewReader(`{
+			"values":["SGVsbG8="],
+			"variant":"invalid"
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assertJSON(t, w)
+}
+
+// TestDecodeBatch_EmptyValues verifies that the endpoint rejects a batch
+// request when the values list is empty.
+func TestDecodeBatch_EmptyValues(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/decode/batch",
+		strings.NewReader(`{
+			"values":[]
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assertJSON(t, w)
+}
+
+// TestDecodeBatch_PartialFailure verifies that invalid Base64 entries are
+// returned as empty results while valid entries are decoded successfully.
+func TestDecodeBatch_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/base64/decode/batch",
+		strings.NewReader(`{
+			"values":["SGVsbG8=","not-valid-base64!!!"]
+		}`),
+	)
+
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	setupRouter().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assertJSON(t, w)
+
+	var resp httpx.Response[httpx.BatchResponse[Result]]
+
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Data.Results, 2)
+
+	assert.Equal(t, "Hello", resp.Data.Results[0].Result)
+
+	// Partial success: invalid entries are returned as empty strings.
+	assert.Equal(t, "", resp.Data.Results[1].Result)
+
+	assert.Equal(t, 2, resp.Data.Total)
+	assert.Equal(t, "2", w.Header().Get("X-Usage-Count"))
 }

--- a/apps/dashboard/config/api_catalog.yml
+++ b/apps/dashboard/config/api_catalog.yml
@@ -659,7 +659,7 @@ apis:
     categories:
       - technology
     description: Encode strings to Base64 and decode Base64 back to plain text. Supports standard and URL-safe (base64url) variants.
-    endpoints_count: 2
+    endpoints_count: 4
     status: live
     popular: false
     documentation_url: /apis/base64

--- a/apps/dashboard/config/api_docs/base64.yml
+++ b/apps/dashboard/config/api_docs/base64.yml
@@ -202,6 +202,100 @@ endpoints:
         else
           puts body['error']  # invalid_base64
         end
+  - name: Encode Batch
+    method: POST
+    path: /v1/technology/base64/encode/batch
+    description: Encode multiple strings to Base64 in a single request
+    parameters:
+      - name: values
+        type: array[string]
+        required: true
+        location: body
+        description: List of values to encode
+        min_items: 1
+        max_items: 50
+        example:
+          - Hello
+          - World
+      - name: variant
+        type: string
+        required: false
+        location: body
+        description: Encoding variant (standard or url)
+        default: standard
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "result": "SGVsbG8="
+            },
+            {
+              "result": "V29ybGQ="
+            }
+          ],
+          "total": 2
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: Encoded results
+      - name: total
+        type: integer
+        description: Number of processed items
+    errors:
+      - code: 422
+        message: validation_failed
+        description: Invalid variant or values list size outside 1-50
+
+  - name: Decode Batch
+    method: POST
+    path: /v1/technology/base64/decode/batch
+    description: Decode multiple Base64 strings in a single request
+    parameters:
+      - name: values
+        type: array[string]
+        required: true
+        location: body
+        description: List of Base64 strings to decode
+        min_items: 1
+        max_items: 50
+      - name: variant
+        type: string
+        required: false
+        location: body
+        description: Encoding variant (standard or url)
+        default: standard
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "result": "Hello"
+            },
+            {
+              "result": "World"
+            }
+          ],
+          "total": 2
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: Decoded results
+      - name: total
+        type: integer
+        description: Number of processed items
+    notes:
+      - Invalid Base64 entries do not fail the request.
+      - Invalid entries are returned as empty result strings.
+      - The endpoint supports partial success semantics.
+    errors:
+      - code: 422
+        message: validation_failed
+        description: Invalid variant or values list size outside 1-50      
 faq:
   - question: What is the difference between standard and url variants?
     answer: >-

--- a/docs/apis/technology/base64.md
+++ b/docs/apis/technology/base64.md
@@ -103,6 +103,141 @@ curl -X POST https://api.requiems.xyz/v1/technology/base64/decode \
 
 ---
 
+### 3. Encode Batch
+
+Encode multiple strings to Base64 in a single request.
+
+**Endpoint:** `POST /v1/technology/base64/encode/batch`
+
+**Request body:**
+
+```json
+{
+  "values": ["Hello", "World"],
+  "variant": "standard"
+}
+```
+
+| Field     | Type     | Required | Description                           |
+| --------- | -------- | -------- | ------------------------------------- |
+| `values`  | string[] | ✅       | List of values to encode (1-50 items) |
+| `variant` | string   | ❌       | `standard` (default) or `url`         |
+
+**Response:** `200 OK`
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "result": "SGVsbG8="
+      },
+      {
+        "result": "V29ybGQ="
+      }
+    ],
+    "total": 2
+  }
+}
+```
+
+**Response headers**
+
+| Header          | Description               |
+| --------------- | ------------------------- |
+| `X-Usage-Count` | Number of processed items |
+
+**Example**
+
+```bash
+curl -X POST https://api.requiems.xyz/v1/technology/base64/encode/batch \
+  -H "requiems-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "values":["Hello","World"]
+      }'
+```
+
+---
+
+### 4. Decode Batch
+
+Decode multiple Base64 strings in a single request.
+
+**Endpoint:** `POST /v1/technology/base64/decode/batch`
+
+**Request body:**
+
+```json
+{
+  "values": ["SGVsbG8=", "V29ybGQ="],
+  "variant": "standard"
+}
+```
+
+| Field     | Type     | Required | Description                           |
+| --------- | -------- | -------- | ------------------------------------- |
+| `values`  | string[] | ✅       | List of values to decode (1-50 items) |
+| `variant` | string   | ❌       | `standard` (default) or `url`         |
+
+**Response:** `200 OK`
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "result": "Hello"
+      },
+      {
+        "result": "World"
+      }
+    ],
+    "total": 2
+  }
+}
+```
+
+#### Partial Success
+
+Invalid Base64 values do not fail the request.
+
+Example request:
+
+```json
+{
+  "values": ["SGVsbG8=", "not-valid-base64!!!"]
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "results": [
+      {
+        "result": "Hello"
+      },
+      {
+        "result": ""
+      }
+    ],
+    "total": 2
+  }
+}
+```
+
+The second entry is returned as an empty string because the value could not be decoded.
+
+**Response headers**
+
+| Header          | Description               |
+| --------------- | ------------------------- |
+| `X-Usage-Count` | Number of processed items |
+
+---
+
 ## Variants
 
 | Variant  | Key        | Alphabet                                          | Padding |


### PR DESCRIPTION
-Added `/base64/encode/batch` and `/base64/decode/batch` endpoints.
-Added validation for batch requests, including variant validation and batch size limits.
-Added unit and handler test coverage for batch operations, including successful requests, validation scenarios, and partial decode failures.
-Added Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch Base64 encoding endpoint supporting up to 50 items per request.
  * Added batch Base64 decoding endpoint with partial success handling—invalid entries return empty strings while valid ones decode successfully.
  * Responses now include a `total` count of processed items.

* **Documentation**
  * Updated API documentation with batch endpoint specifications and usage examples.

* **Tests**
  * Added comprehensive test coverage for batch operations including edge cases and partial failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->