### PR TITLE
Feat/ai skills banner

### DIFF
--- a/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
+++ b/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
@@ -1,16 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Manages the AI Skills promotional banner.
-// Hides the banner when dismissed and remembers the choice in localStorage.
+// Hides the banner when dismissed. Reappears on every page reload.
 export default class extends Controller {
-  connect() {
-    if (localStorage.getItem("ai_skills_banner_dismissed") === "true") {
-      this.element.remove()
-    }
-  }
-
   dismiss() {
-    localStorage.setItem("ai_skills_banner_dismissed", "true")
     this.element.remove()
   }
 }

--- a/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
+++ b/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Manages the AI Skills promotional banner.
+// Hides the banner when dismissed and remembers the choice in localStorage.
+export default class extends Controller {
+  connect() {
+    if (localStorage.getItem("ai_skills_banner_dismissed") === "true") {
+      this.element.remove()
+    }
+  }
+
+  dismiss() {
+    localStorage.setItem("ai_skills_banner_dismissed", "true")
+    this.element.remove()
+  }
+}

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -59,6 +59,7 @@
   <body class="bg-gray-50 dark:bg-gray-900 flex flex-col min-h-screen" data-controller="search-shortcut">
     <%= render "partials/shared/flash_toast" %>
 
+    <%= render "partials/shared/ai_skills_banner" %>
     <%= render "layouts/navbar" %>
 
     <main class="flex-1">

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -57,9 +57,8 @@
   </head>
 
   <body class="bg-gray-50 dark:bg-gray-900 flex flex-col min-h-screen" data-controller="search-shortcut">
-    <%= render "partials/shared/flash_toast" %>
-
-    <%= render "partials/shared/ai_skills_banner" %>
+    <%= render "partials/shared/flash_toast" -%>
+    <%= render "partials/shared/ai_skills_banner" -%>
     <%= render "layouts/navbar" %>
 
     <main class="flex-1">

--- a/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
+++ b/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
@@ -1,0 +1,29 @@
+<div id="ai-skills-banner"
+     data-controller="ai-skills-banner"
+     class="relative text-white" style="background: radial-gradient(ellipse at center, #c084fc 0%, #6d28d9 40%, #0ea5e9 100%)">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5">
+    <div class="flex items-center justify-center gap-x-3 text-sm">
+      <span class="flex-shrink-0 rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase">
+        New
+      </span>
+      <a href="https://github.com/bobadilla-tech/requiems-api-skills"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="flex items-center gap-1.5 font-medium hover:underline">
+        Build with Requiems API faster — install the AI Skills package for Claude, Gemini, and more
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+        </svg>
+      </a>
+    </div>
+  </div>
+
+  <button type="button"
+          data-action="click->ai-skills-banner#dismiss"
+          class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-white/20 transition-colors"
+          aria-label="Dismiss banner">
+    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  </button>
+</div>

--- a/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
+++ b/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
@@ -1,15 +1,15 @@
 <div id="ai-skills-banner"
      data-controller="ai-skills-banner"
-     class="relative text-white" style="background: radial-gradient(ellipse at center, #c084fc 0%, #6d28d9 40%, #0ea5e9 100%)">
+     class="relative bg-gradient-to-r from-gray-900 via-indigo-700 to-gray-900 border-b border-indigo-700/40 text-white">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5">
     <div class="flex items-center justify-center gap-x-3 text-sm">
-      <span class="flex-shrink-0 rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase">
+      <span class="flex-shrink-0 rounded border border-white/60 px-2 py-0.5 text-xs font-semibold tracking-widest uppercase">
         New
       </span>
       <a href="https://github.com/bobadilla-tech/requiems-api-skills"
          target="_blank"
          rel="noopener noreferrer"
-         class="flex items-center gap-1.5 font-medium hover:underline">
+         class="flex items-center gap-1.5 text-white font-medium hover:underline">
         Build with Requiems API faster — install the AI Skills package for Claude, Gemini, and more
         <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
@@ -21,7 +21,7 @@
 
   <button type="button"
           data-action="click->ai-skills-banner#dismiss"
-          class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-white/20 transition-colors"
+          class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors"
           aria-label="Dismiss banner">
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
+++ b/apps/dashboard/app/views/partials/shared/_ai_skills_banner.html.erb
@@ -11,9 +11,10 @@
          rel="noopener noreferrer"
          class="flex items-center gap-1.5 font-medium hover:underline">
         Build with Requiems API faster — install the AI Skills package for Claude, Gemini, and more
-        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
         </svg>
+        <span class="sr-only">(opens in new tab)</span>
       </a>
     </div>
   </div>
@@ -22,7 +23,7 @@
           data-action="click->ai-skills-banner#dismiss"
           class="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-white/20 transition-colors"
           aria-label="Dismiss banner">
-    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
     </svg>
   </button>

--- a/apps/dashboard/app/views/partials/shared/_flash_toast.html.erb
+++ b/apps/dashboard/app/views/partials/shared/_flash_toast.html.erb
@@ -8,8 +8,8 @@
   #   alert  → red error toast
   #
   # Usage (layouts only): render "partials/shared/flash_toast"
-%>
-<% if notice.present? || alert.present? %>
+-%>
+<% if notice.present? || alert.present? -%>
   <div class="fixed top-20 right-4 z-50 space-y-2 max-w-md">
     <% if notice.present? %>
       <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-400 dark:border-green-600 p-4 shadow-md rounded-md"
@@ -49,4 +49,4 @@
       </div>
     <% end %>
   </div>
-<% end %>
+<% end -%>


### PR DESCRIPTION
Adds a promotional banner to the landing page to promote the AI Skills package.

- Banner placed above the navbar (above the fold)
- Radial gradient background (violet center, cyan blue edges)
- CTA links to https://github.com/bobadilla-tech/requiems-api-skills
- Dismissible via X button
- Responsive on desktop and mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Skills promotional banner to the dashboard with a "New" badge, external resource link, accessible dismiss button, and temporary dismissal (reappears on refresh).

* **Bug Fixes**
  * Improved layout rendering behavior around flash toasts to eliminate unexpected whitespace when notifications appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->