### PR TITLE
feat: add random quotes seo tool page

### DIFF
--- a/apps/dashboard/app/controllers/tools_controller.rb
+++ b/apps/dashboard/app/controllers/tools_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ToolsController < ApplicationController
-  SUPPORTED_TOOLS = %w[email-validator sentiment-analysis].freeze
+  SUPPORTED_TOOLS = %w[email-validator sentiment-analysis quotes].freeze
 
   TOOLS_METADATA = {
     "email-validator" => {
@@ -13,6 +13,11 @@ class ToolsController < ApplicationController
       name: "Sentiment Analysis",
       description: "Classify text as positive, negative, or neutral with a confidence score.",
       icon_classes: "bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-400"
+    },
+    "quotes" => {
+      name: "Random Quotes",
+      description: "Fetch random inspirational quotes with author attribution in a single API call.",
+      icon_classes: "bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400"
     }
   }.freeze
 

--- a/apps/dashboard/app/javascript/controllers/quotes_demo_controller.js
+++ b/apps/dashboard/app/javascript/controllers/quotes_demo_controller.js
@@ -1,0 +1,94 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Live demo controller for the Random Quotes tool page.
+// Calls GET /v1/entertainment/quotes/random via the dashboard proxy
+// and renders the result. No user input is required.
+// Error messages are passed via data-values from ERB (i18n-ready).
+export default class extends Controller {
+  static targets = ["button", "result", "errorMessage", "spinner"];
+  static values = {
+    errorRateLimit: String,
+    errorGeneric: String,
+    errorUnexpected: String,
+    errorNetwork: String,
+    errorSecurityToken: String,
+  };
+
+  async fetch() {
+    // Always reset UI state before any early return or async work.
+    this.resultTarget.classList.add("hidden");
+    this._clearError();
+
+    this.buttonTarget.disabled = true;
+    this.spinnerTarget.classList.remove("hidden");
+
+    try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')
+        ?.content;
+
+      if (!csrfToken) {
+        this._showError(this.errorSecurityTokenValue);
+        return;
+      }
+
+      const response = await window.fetch("/api/proxy", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+        },
+        body: JSON.stringify({
+          endpoint: "/v1/entertainment/quotes/random",
+          method: "GET",
+          params: { _t: Date.now() },
+        }),
+      });
+
+      if (response.status === 429) {
+        this._showError(this.errorRateLimitValue);
+        return;
+      }
+
+      if (!response.ok) {
+        this._showError(this.errorGenericValue);
+        return;
+      }
+
+      const json = await response.json();
+      const quote = json?.data?.data;
+
+      if (!quote?.text || !quote?.author) {
+        this._showError(this.errorUnexpectedValue);
+        return;
+      }
+
+      this._renderQuote(quote);
+    } catch (_err) {
+      this._showError(this.errorNetworkValue);
+    } finally {
+      this.buttonTarget.disabled = false;
+      this.spinnerTarget.classList.add("hidden");
+    }
+  }
+
+  _renderQuote(quote) {
+    this.resultTarget.querySelector(
+      "[data-quotes-demo-text]",
+    ).textContent = `“${quote.text}”`;
+    this.resultTarget.querySelector(
+      "[data-quotes-demo-author]",
+    ).textContent = `— ${quote.author}`;
+
+    this.resultTarget.classList.remove("hidden");
+  }
+
+  _showError(message) {
+    this.errorMessageTarget.textContent = message;
+    this.errorMessageTarget.classList.remove("hidden");
+  }
+
+  _clearError() {
+    this.errorMessageTarget.textContent = "";
+    this.errorMessageTarget.classList.add("hidden");
+  }
+}

--- a/apps/dashboard/app/views/partials/tools/quotes/_api_combinations.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_api_combinations.html.erb
@@ -1,0 +1,43 @@
+<section class="py-20 px-4 bg-white dark:bg-gray-950">
+  <div class="max-w-4xl mx-auto">
+    <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+      Pairs well with
+    </h2>
+    <p class="text-gray-600 dark:text-gray-300 mb-10">
+      Combine the Quotes API with other endpoints to build richer experiences.
+    </p>
+
+    <div class="grid sm:grid-cols-3 gap-6">
+      <div class="rounded-xl border border-gray-100 dark:border-gray-800 p-6 bg-gray-50 dark:bg-gray-900">
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">
+          <%= link_to "Sentiment Analysis", api_path("sentiment"),
+                class: "hover:underline", style: "color:#1D9E75;" %>
+        </h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Score the emotional tone of a quote before displaying it — surface only
+          positive, uplifting results.
+        </p>
+      </div>
+      <div class="rounded-xl border border-gray-100 dark:border-gray-800 p-6 bg-gray-50 dark:bg-gray-900">
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">
+          <%= link_to "Detect Language", api_path("detect-language"),
+                class: "hover:underline", style: "color:#1D9E75;" %>
+        </h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Filter or route quotes by language before presenting them to a
+          multilingual audience.
+        </p>
+      </div>
+      <div class="rounded-xl border border-gray-100 dark:border-gray-800 p-6 bg-gray-50 dark:bg-gray-900">
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">
+          <%= link_to "Lorem Ipsum", api_path("lorem-ipsum"),
+                class: "hover:underline", style: "color:#1D9E75;" %>
+        </h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Mix real quotes with generated filler text for flexible content layouts
+          and design systems.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/quotes/_cta.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_cta.html.erb
@@ -1,0 +1,31 @@
+<section class="py-20 px-4 bg-white dark:bg-gray-950">
+  <div class="max-w-2xl mx-auto text-center">
+    <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+      Ready to add quotes to your app?
+    </h2>
+    <p class="text-gray-500 dark:text-gray-400 mb-8">
+      Sign up for free and start fetching inspirational quotes in minutes.
+      No credit card required.
+    </p>
+
+    <div class="flex flex-wrap justify-center gap-4">
+      <%= link_to new_user_registration_path,
+            class: "inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#1D9E75]",
+            style: "background-color:#1D9E75;" do %>
+        Get your free API key
+      <% end %>
+
+      <%= link_to api_path("quotes"),
+            class: "inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-gray-700 dark:text-gray-200 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900 transition" do %>
+        View API documentation
+      <% end %>
+    </div>
+
+    <p class="mt-6 text-xs text-gray-400">
+      Free plan includes 1,000 requests/month.
+      <%= link_to pricing_path, class: "underline hover:text-gray-600 dark:hover:text-gray-300" do %>
+        See all plans
+      <% end %>
+    </p>
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/quotes/_faq.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_faq.html.erb
@@ -1,0 +1,60 @@
+<% faqs = [
+  {
+    q: "Do I need an API key to use the Quotes API?",
+    a: "Yes. Sign up for a free account to get your API key. The free plan includes enough credits to get started immediately."
+  },
+  {
+    q: "Can I filter quotes by author or category?",
+    a: "Currently the API returns random quotes from the full collection. Author and category filtering is planned for a future release."
+  },
+  {
+    q: "Will I ever get the same quote twice?",
+    a: "Quotes are selected randomly on each request, so consecutive calls will typically return different quotes. With a large collection, repeats are rare."
+  },
+  {
+    q: "How many quotes can I fetch at once?",
+    a: "Use the batch endpoint (POST /v1/entertainment/quotes/random/batch) to request up to 50 quotes per call. Each quote counts as one unit of usage."
+  },
+  {
+    q: "What happens if the database has no quotes available?",
+    a: "The API returns a 503 service_unavailable error. This is extremely rare in practice."
+  }
+] %>
+
+<section class="bg-white dark:bg-gray-900 py-20">
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+
+    <div class="text-center mb-12">
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Frequently asked questions</h2>
+    </div>
+
+    <div class="space-y-3" data-controller="faq-accordion">
+      <% faqs.each_with_index do |faq, i| %>
+        <% panel_id = "quotes-faq-#{i}" %>
+        <% button_id = "#{panel_id}-button" %>
+        <div class="rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <button type="button"
+                  id="<%= button_id %>"
+                  class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  data-action="click->faq-accordion#toggle"
+                  data-faq-accordion-target="button"
+                  aria-expanded="false"
+                  aria-controls="<%= panel_id %>">
+            <span class="font-medium text-gray-900 dark:text-gray-100"><%= faq[:q] %></span>
+            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-transform ml-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+          </button>
+          <div id="<%= panel_id %>"
+               class="hidden px-6 pb-5 text-gray-500 dark:text-gray-400 text-sm leading-relaxed"
+               role="region"
+               aria-labelledby="<%= button_id %>"
+               data-faq-accordion-target="content">
+            <%= faq[:a] %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/quotes/_hero.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_hero.html.erb
@@ -1,0 +1,70 @@
+<section class="relative overflow-hidden py-20 px-4"
+         style="background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);">
+  <div class="max-w-4xl mx-auto text-center">
+    <div class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 mb-6 text-sm font-medium"
+         style="background-color:rgba(29,158,117,0.15); color:#1D9E75;">
+      🎯 Random Quotes API — Live Demo
+    </div>
+
+    <h1 class="text-4xl sm:text-5xl font-bold text-white mb-4 leading-tight">
+      Random Quote Generator
+    </h1>
+    <p class="text-lg text-gray-300 max-w-2xl mx-auto mb-10">
+      Instantly fetch inspirational quotes from famous thinkers, leaders, and
+      innovators. One API call — quote + author attribution, ready to use.
+    </p>
+
+    <%# Live demo widget %>
+    <div data-controller="quotes-demo"
+         data-quotes-demo-error-rate-limit-value="<%= t('tools.quotes.demo.error_rate_limit') %>"
+         data-quotes-demo-error-generic-value="<%= t('tools.quotes.demo.error_generic') %>"
+         data-quotes-demo-error-unexpected-value="<%= t('tools.quotes.demo.error_unexpected') %>"
+         data-quotes-demo-error-network-value="<%= t('tools.quotes.demo.error_network') %>"
+         data-quotes-demo-error-security-token-value="<%= t('tools.quotes.demo.error_security_token') %>"
+         class="bg-gray-900 border border-gray-700 rounded-2xl p-8 max-w-xl mx-auto text-left">
+
+      <div class="flex items-center gap-2 mb-6">
+        <span class="text-xs font-mono px-2 py-0.5 rounded"
+              style="background-color:#14532d; color:#86efac;">GET</span>
+        <span class="text-xs font-mono text-gray-400">/v1/entertainment/quotes/random</span>
+      </div>
+
+      <%# Result area %>
+      <div data-quotes-demo-target="result"
+           class="hidden mb-6 p-4 rounded-xl bg-gray-800 border border-gray-700">
+        <p class="text-xl text-white italic leading-relaxed mb-3"
+           data-quotes-demo-text></p>
+        <p class="text-sm font-semibold"
+           style="color:#1D9E75;"
+           data-quotes-demo-author></p>
+      </div>
+
+      <%# Error message %>
+      <p data-quotes-demo-target="errorMessage"
+         class="hidden mb-4 text-sm text-red-400 text-center"></p>
+
+      <%# Fetch button %>
+      <button data-quotes-demo-target="button"
+              data-action="click->quotes-demo#fetch"
+              type="button"
+              class="w-full flex items-center justify-center gap-2 rounded-xl py-3 px-6 text-sm font-semibold text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-[#1D9E75] disabled:opacity-50"
+              style="background-color:#1D9E75;">
+        <span data-quotes-demo-target="spinner"
+              class="hidden h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
+        Get a Random Quote
+      </button>
+    </div>
+
+    <div class="mt-8 flex flex-wrap justify-center gap-4 text-sm">
+      <%= link_to api_path("quotes"),
+            class: "text-gray-300 hover:text-white underline underline-offset-2" do %>
+        View full API docs →
+      <% end %>
+      <%= link_to new_user_registration_path,
+            class: "font-semibold hover:opacity-90",
+            style: "color:#1D9E75;" do %>
+        Get your free API key →
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/quotes/_use_cases.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_use_cases.html.erb
@@ -1,0 +1,74 @@
+<section class="py-20 px-4 bg-gray-50 dark:bg-gray-900">
+  <div class="max-w-4xl mx-auto">
+    <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+      What can you build with it?
+    </h2>
+    <p class="text-gray-600 dark:text-gray-300 mb-10">
+      The Quotes API is a lightweight but versatile building block. Here are the
+      most common use cases developers reach for it.
+    </p>
+
+    <div class="grid sm:grid-cols-2 gap-6">
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">📅</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">Quote of the day</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Show a fresh inspirational quote on every visit — dashboards, homepages,
+            onboarding screens.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">📱</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">Social media content</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Auto-generate quote cards for Twitter/X, Instagram, or LinkedIn without
+            a content team.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">🧘</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">Motivation &amp; wellness apps</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Fuel daily check-in screens, push notifications, or meditation app openers
+            with curated wisdom.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">🎨</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">Design placeholders</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Replace Lorem Ipsum with real, meaningful text in wireframes, mockups,
+            and UI demos.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">🤖</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">AI &amp; chatbot enrichment</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Seed prompts, conversation starters, or personality layers for AI
+            assistants and chatbots.
+          </p>
+        </div>
+      </div>
+      <div class="flex gap-4 items-start">
+        <span class="text-2xl">📧</span>
+        <div>
+          <h3 class="font-semibold text-gray-900 dark:text-white">Email footers &amp; newsletters</h3>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Add a rotating quote to transactional emails, weekly digests, or
+            newsletter signatures.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/dashboard/app/views/partials/tools/quotes/_what_it_does.html.erb
+++ b/apps/dashboard/app/views/partials/tools/quotes/_what_it_does.html.erb
@@ -1,0 +1,41 @@
+<section class="py-20 px-4 bg-white dark:bg-gray-950">
+  <div class="max-w-4xl mx-auto">
+    <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+      What is the Random Quotes API?
+    </h2>
+    <p class="text-lg text-gray-600 dark:text-gray-300 mb-6">
+      The <strong>Random Quotes API</strong> gives you instant access to a curated
+      collection of inspirational and famous quotes. Each call returns a quote and
+      its author — no configuration required.
+    </p>
+    <p class="text-gray-600 dark:text-gray-300 mb-6">
+      Need multiple quotes at once? The
+      <strong>batch endpoint</strong> lets you request up to 50 random quotes in
+      a single HTTP call, with each quote billed as one unit of usage.
+    </p>
+
+    <div class="grid sm:grid-cols-3 gap-6 mt-10">
+      <div class="rounded-xl p-6 border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+        <div class="text-2xl mb-3">⚡</div>
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">Fast</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Median response under 1 second. Quotes served globally.
+        </p>
+      </div>
+      <div class="rounded-xl p-6 border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+        <div class="text-2xl mb-3">✍️</div>
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">Attributed</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Every quote includes the author's name — ready for display.
+        </p>
+      </div>
+      <div class="rounded-xl p-6 border border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+        <div class="text-2xl mb-3">📦</div>
+        <h3 class="font-semibold text-gray-900 dark:text-white mb-1">Batch ready</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          Fetch up to 50 quotes per request with the batch endpoint.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/dashboard/app/views/tools/quotes/show.html.erb
+++ b/apps/dashboard/app/views/tools/quotes/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Random Quote Generator — Free Quotes API Tool" %>
+<% content_for :description,
+   "Generate random inspirational quotes from famous thinkers, leaders, and innovators. Try the live demo and integrate the Quotes API into your app in minutes." %>
+
+<main class="min-h-screen bg-white dark:bg-gray-950">
+  <%= render "partials/tools/quotes/hero" %>
+  <%= render "partials/tools/quotes/what_it_does" %>
+  <%= render "partials/tools/quotes/use_cases" %>
+  <%= render "partials/tools/quotes/api_combinations" %>
+  <%= render "partials/tools/quotes/faq" %>
+  <%= render "partials/tools/quotes/cta" %>
+</main>

--- a/apps/dashboard/config/locales/en/tools.en.yml
+++ b/apps/dashboard/config/locales/en/tools.en.yml
@@ -1,0 +1,9 @@
+en:
+  tools:
+    quotes:
+      demo:
+        error_rate_limit: "Rate limit reached. Please wait a moment and try again."
+        error_generic: "Something went wrong. Please try again."
+        error_unexpected: "Unexpected response from the API."
+        error_network: "Network error. Please check your connection."
+        error_security_token: "Security token missing. Please refresh the page."

--- a/apps/dashboard/test/controllers/tools_controller_test.rb
+++ b/apps/dashboard/test/controllers/tools_controller_test.rb
@@ -13,6 +13,11 @@ class ToolsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "quotes tool page renders successfully" do
+    get "/en/tools/quotes"
+    assert_response :success
+  end
+
   test "unknown tool id redirects to root with alert" do
     get "/en/tools/not-a-real-tool"
     assert_redirected_to root_path


### PR DESCRIPTION
### Add Random Quotes SEO tool page with live demo

- Add `quotes` to `SUPPORTED_TOOLS` and `TOOLS_METADATA` in `ToolsController`
- Add `quotes_demo_controller.js` Stimulus controller (GET, no input, CSRF token, XSS prevention, 429 handling)
- Add `tools/quotes/show.html.erb` with unique title and meta description
- Add 6 partials: hero with live demo, what it does, use cases, API combinations, FAQ accordion, CTA
- Add controller tests: happy path + unknown tool redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Quotes** tool to the dashboard, including a dedicated **Random Quote Generator** page
  * Introduced an interactive **Random Quotes** live demo with loading indicators and friendly error messaging
  * Added detailed supporting sections (what it does, use cases, API pairing ideas, FAQ, and call-to-action/pricing info)
* **Tests**
  * Added a controller test to confirm the quotes tool page loads successfully
<!-- end of auto-generated comment: release notes by coderabbit.ai -->