### PR TITLE
Feat/input validate endpoint

### DIFF
--- a/apps/api/platform/httpx/binding.go
+++ b/apps/api/platform/httpx/binding.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -26,6 +27,8 @@ func BindAndValidate(r *http.Request, dst any) error {
 	if err := dec.Decode(dst); err != nil {
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
+
+	normalizeStruct(dst)
 
 	return validateStruct(dst)
 }
@@ -62,7 +65,62 @@ func BindQuery(r *http.Request, dst any) error {
 		}
 	}
 
+	normalizeStruct(dst)
+
 	return validateStruct(dst)
+}
+
+// normalizeStruct applies opt-in field normalization rules before validation.
+// Currently supported rules:
+//   - normalize:"trim" for string fields
+func normalizeStruct(dst any) {
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return
+	}
+
+	normalizeValue(v.Elem())
+}
+
+func normalizeValue(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return
+		}
+		normalizeValue(v.Elem())
+
+	case reflect.Struct:
+		t := v.Type()
+		for i := range t.NumField() {
+			field := t.Field(i)
+			fv := v.Field(i)
+
+			if fv.Kind() == reflect.String && hasNormalizeTrim(field.Tag.Get("normalize")) {
+				if fv.CanSet() {
+					fv.SetString(strings.TrimSpace(fv.String()))
+				}
+				continue
+			}
+
+			normalizeValue(fv)
+		}
+
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			normalizeValue(v.Index(i))
+		}
+	}
+}
+
+func hasNormalizeTrim(tag string) bool {
+	for _, part := range strings.Split(tag, ",") {
+		if strings.TrimSpace(part) == "trim" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // setFieldValue sets a struct field from a raw string value, converting to the

--- a/apps/api/platform/httpx/binding_test.go
+++ b/apps/api/platform/httpx/binding_test.go
@@ -19,6 +19,10 @@ type bindReq struct {
 	Count int    `json:"count" validate:"min=1"`
 }
 
+type bindTrimReq struct {
+	Email string `json:"email" validate:"required,email" normalize:"trim"`
+}
+
 func TestBindAndValidate_ValidJSON(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +74,18 @@ func TestBindAndValidate_ValidationFailure(t *testing.T) {
 	assert.NotEmpty(t, vf.Fields)
 }
 
+func TestBindAndValidate_NormalizeTrim(t *testing.T) {
+	t.Parallel()
+
+	body := strings.NewReader(`{"email":"  user@example.com  "}`)
+	r := httptest.NewRequest("POST", "/", body)
+
+	var req bindTrimReq
+	err := httpx.BindAndValidate(r, &req)
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", req.Email)
+}
+
 // queryReq is used to exercise BindQuery with several field types.
 type queryReq struct {
 	Name    string    `query:"name"    validate:"required"`
@@ -78,6 +94,10 @@ type queryReq struct {
 	Active  bool      `query:"active"`
 	Since   time.Time `query:"since"`
 	Ignored string    // no query tag – must be skipped
+}
+
+type queryTrimReq struct {
+	Name string `query:"name" validate:"required" normalize:"trim"`
 }
 
 func TestBindQuery_StringField(t *testing.T) {
@@ -199,4 +219,15 @@ func TestBindQuery_NonPointerDst(t *testing.T) {
 	var req queryReq
 	err := httpx.BindQuery(r, req)
 	require.Error(t, err)
+}
+
+func TestBindQuery_NormalizeTrim(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/?name=%20%20alice%20%20", http.NoBody)
+
+	var req queryTrimReq
+	err := httpx.BindQuery(r, &req)
+	require.NoError(t, err)
+	assert.Equal(t, "alice", req.Name)
 }

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -52,7 +52,7 @@ type PhoneResult struct {
 	Country      string       `json:"country,omitempty"`
 	Type         string       `json:"type,omitempty"`
 	Carrier      *CarrierInfo `json:"carrier"`
-	Risk         PhoneRisk    `json:"risk"`
+	Risk         *PhoneRisk   `json:"risk"`
 	Flags        []string     `json:"flags"`
 	QualityScore float64      `json:"quality_score"`
 }
@@ -186,7 +186,7 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 			emailFinalResult.Flags = append(emailFinalResult.Flags, "email_syntax_invalid")
 			emailScore -= 1.0
 		} else {
-			if emailResult.MxValid == false {
+			if !emailResult.MxValid {
 				// Domain has no mail server — email is undeliverable.
 				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_mx_invalid")
 				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_invalid")
@@ -199,7 +199,7 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 				emailScore -= 0.5
 			}
 
-			if emailResult.Suggestion != nil && len(*emailResult.Suggestion) > 0 {
+			if emailResult.Suggestion != nil && *emailResult.Suggestion != "" {
 				// Likely typo in domain (e.g. gmial.com) — low confidence signal.
 				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_has_suggestion")
 				emailScore -= 0.1
@@ -260,8 +260,7 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 				phoneFinalResult.Carrier = &CarrierInfo{Name: phoneResult.Carrier.Name}
 			}
 			if phoneResult.Risk != nil {
-				phoneFinalResult.Risk.IsVirtual = phoneResult.Risk.IsVirtual
-				phoneFinalResult.Risk.IsVoIP = phoneResult.Risk.IsVoIP
+				phoneFinalResult.Risk = &PhoneRisk{IsVoIP: phoneResult.Risk.IsVoIP, IsVirtual: phoneResult.Risk.IsVirtual}
 			}
 
 		} else {
@@ -282,6 +281,7 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 	// --- Text scoring ---
 	// Weight: 0.1. Scoring is deferred until ToxicityScore is available from the sentiment service.
 	// text validation runs but does not contribute to overall_quality_score yet.
+	// Note: text-only requests will return overall_quality_score of 0.0 until scoring is enabled.
 	if text != "" {
 		textFinalResult.IsSafe = true
 		if profanityResult.HasProfanity {

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -1,0 +1,326 @@
+package inputvalidate
+
+import (
+	"context"
+	"math"
+	"sync"
+
+	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+	"requiems-api/services/validation/profanity"
+)
+
+// Request defines the input for the validate endpoint.
+// At least one of Email, Phone, or Text must be present.
+type Request struct {
+	Email string `json:"email" validate:"required_without_all=Phone Text"`
+	Phone string `json:"phone" validate:"required_without_all=Email Text"`
+	Text  string `json:"text"  validate:"required_without_all=Email Phone"`
+}
+
+// CarrierInfo holds the name of the carrier associated with a phone number.
+type CarrierInfo struct {
+	Name string `json:"name"`
+}
+
+// PhoneRisk describes line-type risk signals for a phone number.
+type PhoneRisk struct {
+	IsVoIP    bool `json:"is_voip"`
+	IsVirtual bool `json:"is_virtual"`
+}
+
+// EmailResult is the normalized output of the email validation service,
+// enriched with quality signals and flags computed by this system.
+type EmailResult struct {
+	Valid        bool     `json:"valid"`
+	Normalized   *string  `json:"normalized"`
+	Original     string   `json:"original"`
+	SyntaxValid  bool     `json:"syntax_valid"`
+	MXValid      bool     `json:"mx_valid"`
+	Disposable   bool     `json:"disposable"`
+	Suggestion   *string  `json:"suggestion"`
+	Flags        []string `json:"flags"`
+	QualityScore float64  `json:"quality_score"`
+}
+
+// PhoneResult is the normalized output of the phone validation service,
+// enriched with quality signals and flags computed by this system.
+type PhoneResult struct {
+	Valid        bool         `json:"valid"`
+	Normalized   string       `json:"normalized,omitempty"`
+	Country      string       `json:"country,omitempty"`
+	Type         string       `json:"type,omitempty"`
+	Carrier      *CarrierInfo `json:"carrier"`
+	Risk         PhoneRisk    `json:"risk"`
+	Flags        []string     `json:"flags"`
+	QualityScore float64      `json:"quality_score"`
+}
+
+// TextResult is the combined output of the profanity and sentiment services.
+type TextResult struct {
+	IsSafe        bool     `json:"is_safe"`
+	ToxicityScore *float64 `json:"toxicity_score"`
+	Sentiment     string   `json:"sentiment"`
+	Flags         []string `json:"flags"`
+}
+
+// Response is the unified output of the validate endpoint.
+// Fields are nil when the corresponding input was not provided —
+// null in JSON signals "not requested", not "invalid".
+type Response struct {
+	Email               *EmailResult `json:"email"`
+	Phone               *PhoneResult `json:"phone"`
+	Text                *TextResult  `json:"text"`
+	OverallQualityScore float64      `json:"overall_quality_score"`
+}
+
+// EmailService is the interface for the email validation composed service.
+type EmailService interface {
+	ValidateEmail(ctx context.Context, email string) email.Validation
+}
+
+// PhoneService is the interface for the phone validation composed service.
+type PhoneService interface {
+	Validate(number string) phone.ValidateResponse
+}
+
+// ProfanityService is the interface for the profanity check composed service.
+type ProfanityService interface {
+	Check(ctx context.Context, text string) profanity.Result
+}
+
+// SentimentService is the interface for the sentiment analysis composed service.
+type SentimentService interface {
+	Analyze(text string) sentiment.Result
+}
+
+type Service struct {
+	emailSvc     EmailService
+	phoneSvc     PhoneService
+	profanitySvc ProfanityService
+	sentimentSvc SentimentService
+}
+
+// NewService constructs a Service with all four composed service dependencies injected.
+// Each dependency is defined as an interface to allow stubbing in tests.
+func NewService(
+	emailSvc EmailService,
+	phoneSvc PhoneService,
+	profanitySvc ProfanityService,
+	sentimentSvc SentimentService,
+) *Service {
+	return &Service{
+		emailSvc:     emailSvc,
+		phoneSvc:     phoneSvc,
+		profanitySvc: profanitySvc,
+		sentimentSvc: sentimentSvc,
+	}
+}
+
+// Validate composes the email, phone, profanity, and sentiment services into a single call.
+// Only the services needed for the provided fields are invoked — all active calls run in parallel.
+// The overall_quality_score is a weighted mean of the present signals only,
+// so the denominator adjusts based on which fields were provided.
+func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text string) Response {
+
+	var emailFinalResult EmailResult
+	var phoneFinalResult PhoneResult
+	var textFinalResult TextResult
+
+	overallScore := 0.0
+	weightedSum := 0.0
+	totalWeight := 0.0
+	var wg sync.WaitGroup
+
+	// Raw results from each composed service, populated concurrently.
+	var (
+		emailResult     email.Validation
+		phoneResult     phone.ValidateResponse
+		profanityResult profanity.Result
+		sentimentResult sentiment.Result
+	)
+
+	// Fan out: launch only the goroutines needed based on which fields are present.
+	if emailAddress != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			emailResult = s.emailSvc.ValidateEmail(ctx, emailAddress)
+		}()
+	}
+
+	if phoneNumber != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			phoneResult = s.phoneSvc.Validate(phoneNumber)
+		}()
+	}
+
+	if text != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			profanityResult = s.profanitySvc.Check(ctx, text)
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sentimentResult = s.sentimentSvc.Analyze(text)
+		}()
+	}
+
+	wg.Wait()
+
+	// --- Email scoring ---
+	// Weight: 0.5. Deductions applied for each quality signal.
+	// Floor at 0.0 — score cannot go negative.
+	if emailAddress != "" {
+
+		emailScore := 1.0
+
+		if !emailResult.SyntaxValid {
+			// Invalid syntax is disqualifying — full deduction, skip remaining checks.
+			emailFinalResult.Flags = append(emailFinalResult.Flags, "email_syntax_invalid")
+			emailScore -= 1.0
+		} else {
+			if emailResult.MxValid == false {
+				// Domain has no mail server — email is undeliverable.
+				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_mx_invalid")
+				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_invalid")
+				emailScore -= 0.6
+			}
+
+			if emailResult.Disposable {
+				// Disposable/temporary address — high fraud signal.
+				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_disposable")
+				emailScore -= 0.5
+			}
+
+			if emailResult.Suggestion != nil && len(*emailResult.Suggestion) > 0 {
+				// Likely typo in domain (e.g. gmial.com) — low confidence signal.
+				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_has_suggestion")
+				emailScore -= 0.1
+			}
+		}
+
+		emailScore = math.Max(0, emailScore)
+
+		emailFinalResult.Valid = emailResult.Valid
+		emailFinalResult.Normalized = emailResult.Normalized
+		emailFinalResult.Original = emailAddress
+		emailFinalResult.SyntaxValid = emailResult.SyntaxValid
+		emailFinalResult.MXValid = emailResult.MxValid
+		emailFinalResult.Disposable = emailResult.Disposable
+		emailFinalResult.Suggestion = emailResult.Suggestion
+		emailFinalResult.QualityScore = emailScore
+
+		weightedSum += emailScore * 0.5
+		totalWeight += 0.5
+	}
+
+	// --- Phone scoring ---
+	if phoneNumber != "" {
+		phoneScore := 1.0
+
+		if phoneResult.Valid {
+
+			if phoneResult.Risk != nil {
+				if phoneResult.Risk.IsVirtual || phoneResult.Risk.IsVoIP {
+					// VoIP and virtual share a single deduction — apply once.
+					if phoneResult.Risk.IsVirtual {
+						phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_virtual")
+					}
+
+					if phoneResult.Risk.IsVoIP {
+						phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_voip")
+					}
+					phoneScore -= 0.3
+				}
+			}
+
+			if phoneResult.Type == "unknown" {
+				// Cannot determine line type — minor confidence penalty.
+				phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_unknown_type")
+				phoneScore -= 0.1
+
+			}
+
+			if phoneResult.Type == "landline" {
+				// Landline is less common for contact forms — slight penalty.
+				phoneScore -= 0.05
+			}
+
+			phoneFinalResult.Normalized = phoneResult.Formatted
+			phoneFinalResult.Country = phoneResult.Country
+			phoneFinalResult.Type = phoneResult.Type
+			if phoneResult.Carrier != nil && phoneResult.Carrier.Name != "" {
+				phoneFinalResult.Carrier = &CarrierInfo{Name: phoneResult.Carrier.Name}
+			}
+			if phoneResult.Risk != nil {
+				phoneFinalResult.Risk.IsVirtual = phoneResult.Risk.IsVirtual
+				phoneFinalResult.Risk.IsVoIP = phoneResult.Risk.IsVoIP
+			}
+
+		} else {
+			// Invalid number — full deduction.
+			phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_invalid")
+			phoneScore -= 1.0
+		}
+
+		phoneScore = math.Max(0, phoneScore)
+
+		phoneFinalResult.Valid = phoneResult.Valid
+		phoneFinalResult.QualityScore = phoneScore
+
+		totalWeight += 0.4
+		weightedSum += phoneScore * 0.4
+	}
+
+	// --- Text scoring ---
+	// Weight: 0.1. Score = 1.0 - toxicity_score (inverse of toxicity).
+	// ToxicityScore on the result remains nil until the sentiment service exposes it directly.
+	if text != "" {
+		//textScore := 1.0 // TODO: replace with 1.0 - profanityResult.ToxicityScore once the field is available.
+		textFinalResult.IsSafe = true
+		if profanityResult.HasProfanity {
+			textFinalResult.IsSafe = false
+			textFinalResult.Flags = append(textFinalResult.Flags, "text_profanity")
+		}
+		textFinalResult.Sentiment = sentimentResult.Sentiment
+
+		//weightedSum += textScore * 0.1 // ← missing
+		//totalWeight += 0.1  //← missing
+	}
+
+	// Normalize weighted sum by total active weight.
+	// Denominator adjusts based on which fields were present,
+	if totalWeight > 0 {
+		overallScore = weightedSum / totalWeight
+	}
+
+	// Return nil for absent fields — null in JSON signals "not requested",
+	return Response{
+		Email: func() *EmailResult {
+			if emailAddress != "" {
+				return &emailFinalResult
+			}
+			return nil
+		}(),
+		Phone: func() *PhoneResult {
+			if phoneNumber != "" {
+				return &phoneFinalResult
+			}
+			return nil
+		}(),
+		Text: func() *TextResult {
+			if text != "" {
+				return &textFinalResult
+			}
+			return nil
+		}(),
+		OverallQualityScore: overallScore,
+	}
+}

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -280,19 +280,15 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 	}
 
 	// --- Text scoring ---
-	// Weight: 0.1. Score = 1.0 - toxicity_score (inverse of toxicity).
-	// ToxicityScore on the result remains nil until the sentiment service exposes it directly.
+	// Weight: 0.1. Scoring is deferred until ToxicityScore is available from the sentiment service.
+	// text validation runs but does not contribute to overall_quality_score yet.
 	if text != "" {
-		//textScore := 1.0 // TODO: replace with 1.0 - profanityResult.ToxicityScore once the field is available.
 		textFinalResult.IsSafe = true
 		if profanityResult.HasProfanity {
 			textFinalResult.IsSafe = false
 			textFinalResult.Flags = append(textFinalResult.Flags, "text_profanity")
 		}
 		textFinalResult.Sentiment = sentimentResult.Sentiment
-
-		//weightedSum += textScore * 0.1 // ← missing
-		//totalWeight += 0.1  //← missing
 	}
 
 	// Normalize weighted sum by total active weight.

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -48,9 +48,9 @@ type EmailResult struct {
 // enriched with quality signals and flags computed by this system.
 type PhoneResult struct {
 	Valid        bool         `json:"valid"`
-	Normalized   string       `json:"normalized,omitempty"`
-	Country      string       `json:"country,omitempty"`
-	Type         string       `json:"type,omitempty"`
+	Normalized   *string      `json:"normalized"`
+	Country      *string      `json:"country"`
+	Type         *string      `json:"type"`
 	Carrier      *CarrierInfo `json:"carrier"`
 	Risk         *PhoneRisk   `json:"risk"`
 	Flags        []string     `json:"flags"`
@@ -294,9 +294,9 @@ func buildPhoneResult(p phone.ValidateResponse) (result PhoneResult, score float
 			score -= 0.05
 		}
 
-		result.Normalized = p.Formatted
-		result.Country = p.Country
-		result.Type = p.Type
+		result.Normalized = &p.Formatted
+		result.Country = &p.Country
+		result.Type = &p.Type
 		if p.Carrier != nil && p.Carrier.Name != "" {
 			result.Carrier = &CarrierInfo{Name: p.Carrier.Name}
 		}

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -14,9 +14,9 @@ import (
 // Request defines the input for the validate endpoint.
 // At least one of Email, Phone, or Text must be present.
 type Request struct {
-	Email string `json:"email" validate:"required_without_all=Phone Text"`
-	Phone string `json:"phone" validate:"required_without_all=Email Text"`
-	Text  string `json:"text"  validate:"required_without_all=Email Phone"`
+	Email string `json:"email" validate:"required_without_all=Phone Text" normalize:"trim"`
+	Phone string `json:"phone" validate:"required_without_all=Email Text" normalize:"trim"`
+	Text  string `json:"text"  validate:"required_without_all=Email Phone" normalize:"trim"`
 }
 
 // CarrierInfo holds the name of the carrier associated with a phone number.
@@ -291,12 +291,14 @@ func buildPhoneResult(p phone.ValidateResponse) (result PhoneResult, score float
 
 		if p.Type == "landline" {
 			// Landline is less common for contact forms — slight penalty.
+			flags = append(flags, "phone_landline")
 			score -= 0.05
 		}
 
 		result.Normalized = &p.Formatted
 		result.Country = &p.Country
 		result.Type = &p.Type
+		
 		if p.Carrier != nil && p.Carrier.Name != "" {
 			result.Carrier = &CarrierInfo{Name: p.Carrier.Name}
 		}
@@ -317,6 +319,7 @@ func buildTextResult(p profanity.Result, sent sentiment.Result) TextResult {
 		IsSafe:    true,
 		Sentiment: sent.Sentiment,
 	}
+
 	if p.HasProfanity {
 		result.IsSafe = false
 		result.Flags = append(result.Flags, "text_profanity")

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -123,16 +123,7 @@ func NewService(
 // The overall_quality_score is a weighted mean of the present signals only,
 // so the denominator adjusts based on which fields were provided.
 func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text string) Response {
-
-	var emailFinalResult EmailResult
-	var phoneFinalResult PhoneResult
-	var textFinalResult TextResult
-
-	overallScore := 0.0
-	weightedSum := 0.0
-	totalWeight := 0.0
 	var wg sync.WaitGroup
-
 	// Raw results from each composed service, populated concurrently.
 	var (
 		emailResult     email.Validation
@@ -174,108 +165,28 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 
 	wg.Wait()
 
-	// --- Email scoring ---
+	weightedSum := 0.0
+	totalWeight := 0.0
+
+	var emailFinalResult *EmailResult
+	var phoneFinalResult *PhoneResult
+	var textFinalResult *TextResult
+
 	// Weight: 0.5. Deductions applied for each quality signal.
 	// Floor at 0.0 — score cannot go negative.
 	if emailAddress != "" {
-
-		emailScore := 1.0
-
-		if !emailResult.SyntaxValid {
-			// Invalid syntax is disqualifying — full deduction, skip remaining checks.
-			emailFinalResult.Flags = append(emailFinalResult.Flags, "email_syntax_invalid")
-			emailScore -= 1.0
-		} else {
-			if !emailResult.MxValid {
-				// Domain has no mail server — email is undeliverable.
-				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_mx_invalid")
-				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_invalid")
-				emailScore -= 0.6
-			}
-
-			if emailResult.Disposable {
-				// Disposable/temporary address — high fraud signal.
-				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_disposable")
-				emailScore -= 0.5
-			}
-
-			if emailResult.Suggestion != nil && *emailResult.Suggestion != "" {
-				// Likely typo in domain (e.g. gmial.com) — low confidence signal.
-				emailFinalResult.Flags = append(emailFinalResult.Flags, "email_has_suggestion")
-				emailScore -= 0.1
-			}
-		}
-
-		emailScore = math.Max(0, emailScore)
-
-		emailFinalResult.Valid = emailResult.Valid
-		emailFinalResult.Normalized = emailResult.Normalized
-		emailFinalResult.Original = emailAddress
-		emailFinalResult.SyntaxValid = emailResult.SyntaxValid
-		emailFinalResult.MXValid = emailResult.MxValid
-		emailFinalResult.Disposable = emailResult.Disposable
-		emailFinalResult.Suggestion = emailResult.Suggestion
-		emailFinalResult.QualityScore = emailScore
-
-		weightedSum += emailScore * 0.5
+		result, score := buildEmailResult(emailAddress, emailResult)
+		emailFinalResult = &result
+		weightedSum += score * 0.5
 		totalWeight += 0.5
 	}
 
 	// --- Phone scoring ---
 	if phoneNumber != "" {
-		phoneScore := 1.0
-
-		if phoneResult.Valid {
-
-			if phoneResult.Risk != nil {
-				if phoneResult.Risk.IsVirtual || phoneResult.Risk.IsVoIP {
-					// VoIP and virtual share a single deduction — apply once.
-					if phoneResult.Risk.IsVirtual {
-						phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_virtual")
-					}
-
-					if phoneResult.Risk.IsVoIP {
-						phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_voip")
-					}
-					phoneScore -= 0.3
-				}
-			}
-
-			if phoneResult.Type == "unknown" {
-				// Cannot determine line type — minor confidence penalty.
-				phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_unknown_type")
-				phoneScore -= 0.1
-
-			}
-
-			if phoneResult.Type == "landline" {
-				// Landline is less common for contact forms — slight penalty.
-				phoneScore -= 0.05
-			}
-
-			phoneFinalResult.Normalized = phoneResult.Formatted
-			phoneFinalResult.Country = phoneResult.Country
-			phoneFinalResult.Type = phoneResult.Type
-			if phoneResult.Carrier != nil && phoneResult.Carrier.Name != "" {
-				phoneFinalResult.Carrier = &CarrierInfo{Name: phoneResult.Carrier.Name}
-			}
-			if phoneResult.Risk != nil {
-				phoneFinalResult.Risk = &PhoneRisk{IsVoIP: phoneResult.Risk.IsVoIP, IsVirtual: phoneResult.Risk.IsVirtual}
-			}
-
-		} else {
-			// Invalid number — full deduction.
-			phoneFinalResult.Flags = append(phoneFinalResult.Flags, "phone_invalid")
-			phoneScore -= 1.0
-		}
-
-		phoneScore = math.Max(0, phoneScore)
-
-		phoneFinalResult.Valid = phoneResult.Valid
-		phoneFinalResult.QualityScore = phoneScore
-
+		result, score := buildPhoneResult(phoneResult)
+		phoneFinalResult = &result
 		totalWeight += 0.4
-		weightedSum += phoneScore * 0.4
+		weightedSum += score * 0.4
 	}
 
 	// --- Text scoring ---
@@ -283,13 +194,11 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 	// text validation runs but does not contribute to overall_quality_score yet.
 	// Note: text-only requests will return overall_quality_score of 0.0 until scoring is enabled.
 	if text != "" {
-		textFinalResult.IsSafe = true
-		if profanityResult.HasProfanity {
-			textFinalResult.IsSafe = false
-			textFinalResult.Flags = append(textFinalResult.Flags, "text_profanity")
-		}
-		textFinalResult.Sentiment = sentimentResult.Sentiment
+		result := buildTextResult(profanityResult, sentimentResult)
+		textFinalResult = &result
 	}
+
+	overallScore := 0.0
 
 	// Normalize weighted sum by total active weight.
 	// Denominator adjusts based on which fields were present,
@@ -299,24 +208,119 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 
 	// Return nil for absent fields — null in JSON signals "not requested",
 	return Response{
-		Email: func() *EmailResult {
-			if emailAddress != "" {
-				return &emailFinalResult
-			}
-			return nil
-		}(),
-		Phone: func() *PhoneResult {
-			if phoneNumber != "" {
-				return &phoneFinalResult
-			}
-			return nil
-		}(),
-		Text: func() *TextResult {
-			if text != "" {
-				return &textFinalResult
-			}
-			return nil
-		}(),
+		Email:               emailFinalResult,
+		Phone:               phoneFinalResult,
+		Text:                textFinalResult,
 		OverallQualityScore: overallScore,
 	}
+}
+
+func buildEmailResult(emailAddress string, e email.Validation) (EmailResult, float64) {
+
+	score := 1.0
+	var flags []string
+
+	if !e.SyntaxValid {
+		// Invalid syntax is disqualifying — full deduction, skip remaining checks.
+		flags = append(flags, "email_syntax_invalid")
+		score -= 1.0
+	} else {
+		if !e.MxValid {
+			// Domain has no mail server — email is undeliverable.
+			flags = append(flags, "email_mx_invalid")
+			flags = append(flags, "email_invalid")
+			score -= 0.6
+		}
+
+		if e.Disposable {
+			// Disposable/temporary address — high fraud signal.
+			flags = append(flags, "email_disposable")
+			score -= 0.5
+		}
+
+		if e.Suggestion != nil && *e.Suggestion != "" {
+			// Likely typo in domain (e.g. gmial.com) — low confidence signal.
+			flags = append(flags, "email_has_suggestion")
+			score -= 0.1
+		}
+	}
+
+	return EmailResult{
+		Valid:        e.Valid,
+		Normalized:   e.Normalized,
+		Original:     emailAddress,
+		SyntaxValid:  e.SyntaxValid,
+		MXValid:      e.MxValid,
+		Disposable:   e.Disposable,
+		Suggestion:   e.Suggestion,
+		Flags:        flags,
+		QualityScore: math.Max(0, score),
+	}, math.Max(0, score)
+
+}
+
+func buildPhoneResult(p phone.ValidateResponse) (PhoneResult, float64) {
+	score := 1.0
+	var flags []string
+	result := PhoneResult{Valid: p.Valid}
+
+	if p.Valid {
+
+		if p.Risk != nil {
+			if p.Risk.IsVirtual || p.Risk.IsVoIP {
+				// VoIP and virtual share a single deduction — apply once.
+				if p.Risk.IsVirtual {
+					flags = append(flags, "phone_virtual")
+				}
+
+				if p.Risk.IsVoIP {
+					flags = append(flags, "phone_voip")
+				}
+				score -= 0.3
+			}
+
+			result.Risk = &PhoneRisk{IsVoIP: p.Risk.IsVoIP, IsVirtual: p.Risk.IsVirtual}
+		}
+
+		if p.Type == "unknown" {
+			// Cannot determine line type — minor confidence penalty.
+			flags = append(flags, "phone_unknown_type")
+			score -= 0.1
+
+		}
+
+		if p.Type == "landline" {
+			// Landline is less common for contact forms — slight penalty.
+			score -= 0.05
+		}
+
+		result.Normalized = p.Formatted
+		result.Country = p.Country
+		result.Type = p.Type
+		if p.Carrier != nil && p.Carrier.Name != "" {
+			result.Carrier = &CarrierInfo{Name: p.Carrier.Name}
+		}
+
+	} else {
+		// Invalid number — full deduction.
+		flags = append(flags, "phone_invalid")
+		score -= 1.0
+	}
+
+	result.Flags = flags
+	result.QualityScore = math.Max(0, score)
+	return result, math.Max(0, score)
+}
+
+func buildTextResult(p profanity.Result, sent sentiment.Result) TextResult {
+	result := TextResult{
+		IsSafe:    true,
+		Sentiment: sent.Sentiment,
+	}
+	if p.HasProfanity {
+		result.IsSafe = false
+		result.Flags = append(result.Flags, "text_profanity")
+	}
+
+	return result
 }

--- a/apps/api/services/systems/data_integrity/input_validate/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate/service.go
@@ -215,9 +215,9 @@ func (s *Service) Validate(ctx context.Context, emailAddress, phoneNumber, text 
 	}
 }
 
-func buildEmailResult(emailAddress string, e email.Validation) (EmailResult, float64) {
+func buildEmailResult(emailAddress string, e email.Validation) (result EmailResult, score float64) {
 
-	score := 1.0
+	score = 1.0
 	var flags []string
 
 	if !e.SyntaxValid {
@@ -259,10 +259,10 @@ func buildEmailResult(emailAddress string, e email.Validation) (EmailResult, flo
 
 }
 
-func buildPhoneResult(p phone.ValidateResponse) (PhoneResult, float64) {
-	score := 1.0
+func buildPhoneResult(p phone.ValidateResponse) (result PhoneResult, score float64) {
+	score = 1.0
 	var flags []string
-	result := PhoneResult{Valid: p.Valid}
+	result = PhoneResult{Valid: p.Valid}
 
 	if p.Valid {
 

--- a/apps/api/services/systems/data_integrity/input_validate/transport_http.go
+++ b/apps/api/services/systems/data_integrity/input_validate/transport_http.go
@@ -1,0 +1,18 @@
+package inputvalidate
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts the input validate handler on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/input/validate", httpx.Handle(
+		func(ctx context.Context, req Request) (Response, error) {
+			return svc.Validate(ctx, req.Email, req.Phone, req.Text), nil
+		},
+	))
+}

--- a/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
@@ -36,7 +36,7 @@ type stubEmailService struct {
 	emailResult email.Validation
 }
 
-func (s *stubEmailService) ValidateEmail(ctx context.Context, email string) email.Validation {
+func (s *stubEmailService) ValidateEmail(ctx context.Context, emailAddress string) email.Validation {
 	return s.emailResult
 }
 

--- a/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
@@ -257,3 +257,20 @@ func TestInputValidate_Validate_NoFieldsPresent_Returns422(t *testing.T) {
 
 	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
+
+func TestInputValidate_Validate_TextOnly_OverallScoreIsZero(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter(&stubEmailService{}, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"text": "I just wanted to say that your customer service team was incredibly helpful."}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Nil(t, resp.Data.Email)
+	assert.Nil(t, resp.Data.Phone)
+	assert.NotNil(t, resp.Data.Text)
+	assert.Equal(t, 0.0, resp.Data.OverallQualityScore)
+}

--- a/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
@@ -249,11 +249,46 @@ func TestInputValidate_Validate_VoIPPhone_ReturnsVoIPFlagAndReducedScore(t *test
 	assert.Equal(t, 0.7, resp.Data.Phone.QualityScore) // 1.0 - 0.3 voip deduction
 }
 
+func TestInputValidate_Validate_LandlinePhone_ReturnsLandlineFlagAndReducedScore(t *testing.T) {
+	t.Parallel()
+	phoneSvc := &stubPhoneService{
+		phoneResult: phone.ValidateResponse{
+			Valid:     true,
+			Formatted: "+12015551234",
+			Country:   "US",
+			Type:      "landline",
+			Carrier:   nil,
+			Risk:      &phone.Risk{IsVoIP: false, IsVirtual: false},
+		},
+	}
+
+	r := setupRouter(&stubEmailService{}, phoneSvc, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"phone": "+12015551234"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, "landline", *resp.Data.Phone.Type)
+	assert.Contains(t, resp.Data.Phone.Flags, "phone_landline")
+	assert.Equal(t, 0.95, resp.Data.Phone.QualityScore) // 1.0 - 0.05 landline deduction
+}
+
 func TestInputValidate_Validate_NoFieldsPresent_Returns422(t *testing.T) {
 	t.Parallel()
 
 	r := setupRouter(&stubEmailService{}, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
 	w := post(t, r, `{}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestInputValidate_Validate_WhitespaceOnlyFields_Returns422(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter(&stubEmailService{}, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email":"   ","phone":"\t\n","text":"   "}`)
 
 	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }

--- a/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate/transport_http_test.go
@@ -1,0 +1,259 @@
+package inputvalidate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
+	"requiems-api/services/validation/profanity"
+)
+
+func setupRouter(
+	emailSvc EmailService,
+	phoneSvc PhoneService,
+	profanitySvc ProfanityService,
+	sentimentSvc SentimentService,
+) chi.Router {
+	r := chi.NewRouter()
+	svc := NewService(emailSvc, phoneSvc, profanitySvc, sentimentSvc)
+	RegisterRoutes(r, svc)
+	return r
+}
+
+// --- Email stub ---
+type stubEmailService struct {
+	emailResult email.Validation
+}
+
+func (s *stubEmailService) ValidateEmail(ctx context.Context, email string) email.Validation {
+	return s.emailResult
+}
+
+// --- Phone stub ---
+type stubPhoneService struct {
+	phoneResult phone.ValidateResponse
+}
+
+func (s *stubPhoneService) Validate(number string) phone.ValidateResponse {
+	return s.phoneResult
+}
+
+// --- Profanity stub ---
+type stubProfanityService struct {
+	result profanity.Result
+}
+
+func (s *stubProfanityService) Check(ctx context.Context, text string) profanity.Result {
+	return s.result
+}
+
+// --- Sentiment stub ---
+type stubSentimentService struct {
+	result sentiment.Result
+}
+
+func (s *stubSentimentService) Analyze(text string) sentiment.Result {
+	return s.result
+}
+
+func ptr(s string) *string {
+	return &s
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/input/validate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestInputValidate_Validate_ValidEmailAndPhone_ReturnsHighScore(t *testing.T) {
+	t.Parallel()
+	emailSvc := &stubEmailService{
+		emailResult: email.Validation{
+			Valid:       true,
+			Normalized:  ptr("user@gmail.com"),
+			SyntaxValid: true,
+			MxValid:     true,
+			Disposable:  false,
+			Suggestion:  nil,
+		},
+	}
+
+	phoneSvc := &stubPhoneService{
+		phoneResult: phone.ValidateResponse{
+			Valid:     true,
+			Formatted: "+4915123456789",
+			Country:   "DE",
+			Type:      "mobile",
+			Carrier:   &phone.Carrier{Name: "Telekom"},
+			Risk:      &phone.Risk{IsVoIP: false, IsVirtual: false},
+		},
+	}
+
+	r := setupRouter(emailSvc, phoneSvc, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email": "user@gmail.com", "phone": "+4915123456789"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.True(t, resp.Data.Email.Valid)
+	assert.True(t, resp.Data.Phone.Valid)
+	assert.Nil(t, resp.Data.Text) // text not requested → null
+	assert.Greater(t, resp.Data.OverallQualityScore, 0.9)
+}
+
+func TestInputValidate_Validate_DisposableEmail_ReturnsLowScore(t *testing.T) {
+	t.Parallel()
+	emailSvc := &stubEmailService{
+		emailResult: email.Validation{
+			Valid:       true,
+			Normalized:  ptr("user@mailinator.com"),
+			SyntaxValid: true,
+			MxValid:     true,
+			Disposable:  true,
+			Suggestion:  nil,
+		},
+	}
+
+	r := setupRouter(emailSvc, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email": "user@mailinator.com"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.True(t, resp.Data.Email.Disposable)
+	assert.Contains(t, resp.Data.Email.Flags, "email_disposable")
+	assert.LessOrEqual(t, resp.Data.Email.QualityScore, 0.5)
+}
+
+func TestInputValidate_Validate_InvalidEmailSyntax_ReturnsZeroScore(t *testing.T) {
+	t.Parallel()
+	emailSvc := &stubEmailService{
+		emailResult: email.Validation{
+			Valid:       false,
+			Normalized:  nil,
+			SyntaxValid: false,
+			MxValid:     false,
+			Disposable:  false,
+			Suggestion:  nil,
+		},
+	}
+
+	r := setupRouter(emailSvc, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email": "not-an-email"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.False(t, resp.Data.Email.Valid)
+	assert.Contains(t, resp.Data.Email.Flags, "email_syntax_invalid")
+	assert.Equal(t, 0.0, resp.Data.Email.QualityScore)
+}
+
+func TestInputValidate_Validate_EmailOnly_PhoneIsNullAndScoreBasedOnEmailOnly(t *testing.T) {
+	t.Parallel()
+	emailSvc := &stubEmailService{
+		emailResult: email.Validation{
+			Valid:       true,
+			Normalized:  ptr("user@gmail.com"),
+			SyntaxValid: true,
+			MxValid:     true,
+			Disposable:  false,
+			Suggestion:  nil,
+		},
+	}
+
+	r := setupRouter(emailSvc, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email": "user@gmail.com"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Nil(t, resp.Data.Phone)                      // phone not requested → null
+	assert.Nil(t, resp.Data.Text)                       // text not requested → null
+	assert.Equal(t, 1.0, resp.Data.OverallQualityScore) // email score 1.0, weight 0.5/0.5 = 1.0
+}
+
+func TestInputValidate_Validate_EmailWithTypoSuggestion_ReturnsSuggestionAndFlag(t *testing.T) {
+	t.Parallel()
+	emailSvc := &stubEmailService{
+		emailResult: email.Validation{
+			Valid:       true,
+			Normalized:  ptr("user@gmail.com"),
+			SyntaxValid: true,
+			MxValid:     true,
+			Disposable:  false,
+			Suggestion:  ptr("gmail.com"),
+		},
+	}
+
+	r := setupRouter(emailSvc, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"email": "user@gmial.com"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.NotNil(t, resp.Data.Email.Suggestion)
+	assert.Equal(t, "gmail.com", *resp.Data.Email.Suggestion)
+	assert.Contains(t, resp.Data.Email.Flags, "email_has_suggestion")
+	assert.Equal(t, 0.9, resp.Data.Email.QualityScore) // 1.0 - 0.1 typo deduction
+}
+
+func TestInputValidate_Validate_VoIPPhone_ReturnsVoIPFlagAndReducedScore(t *testing.T) {
+	t.Parallel()
+	phoneSvc := &stubPhoneService{
+		phoneResult: phone.ValidateResponse{
+			Valid:     true,
+			Formatted: "+14155552671",
+			Country:   "US",
+			Type:      "voip",
+			Carrier:   nil,
+			Risk:      &phone.Risk{IsVoIP: true, IsVirtual: false},
+		},
+	}
+
+	r := setupRouter(&stubEmailService{}, phoneSvc, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{"phone": "+14155552671"}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[Response]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.True(t, resp.Data.Phone.Risk.IsVoIP)
+	assert.Contains(t, resp.Data.Phone.Flags, "phone_voip")
+	assert.Equal(t, 0.7, resp.Data.Phone.QualityScore) // 1.0 - 0.3 voip deduction
+}
+
+func TestInputValidate_Validate_NoFieldsPresent_Returns422(t *testing.T) {
+	t.Parallel()
+
+	r := setupRouter(&stubEmailService{}, &stubPhoneService{}, &stubProfanityService{}, &stubSentimentService{})
+	w := post(t, r, `{}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}

--- a/apps/api/services/systems/data_integrity/router.go
+++ b/apps/api/services/systems/data_integrity/router.go
@@ -7,9 +7,12 @@ import (
 	"requiems-api/services/networking/whois"
 	contentmoderate "requiems-api/services/systems/data_integrity/content_moderate"
 	domaintrust "requiems-api/services/systems/data_integrity/domain_trust"
+	inputvalidate "requiems-api/services/systems/data_integrity/input_validate"
 	textnormalize "requiems-api/services/systems/data_integrity/text_normalize"
 	"requiems-api/services/text/detectlanguage"
 	"requiems-api/services/text/sentiment"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
 	"requiems-api/services/validation/profanity"
 )
 
@@ -26,4 +29,9 @@ func RegisterRoutes(r chi.Router) {
 	whoIsSvc := whois.NewService()
 	domainTrustSvc := domaintrust.NewService(whoIsSvc, domainSvc)
 	domaintrust.RegisterRoutes(r, domainTrustSvc)
+
+	emailSvc := email.NewService()
+	phoneSvc := phone.NewService()
+	inputValidateSvc := inputvalidate.NewService(emailSvc, phoneSvc, profanitySvc, sentimentSvc)
+	inputvalidate.RegisterRoutes(r, inputValidateSvc)
 }

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -112,7 +112,7 @@ endpoints:
         description: Suggested correction when a typo is detected in the domain (e.g. gmial.com → gmail.com). Null otherwise.
       - name: email.flags
         type: array or null
-        description: "Triggered flags. Possible values: email_invalid, email_mx_invalid, email_disposable, email_has_suggestion."
+        description: "Triggered flags. Possible values: email_syntax_invalid, email_mx_invalid, email_disposable, email_has_suggestion."
       - name: email.quality_score
         type: number
         description: Email quality score from 0.0 to 1.0. Penalized by invalidity, disposable domain, and suggestions.
@@ -123,8 +123,8 @@ endpoints:
         type: boolean
         description: True when the phone number is valid and dialable.
       - name: phone.normalized
-        type: string or null
-        description: Normalized phone number in international format. Null when invalid.
+        type: string
+        description: Normalized phone number in international format. Omitted when invalid.
       - name: phone.country
         type: string or null
         description: ISO 3166-1 alpha-2 country code detected from the number (e.g. US, CO).
@@ -139,13 +139,13 @@ endpoints:
         description: Name of the carrier or operator associated with the number.
       - name: phone.risk
         type: object or null
-        description: Risk signals associated with the phone number. Null when not available.
+        description: Risk signals associated with the phone number. Null when the validator could not determine risk information.
       - name: phone.risk.is_voip
         type: boolean
-        description: True when the number is identified as a VoIP line.
+        description: True when the number is confirmed as a VoIP line. False when explicitly confirmed as non-VoIP.
       - name: phone.risk.is_virtual
         type: boolean
-        description: True when the number is identified as a virtual number.
+        description: True when the number is confirmed as a virtual number. False when explicitly confirmed as non-virtual.
       - name: phone.flags
         type: array or null
         description: "Triggered flags. Possible values: phone_invalid, phone_voip, phone_virtual, phone_unknown_type, phone_landline."
@@ -162,14 +162,19 @@ endpoints:
         type: number or null
         description: Reserved for future use. Currently always null.
       - name: text.sentiment
-        type: string or null
+        type: string
         description: "Detected sentiment: positive, negative, or neutral."
       - name: text.flags
         type: array or null
         description: "Triggered moderation flags. Possible values: text_profanity."
       - name: overall_quality_score
         type: number
-        description: Weighted quality score from 0.0 to 1.0 combining all provided fields. Weights are email 0.5, phone 0.4, text 0.1. Adjusted proportionally when one or more fields are absent.
+        description: >-
+          Weighted quality score from 0.0 to 1.0 combining email and phone fields only.
+          Weights are email 0.5 and phone 0.4, adjusted proportionally when one field is absent.
+          Text does not currently contribute to this score — scoring will be enabled once
+          toxicity_score is available from the sentiment service.
+          Returns 0.0 when only text is provided.
     errors:
       - code: 422
         message: validation_failed

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -17,6 +17,230 @@ overview:
     - Unicode normalization, HTML stripping, case conversion, and whitespace collapsing
     - Safe for any text content — no data is stored or logged
 endpoints:
+  - name: Input Validate
+    method: POST
+    path: /v1/systems/input/validate
+    description: Validates and scores a single email address, phone number, or text input — or any combination of the three. Returns per-field quality scores, normalized values, risk flags, and an overall quality score for gating or enriching input data.
+    parameters:
+      - name: email
+        type: string
+        required: false
+        location: body
+        description: The email address to validate. At least one of email, phone, or text must be provided.
+        example: "user@example.com"
+      - name: phone
+        type: string
+        required: false
+        location: body
+        description: The phone number to validate. Must include country code in E.164 format. At least one of email, phone, or text must be provided.
+        example: "+12015551234"
+      - name: text
+        type: string
+        required: false
+        location: body
+        description: The text content to analyze for profanity, toxicity, and sentiment. At least one of email, phone, or text must be provided.
+        example: "I just wanted to say that your customer service team was incredibly helpful and resolved my issue faster than expected."
+    request_example: |
+      {
+        "email": "user@example.com",
+        "phone": "+12015551234",
+        "text": "I just wanted to say that your customer service team was incredibly helpful and resolved my issue faster than expected."
+      }
+    response_example: |
+      {
+        "data": {
+          "email": {
+            "valid": true,
+            "normalized": "user@example.com",
+            "original": "user@example.com",
+            "syntax_valid": true,
+            "mx_valid": true,
+            "disposable": false,
+            "suggestion": null,
+            "flags": null,
+            "quality_score": 1
+          },
+          "phone": {
+            "valid": true,
+            "normalized": "+1 201-555-1234",
+            "country": "US",
+            "type": "landline_or_mobile",
+            "carrier": null,
+            "risk": {
+              "is_voip": false,
+              "is_virtual": false
+            },
+            "flags": null,
+            "quality_score": 1
+          },
+          "text": {
+            "is_safe": true,
+            "toxicity_score": null,
+            "sentiment": "positive",
+            "flags": null
+          },
+          "overall_quality_score": 1
+        },
+        "metadata": {
+          "timestamp": "2026-06-09T23:20:55Z"
+        }
+      }
+    response_fields:
+      - name: email
+        type: object or null
+        description: Email validation result. Null when email was not provided.
+      - name: email.valid
+        type: boolean
+        description: True when the email passes syntax and MX validation.
+      - name: email.normalized
+        type: string or null
+        description: Normalized form of the email address. Null when syntax is invalid.
+      - name: email.original
+        type: string
+        description: The original email address as provided in the request.
+      - name: email.syntax_valid
+        type: boolean
+        description: True when the email address has a valid structure.
+      - name: email.mx_valid
+        type: boolean
+        description: True when the email domain has valid MX records.
+      - name: email.disposable
+        type: boolean
+        description: True when the email domain is a known disposable or temporary provider.
+      - name: email.suggestion
+        type: string or null
+        description: Suggested correction when a typo is detected in the domain (e.g. gmial.com → gmail.com). Null otherwise.
+      - name: email.flags
+        type: array or null
+        description: "Triggered flags. Possible values: email_invalid, email_mx_invalid, email_disposable, email_has_suggestion."
+      - name: email.quality_score
+        type: number
+        description: Email quality score from 0.0 to 1.0. Penalized by invalidity, disposable domain, and suggestions.
+      - name: phone
+        type: object or null
+        description: Phone validation result. Null when phone was not provided.
+      - name: phone.valid
+        type: boolean
+        description: True when the phone number is valid and dialable.
+      - name: phone.normalized
+        type: string or null
+        description: Normalized phone number in international format. Null when invalid.
+      - name: phone.country
+        type: string or null
+        description: ISO 3166-1 alpha-2 country code detected from the number (e.g. US, CO).
+      - name: phone.type
+        type: string or null
+        description: "Line type. Possible values: mobile, landline, voip, toll_free, unknown."
+      - name: phone.carrier
+        type: object or null
+        description: Carrier information. Null when not available.
+      - name: phone.carrier.name
+        type: string
+        description: Name of the carrier or operator associated with the number.
+      - name: phone.risk
+        type: object or null
+        description: Risk signals associated with the phone number. Null when not available.
+      - name: phone.risk.is_voip
+        type: boolean
+        description: True when the number is identified as a VoIP line.
+      - name: phone.risk.is_virtual
+        type: boolean
+        description: True when the number is identified as a virtual number.
+      - name: phone.flags
+        type: array or null
+        description: "Triggered flags. Possible values: phone_invalid, phone_voip, phone_virtual, phone_unknown_type, phone_landline."
+      - name: phone.quality_score
+        type: number
+        description: Phone quality score from 0.0 to 1.0. Penalized by invalidity, VoIP, virtual, landline, and unknown type.
+      - name: text
+        type: object or null
+        description: Text analysis result. Null when text was not provided.
+      - name: text.is_safe
+        type: boolean
+        description: False when any moderation flag is triggered. True otherwise.
+      - name: text.toxicity_score
+        type: number or null
+        description: Reserved for future use. Currently always null.
+      - name: text.sentiment
+        type: string or null
+        description: "Detected sentiment: positive, negative, or neutral."
+      - name: text.flags
+        type: array or null
+        description: "Triggered moderation flags. Possible values: text_profanity."
+      - name: overall_quality_score
+        type: number
+        description: Weighted quality score from 0.0 to 1.0 combining all provided fields. Weights are email 0.5, phone 0.4, text 0.1. Adjusted proportionally when one or more fields are absent.
+    errors:
+      - code: 422
+        message: validation_failed
+        description: All fields (email, phone, text) are absent or empty. At least one must be provided.
+      - code: 401
+        message: unauthorized
+        description: Missing or invalid API key.
+    code_examples:
+      curl: |
+        curl -X POST https://api.requiems.xyz/v1/systems/input/validate \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"email": "user@example.com", "phone": "+12015551234", "text": "I just wanted to say that your customer service team was incredibly helpful."}'
+      python: |
+        import requests
+
+        response = requests.post(
+          "https://api.requiems.xyz/v1/systems/input/validate",
+          headers={"requiems-api-key": "YOUR_API_KEY"},
+          json={
+            "email": "user@example.com",
+            "phone": "+12015551234",
+            "text": "I just wanted to say that your customer service team was incredibly helpful."
+          }
+        )
+        data = response.json()["data"]
+
+        if data.get("email"):
+          print("Email valid:", data["email"]["valid"], "| Score:", data["email"]["quality_score"])
+        if data.get("phone"):
+          print("Phone valid:", data["phone"]["valid"], "| Score:", data["phone"]["quality_score"])
+        if data.get("text"):
+          print("Text safe:", data["text"]["is_safe"], "| Sentiment:", data["text"]["sentiment"])
+        print("Overall quality score:", data["overall_quality_score"])
+      javascript: |
+        const { data } = await fetch('https://api.requiems.xyz/v1/systems/input/validate', {
+          method: 'POST',
+          headers: { 'requiems-api-key': 'YOUR_API_KEY', 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: 'user@example.com',
+            phone: '+12015551234',
+            text: 'I just wanted to say that your customer service team was incredibly helpful.'
+          })
+        }).then(r => r.json());
+
+        if (data.email) console.log('Email valid:', data.email.valid, '| Score:', data.email.quality_score);
+        if (data.phone) console.log('Phone valid:', data.phone.valid, '| Score:', data.phone.quality_score);
+        if (data.text) console.log('Text safe:', data.text.is_safe, '| Sentiment:', data.text.sentiment);
+        console.log('Overall quality score:', data.overall_quality_score);
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/systems/input/validate')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = {
+          email: 'user@example.com',
+          phone: '+12015551234',
+          text: 'I just wanted to say that your customer service team was incredibly helpful.'
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |h| h.request(request) }
+        data = JSON.parse(response.body)['data']
+
+        puts "Email valid: #{data['email']['valid']} | Score: #{data['email']['quality_score']}" if data['email']
+        puts "Phone valid: #{data['phone']['valid']} | Score: #{data['phone']['quality_score']}" if data['phone']
+        puts "Text safe: #{data['text']['is_safe']} | Sentiment: #{data['text']['sentiment']}" if data['text']
+        puts "Overall quality score: #{data['overall_quality_score']}"
+        
   - name: Moderate Content
     method: POST
     path: /v1/systems/content/moderate

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -123,14 +123,14 @@ endpoints:
         type: boolean
         description: True when the phone number is valid and dialable.
       - name: phone.normalized
-        type: string
-        description: Normalized phone number in international format. Omitted when invalid.
+        type: string or null
+        description: Normalized phone number in international format. Null when the number is invalid.
       - name: phone.country
         type: string or null
-        description: ISO 3166-1 alpha-2 country code detected from the number (e.g. US, CO).
+        description: ISO 3166-1 alpha-2 country code detected from the number (e.g. US, CO). Null when the number is invalid.
       - name: phone.type
         type: string or null
-        description: "Line type. Possible values: mobile, landline, voip, toll_free, unknown."
+        description: "Line type. Null when the number is invalid. Possible values: mobile, landline, voip, toll_free, unknown."
       - name: phone.carrier
         type: object or null
         description: Carrier information. Null when not available.


### PR DESCRIPTION
### Endpoint
- `POST /v1/systems/input/validate` accepts any combination of `email`, `phone`, and `text` — at least one required
- runs email, phone, profanity, and sentiment services concurrently using `sync.WaitGroup`
- computes per-field quality scores with penalties for invalid, disposable, VoIP, virtual, landline, and typo signals
- overall quality score uses weighted average (email 0.5, phone 0.4, text 0.1) adjusted by fields present
- absent fields return `null` in the response

### Tests
- valid email and phone returns high overall score
- disposable email applies penalty and returns `email_disposable` flag
- invalid email syntax returns zero score and `email_syntax_invalid` flag
- email only request returns `null` for phone and text, overall score based on email weight only
- email with typo returns suggestion and `email_has_suggestion` flag with 0.1 deduction
- VoIP phone returns `phone_voip` flag and 0.3 deduction
- empty request body returns `422`

### Docs
- added endpoint documentation.

### Known limitations
- text validation runs but does not contribute to `overall_quality_score` yet.
  Scoring will be enabled once `toxicity_score` is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POST /v1/systems/input/validate to validate email, phone, and/or text in one request; returns per-field details and an OverallQualityScore (text-only = 0.0)
  * Request binding now trims marked string fields (whitespace normalized) before validation

* **Documentation**
  * Added API docs with request/response examples and multi-language code samples

* **Tests**
  * Added HTTP and binding tests covering validation scenarios, trimming, and error cases (422)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->