### PR TITLE
feat: add sentiment analysis tool page

### DIFF
--- a/apps/dashboard/app/controllers/tools_controller.rb
+++ b/apps/dashboard/app/controllers/tools_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ToolsController < ApplicationController
+  SUPPORTED_TOOLS = %w[email-validator sentiment-analysis].freeze
+
+  def show
+    @tool_id = params[:id]
+
+    unless SUPPORTED_TOOLS.include?(@tool_id)
+      redirect_to root_path, alert: "Tool not found."
+      return
+    end
+
+    render "tools/#{@tool_id.tr('-', '_')}/show"
+  end
+end

--- a/apps/dashboard/app/javascript/controllers/faq_accordion_controller.js
+++ b/apps/dashboard/app/javascript/controllers/faq_accordion_controller.js
@@ -12,6 +12,10 @@ export default class extends Controller {
     // Toggle content visibility
     content.classList.toggle("hidden");
 
+    // Keep aria-expanded in sync with visibility state
+    const isOpen = !content.classList.contains("hidden");
+    button.setAttribute("aria-expanded", String(isOpen));
+
     // Rotate icon
     if (content.classList.contains("hidden")) {
       icon.style.transform = "rotate(0deg)";

--- a/apps/dashboard/app/javascript/controllers/sentiment_demo_controller.js
+++ b/apps/dashboard/app/javascript/controllers/sentiment_demo_controller.js
@@ -1,0 +1,159 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Handles the live sentiment analysis demo in the hero section.
+// Calls /api/proxy → POST /v1/text/sentiment and renders the result inline.
+export default class extends Controller {
+  static targets = [
+    "input",
+    "button",
+    "result",
+    "errorMessage",
+    "spinner",
+  ];
+
+  connect() {
+    this._pending = false;
+  }
+
+  async analyze(event) {
+    event.preventDefault();
+    if (this._pending) return;
+
+    const text = this.inputTarget.value.trim();
+    this.resultTarget.classList.add("hidden");
+
+    if (!text) {
+      this._showError("Enter some text to analyze.");
+      return;
+    }
+
+    this._setLoading(true);
+    this._clearError();
+
+    try {
+      const response = await fetch("/api/proxy", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": this._csrfToken(),
+        },
+        body: JSON.stringify({
+          endpoint: "/v1/text/sentiment",
+          method: "POST",
+          params: { text },
+        }),
+      });
+
+      if (response.status === 429) {
+        this._showError("Too many requests. Wait a moment and try again.");
+        return;
+      }
+
+      const json = await response.json();
+
+      if (!response.ok || json.error) {
+        this._showError("Something went wrong. Try again.");
+        return;
+      }
+
+      this._renderResult(json.data?.data ?? json.data);
+    } catch (_err) {
+      this._showError("Could not reach the API. Check your connection.");
+    } finally {
+      this._setLoading(false);
+    }
+  }
+
+  // ── private ────────────────────────────────────────────────────────────────
+
+  _renderResult(data) {
+    if (!data) {
+      this._showError("No data returned.");
+      return;
+    }
+
+    const VALID_SENTIMENTS = ["positive", "negative", "neutral"];
+    const sentiment = VALID_SENTIMENTS.includes(data.sentiment)
+      ? data.sentiment
+      : "neutral";
+    const score = Math.round((data.score ?? 0) * 100);
+    const breakdown = data.breakdown ?? {};
+
+    const colors = this._sentimentColors(sentiment);
+    const label = this._capitalize(sentiment);
+
+    const breakdownRows = ["positive", "negative", "neutral"]
+      .map((key) => {
+        const pct = Math.round((breakdown[key] ?? 0) * 100);
+        const barColors = this._sentimentColors(key);
+        return `
+        <div class="flex items-center gap-3 py-1">
+          <span class="w-16 text-xs text-gray-500 dark:text-gray-400 capitalize">${key}</span>
+          <div class="flex-1 bg-gray-100 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
+            <div class="h-1.5 rounded-full ${barColors.bar}" style="width:${pct}%"></div>
+          </div>
+          <span class="w-8 text-xs text-right font-medium text-gray-700 dark:text-gray-300">${pct}%</span>
+        </div>`;
+      })
+      .join("");
+
+    this.resultTarget.innerHTML = `
+      <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+        <div class="px-5 py-4 flex items-center gap-3 bg-gray-50 dark:bg-gray-900">
+          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold ${colors.badge}">
+            ${label}
+          </span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">${score}% confident</span>
+        </div>
+        <div class="px-5 py-4">
+          <p class="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-3">Breakdown</p>
+          ${breakdownRows}
+        </div>
+      </div>`;
+
+    this.resultTarget.classList.remove("hidden");
+  }
+
+  _sentimentColors(sentiment) {
+    const map = {
+      positive: {
+        badge:
+          "bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300",
+        bar: "bg-emerald-500",
+      },
+      negative: {
+        badge: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+        bar: "bg-red-500",
+      },
+      neutral: {
+        badge: "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300",
+        bar: "bg-gray-400",
+      },
+    };
+    return map[sentiment] ?? map.neutral;
+  }
+
+  _capitalize(str) {
+    return String(str).charAt(0).toUpperCase() + String(str).slice(1);
+  }
+
+  _setLoading(state) {
+    this._pending = state;
+    this.buttonTarget.disabled = state;
+    this.spinnerTarget.classList.toggle("hidden", !state);
+  }
+
+  _showError(msg) {
+    this.errorMessageTarget.textContent = msg;
+    this.errorMessageTarget.classList.remove("hidden");
+  }
+
+  _clearError() {
+    this.errorMessageTarget.classList.add("hidden");
+    this.errorMessageTarget.textContent = "";
+  }
+
+  _csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content ?? "";
+  }
+}

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_api_combinations.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_api_combinations.html.erb
@@ -1,0 +1,50 @@
+<% combos = [
+  {
+    title: "Sentiment + Spell Check",
+    body: "Run spell check first to clean up noisy user input, then analyze sentiment on the corrected text for more accurate results.",
+    link_text: "Spell Check API",
+    link_id: "spell-check"
+  },
+  {
+    title: "Sentiment + Language Detection",
+    body: "Detect the language before routing text to the right sentiment model. Useful for multilingual support queues and global review platforms.",
+    link_text: "Language Detection API",
+    link_id: "language-detection"
+  },
+  {
+    title: "Sentiment + Email Validator",
+    body: "Validate the sender's email and analyze the tone of their message in one pass — before storing feedback or opening a support ticket.",
+    link_text: "Email Validator API",
+    link_id: "email-validate"
+  }
+] %>
+
+<section class="bg-gray-50 dark:bg-gray-800 py-20">
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="text-center mb-14">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Pair it with other APIs</h2>
+      <p class="mt-3 text-gray-500 dark:text-gray-400 max-w-xl mx-auto">
+        Sentiment works best as part of a pipeline. Here are three natural combinations.
+      </p>
+    </div>
+
+    <div class="grid md:grid-cols-3 gap-6">
+      <% combos.each do |combo| %>
+        <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-700 p-6 flex flex-col">
+          <h3 class="font-semibold text-gray-900 dark:text-white mb-2"><%= combo[:title] %></h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 flex-1"><%= combo[:body] %></p>
+          <%= link_to api_path(combo[:link_id]),
+                class: "mt-4 text-sm font-medium inline-flex items-center gap-1",
+                style: "color:#1D9E75;" do %>
+            <%= combo[:link_text] %>
+            <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+            </svg>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_cta.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_cta.html.erb
@@ -1,0 +1,28 @@
+<section class="bg-gray-900 dark:bg-gray-950 py-20">
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+
+    <h2 class="text-3xl sm:text-4xl font-bold text-white">
+      Automate this with Requiems.
+    </h2>
+    <p class="mt-4 text-lg text-gray-400 max-w-xl mx-auto">
+      One API key. Sentiment analysis, plus 50+ other APIs across validation, finance, networking, and more.
+    </p>
+
+    <div class="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
+      <%= link_to new_user_registration_path,
+            class: "inline-flex items-center px-7 py-3 rounded-lg text-white font-semibold text-base shadow-sm transition-opacity hover:opacity-90",
+            style: "background-color:#1D9E75;" do %>
+        Get your free API key
+      <% end %>
+
+      <%= link_to api_path("sentiment"),
+            class: "inline-flex items-center px-7 py-3 rounded-lg border border-gray-600 text-gray-300 font-semibold text-base hover:bg-gray-800 transition-colors" do %>
+        Read the docs
+        <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+        </svg>
+      <% end %>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_faq.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_faq.html.erb
@@ -1,0 +1,55 @@
+<% faqs = [
+  {
+    q: "What are the possible sentiment values?",
+    a: "The sentiment field returns one of three values — positive, negative, or neutral — based on whichever class has the highest confidence score."
+  },
+  {
+    q: "What does the breakdown represent?",
+    a: "The three breakdown values (positive, negative, neutral) always sum to 1.0. They show the proportional confidence across all classes, not just the dominant one. A score of 0.97 positive means the model is highly certain; 0.51 means it's leaning positive but the text is ambiguous."
+  },
+  {
+    q: "How long can the input text be?",
+    a: "There is no strict character limit enforced at the API level, but very long inputs may be truncated by the underlying model. Aim for inputs under 512 tokens (roughly 400 words) for best accuracy."
+  },
+  {
+    q: "Can I analyze multiple texts at once?",
+    a: "Yes. The batch endpoint (POST /v1/text/sentiment/batch) accepts up to 50 texts per request. Results are returned in the same order as the input and each text counts as one unit of usage."
+  },
+  {
+    q: "Is it free to use?",
+    a: "The demo above works without an account. Paid plans offer higher rate limits and full API access for production use."
+  }
+] %>
+
+<section class="bg-white dark:bg-gray-900 py-20">
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="text-center mb-12">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Frequently asked questions</h2>
+    </div>
+
+    <div class="space-y-3" data-controller="faq-accordion">
+      <% faqs.each_with_index do |faq, i| %>
+        <div class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <button type="button"
+                  class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  data-action="click->faq-accordion#toggle"
+                  data-faq-accordion-target="button"
+                  aria-expanded="false"
+                  aria-controls="faq-sentiment-<%= i %>">
+            <span class="font-medium text-gray-900 dark:text-gray-100"><%= faq[:q] %></span>
+            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-transform ml-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+          </button>
+          <div id="faq-sentiment-<%= i %>"
+               class="hidden px-6 pb-5 text-gray-500 dark:text-gray-400 text-sm leading-relaxed"
+               data-faq-accordion-target="content">
+            <%= faq[:a] %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_hero.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_hero.html.erb
@@ -1,0 +1,70 @@
+<section class="bg-white dark:bg-gray-900 pt-20 pb-16">
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+
+    <h1 class="text-4xl sm:text-5xl font-bold tracking-tight text-gray-900 dark:text-white leading-tight">
+      Know how your text lands.
+    </h1>
+
+    <p class="mt-5 text-lg sm:text-xl text-gray-500 dark:text-gray-400 max-w-2xl mx-auto">
+      Classify any text as positive, negative, or neutral — with a confidence score and full breakdown, in a single API call.
+    </p>
+
+    <div class="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+      <%= link_to new_user_registration_path,
+            class: "inline-flex items-center px-6 py-3 rounded-lg text-white font-semibold text-base shadow-sm transition-colors",
+            style: "background-color:#1D9E75;" do %>
+        Get API Key
+        <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>
+        </svg>
+      <% end %>
+      <%= link_to api_path("sentiment"),
+            class: "inline-flex items-center px-6 py-3 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-base hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors" do %>
+        Read the docs
+      <% end %>
+    </div>
+
+    <!-- Live demo -->
+    <div class="mt-12 max-w-xl mx-auto"
+         data-controller="sentiment-demo">
+
+      <form data-action="submit->sentiment-demo#analyze" novalidate>
+        <textarea
+          data-sentiment-demo-target="input"
+          aria-label="Text to analyze"
+          placeholder="Paste any text, review, comment, or feedback..."
+          rows="3"
+          class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-3 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:border-transparent text-sm resize-none"
+          style="focus-ring-color:#1D9E75;"
+        ></textarea>
+
+        <div class="mt-2 flex items-center justify-between">
+          <p class="text-xs text-gray-400 dark:text-gray-500">No account required for the demo.</p>
+          <button
+            type="submit"
+            data-sentiment-demo-target="button"
+            class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-white font-semibold text-sm transition-colors disabled:opacity-60"
+            style="background-color:#1D9E75;"
+          >
+            <span data-sentiment-demo-target="spinner" class="hidden">
+              <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+              </svg>
+            </span>
+            Analyze
+          </button>
+        </div>
+
+        <p data-sentiment-demo-target="errorMessage"
+           class="hidden mt-2 text-sm text-red-500 text-left"
+           role="alert"></p>
+      </form>
+
+      <div data-sentiment-demo-target="result"
+           class="hidden mt-4 text-left">
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_use_cases.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_use_cases.html.erb
@@ -1,0 +1,55 @@
+<% cards = [
+  {
+    icon: "💬",
+    title: "Customer support",
+    body: "Route tickets automatically. Flag frustrated customers for priority handling before they churn."
+  },
+  {
+    icon: "⭐",
+    title: "Product reviews",
+    body: "Aggregate sentiment across thousands of reviews without reading them one by one."
+  },
+  {
+    icon: "📣",
+    title: "Social media monitoring",
+    body: "Track brand mentions in real time and detect sentiment shifts before they become PR issues."
+  },
+  {
+    icon: "🛡️",
+    title: "Content moderation",
+    body: "Pre-screen user-generated content for hostile or harmful tone before it reaches other users."
+  },
+  {
+    icon: "🤖",
+    title: "NLP pipelines",
+    body: "Use sentiment as a feature in ML models — preprocessing text classification, recommendation, or ranking tasks."
+  },
+  {
+    icon: "📊",
+    title: "Survey analysis",
+    body: "Turn open-ended survey responses into structured sentiment data without manual tagging."
+  }
+] %>
+
+<section class="bg-white dark:bg-gray-900 py-20">
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="text-center mb-14">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Built for real use cases</h2>
+      <p class="mt-3 text-gray-500 dark:text-gray-400 max-w-xl mx-auto">
+        Anywhere text flows through your system, sentiment gives you signal.
+      </p>
+    </div>
+
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% cards.each do |card| %>
+        <div class="rounded-2xl border border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-6">
+          <div class="text-3xl mb-3"><%= card[:icon] %></div>
+          <h3 class="font-semibold text-gray-900 dark:text-white mb-1"><%= card[:title] %></h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400"><%= card[:body] %></p>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/sentiment_analysis/_what_it_does.html.erb
+++ b/apps/dashboard/app/views/partials/tools/sentiment_analysis/_what_it_does.html.erb
@@ -1,0 +1,52 @@
+<section class="bg-gray-50 dark:bg-gray-800 py-20">
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="text-center mb-14">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">What it does</h2>
+      <p class="mt-3 text-gray-500 dark:text-gray-400 max-w-xl mx-auto">
+        One call. Three values. Enough signal to act.
+      </p>
+    </div>
+
+    <div class="grid md:grid-cols-2 gap-8">
+
+      <!-- Block 1: Classification -->
+      <div class="bg-white dark:bg-gray-900 rounded-2xl p-8 shadow-sm">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300 mb-4">
+          Instant classification
+        </div>
+        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Positive, negative, or neutral</h3>
+        <p class="text-gray-500 dark:text-gray-400 text-sm mb-6">
+          Every text gets a dominant label plus a confidence score between 0.0 and 1.0, so you can threshold results with precision.
+        </p>
+        <div class="rounded-xl bg-gray-900 p-4 font-mono text-xs text-left overflow-x-auto">
+          <pre class="text-gray-300">{
+  <span class="text-blue-400">"sentiment"</span>: <span class="text-emerald-400">"positive"</span>,
+  <span class="text-blue-400">"score"</span>:     <span class="text-amber-400">0.97</span>
+}</pre>
+        </div>
+      </div>
+
+      <!-- Block 2: Breakdown -->
+      <div class="bg-white dark:bg-gray-900 rounded-2xl p-8 shadow-sm">
+        <div class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 mb-4">
+          Full breakdown
+        </div>
+        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Proportional scores across all classes</h3>
+        <p class="text-gray-500 dark:text-gray-400 text-sm mb-6">
+          The breakdown shows how the model distributes confidence across all three classes — always summing to 1.0. Useful for ambiguous or mixed-tone text.
+        </p>
+        <div class="rounded-xl bg-gray-900 p-4 font-mono text-xs text-left overflow-x-auto">
+          <pre class="text-gray-300">{
+  <span class="text-blue-400">"breakdown"</span>: {
+    <span class="text-blue-400">"positive"</span>: <span class="text-emerald-400">0.97</span>,
+    <span class="text-blue-400">"negative"</span>: <span class="text-red-400">0.01</span>,
+    <span class="text-blue-400">"neutral"</span>:  <span class="text-gray-400">0.02</span>
+  }
+}</pre>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>

--- a/apps/dashboard/app/views/tools/sentiment_analysis/show.html.erb
+++ b/apps/dashboard/app/views/tools/sentiment_analysis/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Free Sentiment Analysis Tool — Positive, Negative & Neutral Text Detection | Requiems API" %>
+<% content_for :description, "Analyze the sentiment of any text instantly. Get a positive, negative, or neutral classification with a confidence score and full breakdown — free, no account required." %>
+
+<%= render "partials/tools/sentiment_analysis/hero" %>
+<%= render "partials/shared/logo_marquee",
+      logos: [
+        { file: "companies/bobadilla-tech.png",   alt: "Bobadilla Tech"   },
+        { file: "companies/compile-strength.png", alt: "Compile Strength" },
+        { file: "companies/flyver.jpeg",           alt: "Flyver"           },
+        { file: "companies/korealexa.png",         alt: "Korealexa"        },
+        { file: "companies/shareweave.jpeg",       alt: "Shareweave"       },
+      ],
+      label: "Trusted by teams at",
+      speed: "34s" %>
+<%= render "partials/tools/sentiment_analysis/what_it_does" %>
+<%= render "partials/tools/sentiment_analysis/use_cases" %>
+<%= render "partials/tools/sentiment_analysis/api_combinations" %>
+<%= render "partials/tools/sentiment_analysis/faq" %>
+<%= render "partials/tools/sentiment_analysis/cta" %>

--- a/apps/dashboard/config/routes.rb
+++ b/apps/dashboard/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
     get "examples", to: "examples#index"
     get "apis/:id/index.md", to: "sitemap#api_doc", defaults: { format: :text }
     resources :apis, only: [ :index, :show ]
+    resources :tools, only: [ :show ]
     resources :categories, only: [ :show ]
     resources :examples, only: [ :show ]
 

--- a/apps/dashboard/test/controllers/tools_controller_test.rb
+++ b/apps/dashboard/test/controllers/tools_controller_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ToolsControllerTest < ActionDispatch::IntegrationTest
+  test "sentiment analysis tool page renders successfully" do
+    get "/en/tools/sentiment-analysis"
+    assert_response :success
+  end
+
+  test "unknown tool id redirects to root with alert" do
+    get "/en/tools/not-a-real-tool"
+    assert_redirected_to root_path
+    assert_equal "Tool not found.", flash[:alert]
+  end
+end


### PR DESCRIPTION
Adds the Sentiment Analysis tool page at /tools/sentiment-analysis.

### Changes
- New ToolsController supporting email-validator and sentiment-analysis
- Live demo form → calls /api/proxy → displays sentiment, confidence score, and breakdown
- 7 sections: hero, trusted by, what it does, use cases, API combinations, FAQ, CTA
- New Stimulus controller sentiment-demo handles loading, errors, and rate-limit (429)
- Controller test covering happy path and unknown tool redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Sentiment Analysis tool page with live demo to analyze text in real-time
  * Tool page includes FAQ, use cases, API integration examples, and documentation
  * Users can access API key signup and documentation from the tool page

* **Tests**
  * Added controller tests for tool page routing and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->