### PR TITLE
Feat/input validate batch endpoint

### DIFF
--- a/apps/api/platform/httpx/handler.go
+++ b/apps/api/platform/httpx/handler.go
@@ -28,6 +28,13 @@ import (
 //	        return svc.CheckEmail(req.Email), nil
 //	    },
 //	))
+
+// UsageCounter is implemented by responses that report a usage count.
+// When implemented, Handle automatically sets the X-Usage-Count response header.
+type UsageCounter interface {
+	UsageCount() int
+}
+
 func Handle[Req any, Res any](
 	fn func(ctx context.Context, req Req) (Res, error),
 ) http.HandlerFunc {
@@ -61,6 +68,10 @@ func Handle[Req any, Res any](
 			sentry.CaptureException(err)
 			Error(w, http.StatusInternalServerError, "internal_error", "internal server error")
 			return
+		}
+
+		if uc, ok := any(res).(UsageCounter); ok {
+			w.Header().Set("X-Usage-Count", strconv.Itoa(uc.UsageCount()))
 		}
 
 		JSON(w, http.StatusOK, res)

--- a/apps/api/services/systems/data_integrity/input_validate_batch/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/service.go
@@ -1,0 +1,206 @@
+package inputvalidatebatch
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	inputvalidate "requiems-api/services/systems/data_integrity/input_validate"
+)
+
+// Item represents a single contact record to validate within a batch request.
+type Item struct {
+	Email string `json:"email" validate:"required" normalize:"trim"`
+	Phone string `json:"phone" validate:"required" normalize:"trim"`
+	Text  string `json:"text" normalize:"trim"`
+}
+
+// Request is the input payload for the batch validation endpoint.
+type Request struct {
+	Items []Item `json:"items" validate:"required,min=1,max=50,dive"`
+}
+
+// EmailResult carries the outcome of email validation and normalization.
+// Normalized is nil when Valid is false — no canonical form can be produced
+// for an invalid address.
+type EmailResult struct {
+	Valid        bool    `json:"valid"`
+	Normalized   *string `json:"normalized"`
+	QualityScore float64 `json:"quality_score"`
+	Disposable   bool    `json:"disposable"`
+}
+
+// PhoneResult carries the outcome of phone validation and normalization.
+// Normalized is nil when Valid is false.
+type PhoneResult struct {
+	Valid        bool    `json:"valid"`
+	Normalized   *string `json:"normalized"`
+	QualityScore float64 `json:"quality_score"`
+}
+
+type TextResult struct {
+	IsSafe        bool     `json:"is_safe"`
+	ToxicityScore *float64 `json:"toxicity_score"`
+	Sentiment     string   `json:"sentiment"`
+}
+
+// ItemResult holds the validation outcome for a single item in the batch.
+// Index mirrors the item's position in the original request array, preserving
+// order regardless of the order in which workers completed.
+// Error is non-nil only for processing failures (timeout, panic) — field-level
+// failures (bad email format) are expressed via Email.Valid / Phone.Valid instead.
+type ItemResult struct {
+	Index               int          `json:"index"`
+	Email               *EmailResult `json:"email"`
+	Phone               *PhoneResult `json:"phone"`
+	Text                *TextResult  `json:"text"`
+	OverallQualityScore float64      `json:"overall_quality_score"`
+	Error               *string      `json:"error"`
+}
+
+// BatchResponse is the top-level response envelope for the batch endpoint.
+// Results preserves input order via the Index field on each ItemResult.
+// AverageQualityScore is computed only over items that processed successfully;
+// items with a non-nil Error are excluded from the average.
+type BatchResponse struct {
+	Results             []ItemResult `json:"results"`
+	Total               int          `json:"total"`
+	ValidCount          int          `json:"valid_count"`
+	InvalidCount        int          `json:"invalid_count"`
+	AverageQualityScore float64      `json:"average_quality_score"`
+}
+
+// InputValidateService is the interface for the single-item validation logic
+type InputValidateService interface {
+	Validate(ctx context.Context, emailAddress, phoneNumber, text string) inputvalidate.Response
+}
+
+// Service holds the dependencies for batch validation.
+type Service struct {
+	InputValidateSvc InputValidateService
+}
+
+// NewService constructs a Service with its required dependency.
+func NewService(inputValidateSvc InputValidateService) *Service {
+	return &Service{
+		InputValidateSvc: inputValidateSvc,
+	}
+}
+
+// ValidateBatch runs up to 8 concurrent workers to validate each item in the
+// batch against the single-item validation service. Each item is given a
+// 2-second timeout; items that exceed it are marked with an error and counted
+// as invalid. Results preserve the original request order via the Index field.
+func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse {
+	const workers = 8
+	const perItemTimeout = 2 * time.Second
+
+	sem := make(chan struct{}, workers)
+	results := make([]ItemResult, len(items))
+
+	var (
+		mu                  sync.Mutex
+		wg                  sync.WaitGroup
+		validCount          int
+		invalidCount        int
+		sumQualityScore     float64
+		averageQualityScore float64
+	)
+
+	for i, item := range items {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, item Item) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			itemCtx, cancel := context.WithTimeout(ctx, perItemTimeout)
+			defer cancel()
+
+			ch := make(chan inputvalidate.Response, 1)
+
+			go func() {
+				ch <- s.InputValidateSvc.Validate(itemCtx, item.Email, item.Phone, item.Text)
+			}()
+
+			select {
+			case result := <-ch:
+				emailResult := EmailResult{
+					Valid:        result.Email.Valid,
+					QualityScore: result.Email.QualityScore,
+					Disposable:   result.Email.Disposable,
+				}
+
+				if result.Email.Normalized != nil {
+					emailResult.Normalized = result.Email.Normalized
+				}
+
+				phoneResult := PhoneResult{
+					Valid:        result.Phone.Valid,
+					QualityScore: result.Phone.QualityScore,
+				}
+
+				if result.Phone.Normalized != nil {
+					phoneResult.Normalized = result.Phone.Normalized
+				}
+
+				var textResult *TextResult
+				if result.Text != nil {
+					textResult = &TextResult{
+						IsSafe:        result.Text.IsSafe,
+						Sentiment:     result.Text.Sentiment,
+						ToxicityScore: result.Text.ToxicityScore,
+					}
+				}
+
+				mu.Lock()
+				if result.Email.Valid && result.Phone.Valid {
+					validCount++
+					sumQualityScore += result.OverallQualityScore
+				} else {
+					invalidCount++
+				}
+				mu.Unlock()
+
+				results[i] = ItemResult{
+					Index:               i,
+					Email:               &emailResult,
+					Phone:               &phoneResult,
+					Text:                textResult,
+					OverallQualityScore: result.OverallQualityScore,
+				}
+			case <-itemCtx.Done():
+				mu.Lock()
+				invalidCount++
+				mu.Unlock()
+
+				errMsg := "timeout: validation took longer than 2 seconds"
+				results[i] = ItemResult{
+					Index: i,
+					Error: &errMsg,
+				}
+			}
+		}(i, item)
+	}
+
+	wg.Wait()
+
+	if validCount > 0 {
+		averageQualityScore = sumQualityScore / float64(validCount)
+	}
+
+	return BatchResponse{
+		Results:             results,
+		ValidCount:          validCount,
+		InvalidCount:        invalidCount,
+		Total:               len(items),
+		AverageQualityScore: averageQualityScore,
+	}
+}
+
+// UsageCount implements the UsageCounter interface, allowing Handle to
+// automatically set the X-Usage-Count response header with the total
+// number of items processed in the batch.
+func (b BatchResponse) UsageCount() int {
+	return b.Total
+}

--- a/apps/api/services/systems/data_integrity/input_validate_batch/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/service.go
@@ -101,6 +101,7 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 	var (
 		mu                  sync.Mutex
 		wg                  sync.WaitGroup
+		processedCount      int
 		validCount          int
 		invalidCount        int
 		sumQualityScore     float64
@@ -154,9 +155,10 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 				}
 
 				mu.Lock()
+				processedCount++
+				sumQualityScore += result.OverallQualityScore
 				if result.Email.Valid && result.Phone.Valid {
 					validCount++
-					sumQualityScore += result.OverallQualityScore
 				} else {
 					invalidCount++
 				}
@@ -185,8 +187,8 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 
 	wg.Wait()
 
-	if validCount > 0 {
-		averageQualityScore = sumQualityScore / float64(validCount)
+	if processedCount > 0 {
+		averageQualityScore = sumQualityScore / float64(processedCount)
 	}
 
 	return BatchResponse{

--- a/apps/api/services/systems/data_integrity/input_validate_batch/service.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/service.go
@@ -99,13 +99,12 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 	results := make([]ItemResult, len(items))
 
 	var (
-		mu                  sync.Mutex
-		wg                  sync.WaitGroup
-		processedCount      int
-		validCount          int
-		invalidCount        int
-		sumQualityScore     float64
-		averageQualityScore float64
+		mu              sync.Mutex
+		wg              sync.WaitGroup
+		processedCount  int
+		validCount      int
+		invalidCount    int
+		sumQualityScore float64
 	)
 
 	for i, item := range items {
@@ -118,14 +117,33 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 			itemCtx, cancel := context.WithTimeout(ctx, perItemTimeout)
 			defer cancel()
 
-			ch := make(chan inputvalidate.Response, 1)
+			type validateOutcome struct {
+				res      inputvalidate.Response
+				panicMsg *string
+			}
+			ch := make(chan validateOutcome, 1)
 
 			go func() {
-				ch <- s.InputValidateSvc.Validate(itemCtx, item.Email, item.Phone, item.Text)
+				defer func() {
+					if r := recover(); r != nil {
+						msg := "panic: validation worker failed"
+						ch <- validateOutcome{panicMsg: &msg}
+					}
+				}()
+				ch <- validateOutcome{res: s.InputValidateSvc.Validate(itemCtx, item.Email, item.Phone, item.Text)}
 			}()
 
 			select {
-			case result := <-ch:
+			case out := <-ch:
+				if out.panicMsg != nil {
+					mu.Lock()
+					invalidCount++
+					mu.Unlock()
+					results[i] = ItemResult{Index: i, Error: out.panicMsg}
+					return
+				}
+				result := out.res
+
 				emailResult := EmailResult{
 					Valid:        result.Email.Valid,
 					QualityScore: result.Email.QualityScore,
@@ -187,6 +205,7 @@ func (s *Service) ValidateBatch(ctx context.Context, items []Item) BatchResponse
 
 	wg.Wait()
 
+	var averageQualityScore float64
 	if processedCount > 0 {
 		averageQualityScore = sumQualityScore / float64(processedCount)
 	}

--- a/apps/api/services/systems/data_integrity/input_validate_batch/transport_http.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/transport_http.go
@@ -1,0 +1,19 @@
+package inputvalidatebatch
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+
+	"requiems-api/platform/httpx"
+)
+
+// RegisterRoutes mounts the input validate batch handler on the given router.
+func RegisterRoutes(r chi.Router, svc *Service) {
+	r.Post("/input/validate/batch", httpx.Handle(
+
+		func(ctx context.Context, req Request) (BatchResponse, error) {
+			return svc.ValidateBatch(ctx, req.Items), nil
+		},
+	))
+}

--- a/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
@@ -1,0 +1,276 @@
+package inputvalidatebatch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"requiems-api/platform/httpx"
+	inputvalidate "requiems-api/services/systems/data_integrity/input_validate"
+)
+
+func setupRouter(inputValidateSvc InputValidateService) chi.Router {
+	r := chi.NewRouter()
+	svc := NewService(inputValidateSvc)
+	RegisterRoutes(r, svc)
+	return r
+}
+
+type stubInputValidateService struct {
+	responses map[string]inputvalidate.Response
+}
+
+func (s *stubInputValidateService) Validate(ctx context.Context, email, phone, text string) inputvalidate.Response {
+	return s.responses[email]
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+type stubInputValidateServiceWithTimeout struct {
+	responses map[string]inputvalidate.Response
+	blockOn   string // email que va a causar timeout
+}
+
+func (s *stubInputValidateServiceWithTimeout) Validate(ctx context.Context, email, phone, text string) inputvalidate.Response {
+	if email == s.blockOn {
+		<-ctx.Done()
+		return inputvalidate.Response{}
+	}
+	return s.responses[email]
+}
+
+func validEmailResult(email string) inputvalidate.Response {
+	normalized := email
+	country := "US"
+	phoneNormalized := "+14155550001"
+
+	return inputvalidate.Response{
+		Email: &inputvalidate.EmailResult{
+			Valid:        true,
+			Normalized:   &normalized,
+			Original:     email,
+			SyntaxValid:  true,
+			MXValid:      true,
+			Disposable:   false,
+			Flags:        []string{},
+			QualityScore: 0.98,
+		},
+		Phone: &inputvalidate.PhoneResult{
+			Valid:        true,
+			Normalized:   &phoneNormalized,
+			Country:      &country,
+			Flags:        []string{},
+			QualityScore: 0.95,
+		},
+		OverallQualityScore: 0.97,
+	}
+}
+
+func post(t *testing.T, r chi.Router, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/input/validate/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestValidateBatch_TwoValidItems(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateService{
+		responses: map[string]inputvalidate.Response{
+			"alice@example.com": validEmailResult("alice@example.com"),
+			"bob@example.com":   validEmailResult("bob@example.com"),
+		},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{
+    "items": [
+        { "email": "alice@example.com", "phone": "+14155550001" },
+        { "email": "bob@example.com",   "phone": "+14155550002" }
+    ]
+}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, 2, resp.Data.Total)
+	assert.Equal(t, 2, resp.Data.ValidCount)
+	assert.Equal(t, 0, resp.Data.InvalidCount)
+	assert.Greater(t, resp.Data.AverageQualityScore, 0.9)
+}
+
+func invalidEmailResult(email string) inputvalidate.Response {
+	country := "US"
+	phoneNormalized := "+14155550003"
+
+	return inputvalidate.Response{
+		Email: &inputvalidate.EmailResult{
+			Valid:        false,
+			Normalized:   nil,
+			Original:     email,
+			SyntaxValid:  false,
+			MXValid:      false,
+			Disposable:   false,
+			Flags:        []string{"invalid_syntax"},
+			QualityScore: 0.0,
+		},
+		Phone: &inputvalidate.PhoneResult{
+			Valid:        true,
+			Normalized:   &phoneNormalized,
+			Country:      &country,
+			Flags:        []string{},
+			QualityScore: 0.95,
+		},
+		OverallQualityScore: 0.0,
+	}
+}
+
+func TestValidateBatch_MixValidAndInvalid(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateService{
+		responses: map[string]inputvalidate.Response{
+			"alice@example.com": validEmailResult("alice@example.com"),
+			"invalid-email":     invalidEmailResult("invalid-email"),
+		},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{
+		"items": [
+			{ "email": "alice@example.com", "phone": "+14155550001" },
+			{ "email": "invalid-email",     "phone": "+14155550003" }
+		]
+	}`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, 2, resp.Data.Total)
+	assert.Equal(t, 1, resp.Data.ValidCount)
+	assert.Equal(t, 1, resp.Data.InvalidCount)
+
+	// per-item valid differs
+	assert.True(t, resp.Data.Results[0].Email.Valid)
+	assert.False(t, resp.Data.Results[1].Email.Valid)
+}
+
+func TestValidateBatch_OneItemTimeout(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateServiceWithTimeout{
+		blockOn: "slow@example.com",
+		responses: map[string]inputvalidate.Response{
+			"alice@example.com": validEmailResult("alice@example.com"),
+			"bob@example.com":   validEmailResult("bob@example.com"),
+		},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{
+        "items": [
+            { "email": "alice@example.com", "phone": "+14155550001" },
+            { "email": "slow@example.com",  "phone": "+14155550002" },
+            { "email": "bob@example.com",   "phone": "+14155550003" }
+        ]
+    }`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, 3, resp.Data.Total)
+	assert.Equal(t, 2, resp.Data.ValidCount)
+	assert.Equal(t, 1, resp.Data.InvalidCount)
+
+	assert.NotNil(t, resp.Data.Results[1].Error)
+
+	assert.Nil(t, resp.Data.Results[0].Error)
+	assert.Nil(t, resp.Data.Results[2].Error)
+}
+
+func TestValidateBatch_Over50Items(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateService{
+		responses: map[string]inputvalidate.Response{},
+	}
+
+	r := setupRouter(stub)
+
+	items := make([]Item, 51)
+	for i := range items {
+		items[i] = Item{
+			Email: "contact@example.com",
+			Phone: "+14155550001",
+		}
+	}
+
+	body, _ := json.Marshal(Request{
+		Items: items,
+	})
+
+	w := post(t, r, string(body))
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestValidateBatch_EmptyItems(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateService{
+		responses: map[string]inputvalidate.Response{},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+}
+
+func TestValidateBatch_SetsUsageCountHeader(t *testing.T) {
+	stub := &stubInputValidateService{
+		responses: map[string]inputvalidate.Response{
+			"alice@example.com": validEmailResult("alice@example.com"),
+			"invalid-email":     invalidEmailResult("invalid-email"),
+		},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{
+		"items": [
+			{ "email": "alice@example.com", "phone": "+14155550001" },
+			{ "email": "invalid-email",     "phone": "+14155550003" }
+		]
+	}`)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	if got := w.Header().Get("X-Usage-Count"); got != "2" {
+		t.Errorf("Expected X-Usage-Count: 2, got %q", got)
+	}
+}

--- a/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
@@ -25,21 +25,17 @@ func setupRouter(inputValidateSvc InputValidateService) chi.Router {
 
 type stubInputValidateService struct {
 	responses map[string]inputvalidate.Response
+	blockOn   string
+	panicOn   string
 }
 
 func (s *stubInputValidateService) Validate(ctx context.Context, email, phone, text string) inputvalidate.Response {
-	return s.responses[email]
-}
-
-type stubInputValidateServiceWithTimeout struct {
-	responses map[string]inputvalidate.Response
-	blockOn   string // email que va a causar timeout
-}
-
-func (s *stubInputValidateServiceWithTimeout) Validate(ctx context.Context, email, phone, text string) inputvalidate.Response {
 	if email == s.blockOn {
 		<-ctx.Done()
 		return inputvalidate.Response{}
+	}
+	if email == s.panicOn {
+		panic("simulated panic")
 	}
 	return s.responses[email]
 }
@@ -167,12 +163,16 @@ func TestValidateBatch_MixValidAndInvalid(t *testing.T) {
 	// per-item valid differs
 	assert.True(t, resp.Data.Results[0].Email.Valid)
 	assert.False(t, resp.Data.Results[1].Email.Valid)
+
+	// average includes both valid and invalid processed items
+	// alice: 0.97, invalid-email: 0.0 → average = 0.485
+	assert.InDelta(t, 0.485, resp.Data.AverageQualityScore, 0.01)
 }
 
 func TestValidateBatch_OneItemTimeout(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubInputValidateServiceWithTimeout{
+	stub := &stubInputValidateService{
 		blockOn: "slow@example.com",
 		responses: map[string]inputvalidate.Response{
 			"alice@example.com": validEmailResult("alice@example.com"),
@@ -203,6 +203,9 @@ func TestValidateBatch_OneItemTimeout(t *testing.T) {
 
 	assert.Nil(t, resp.Data.Results[0].Error)
 	assert.Nil(t, resp.Data.Results[2].Error)
+
+	// only alice and bob are included in average, slow@example.com timed out
+	assert.InDelta(t, 0.97, resp.Data.AverageQualityScore, 0.01)
 }
 
 func TestValidateBatch_Over50Items(t *testing.T) {
@@ -269,4 +272,43 @@ func TestValidateBatch_SetsUsageCountHeader(t *testing.T) {
 	if got := w.Header().Get("X-Usage-Count"); got != "2" {
 		t.Errorf("Expected X-Usage-Count: 2, got %q", got)
 	}
+}
+
+func TestValidateBatch_OneItemPanic(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInputValidateService{
+		panicOn: "panic@example.com",
+		responses: map[string]inputvalidate.Response{
+			"alice@example.com": validEmailResult("alice@example.com"),
+			"bob@example.com":   validEmailResult("bob@example.com"),
+		},
+	}
+
+	r := setupRouter(stub)
+
+	w := post(t, r, `{
+        "items": [
+            { "email": "alice@example.com", "phone": "+14155550001" },
+            { "email": "panic@example.com", "phone": "+14155550002" },
+            { "email": "bob@example.com",   "phone": "+14155550003" }
+        ]
+    }`)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp httpx.Response[BatchResponse]
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, 3, resp.Data.Total)
+	assert.Equal(t, 2, resp.Data.ValidCount)
+	assert.Equal(t, 1, resp.Data.InvalidCount)
+
+	// panic item has error, others don't
+	assert.Nil(t, resp.Data.Results[0].Error)
+	assert.NotNil(t, resp.Data.Results[1].Error)
+	assert.Nil(t, resp.Data.Results[2].Error)
+
+	// panic item is excluded from average
+	assert.InDelta(t, 0.97, resp.Data.AverageQualityScore, 0.01)
 }

--- a/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
+++ b/apps/api/services/systems/data_integrity/input_validate_batch/transport_http_test.go
@@ -31,10 +31,6 @@ func (s *stubInputValidateService) Validate(ctx context.Context, email, phone, t
 	return s.responses[email]
 }
 
-func strPtr(s string) *string {
-	return &s
-}
-
 type stubInputValidateServiceWithTimeout struct {
 	responses map[string]inputvalidate.Response
 	blockOn   string // email que va a causar timeout

--- a/apps/api/services/systems/data_integrity/router.go
+++ b/apps/api/services/systems/data_integrity/router.go
@@ -8,6 +8,7 @@ import (
 	contentmoderate "requiems-api/services/systems/data_integrity/content_moderate"
 	domaintrust "requiems-api/services/systems/data_integrity/domain_trust"
 	inputvalidate "requiems-api/services/systems/data_integrity/input_validate"
+	inputvalidatebatch "requiems-api/services/systems/data_integrity/input_validate_batch"
 	textnormalize "requiems-api/services/systems/data_integrity/text_normalize"
 	"requiems-api/services/text/detectlanguage"
 	"requiems-api/services/text/sentiment"
@@ -34,4 +35,7 @@ func RegisterRoutes(r chi.Router) {
 	phoneSvc := phone.NewService()
 	inputValidateSvc := inputvalidate.NewService(emailSvc, phoneSvc, profanitySvc, sentimentSvc)
 	inputvalidate.RegisterRoutes(r, inputValidateSvc)
+
+	inputValidateBatchSvc := inputvalidatebatch.NewService(inputValidateSvc)
+	inputvalidatebatch.RegisterRoutes(r, inputValidateBatchSvc)
 }

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -17,6 +17,233 @@ overview:
     - Unicode normalization, HTML stripping, case conversion, and whitespace collapsing
     - Safe for any text content — no data is stored or logged
 endpoints:
+  - name: Batch Input Validate
+    method: POST
+    path: /v1/systems/input/validate/batch
+    description: Validates and scores a batch of up to 50 contact records in a single request. Each record is processed independently — one item failing does not affect others. Returns per-item email, phone, and text validation results with quality scores, normalized values, plus batch-level aggregates including total, valid_count, invalid_count, and average_quality_score.
+    parameters:
+      - name: items
+        type: array
+        required: true
+        location: body
+        description: "Array of contact records to validate. Each item must include email and phone. Text is optional. Min: 1, Max: 50."
+        example: '[{"email":"alice@example.com","phone":"+14155550001"},{"email":"bob@example.com","phone":"+14155550002"}]'
+    response_example: |
+      {
+        "data": {
+          "results": [
+            {
+              "index": 0,
+              "email": {
+                "valid": true,
+                "normalized": "alice@example.com",
+                "quality_score": 1,
+                "disposable": false
+              },
+              "phone": {
+                "valid": true,
+                "normalized": "+1 415-555-0001",
+                "quality_score": 1
+              },
+                "text": null,
+                "overall_quality_score": 1,
+                "error": null
+              },
+              {
+              "index": 1,
+              "email": {
+                "valid": true,
+                "normalized": "bob@example.com",
+                "quality_score": 1,
+                "disposable": false
+              },
+              "phone": {
+                "valid": true,
+                "normalized": "+1 415-555-0002",
+                "quality_score": 1
+              },
+              "text": null,
+              "overall_quality_score": 1,
+              "error": null
+            }
+          ],
+          "total": 2,
+          "valid_count": 2,
+          "invalid_count": 0,
+          "average_quality_score": 1
+        },
+        "metadata": {
+          "timestamp": "2026-06-16T21:28:14Z"
+        }
+      }
+    response_fields:
+      - name: results
+        type: array
+        description: List of validation results, one per input item. Preserves the original submission order via the index field.
+      - name: results[].index
+        type: integer
+        description: Zero-based position of the item in the original request array.
+      - name: results[].email
+        type: object or null
+        description: Email validation result. Null when email was not provided for this item.
+      - name: results[].email.valid
+        type: boolean
+        description: True when the email passes syntax and MX validation.
+      - name: results[].email.normalized
+        type: string or null
+        description: Normalized form of the email address. Null when syntax is invalid.
+      - name: results[].email.quality_score
+        type: number
+        description: Email quality score from 0.0 to 1.0. Penalized by invalidity, disposable domain, and suggestions.
+      - name: results[].email.disposable
+        type: boolean
+        description: True when the email domain is a known disposable or temporary provider.
+      - name: results[].phone
+        type: object or null
+        description: Phone validation result. Null when phone was not provided for this item.
+      - name: results[].phone.valid
+        type: boolean
+        description: True when the phone number is valid and dialable.
+      - name: results[].phone.normalized
+        type: string or null
+        description: Normalized phone number in international format. Null when the number is invalid.
+      - name: results[].phone.quality_score
+        type: number
+        description: Phone quality score from 0.0 to 1.0. Penalized by invalidity, VoIP, virtual, landline, and unknown type.
+      - name: results[].text
+        type: object or null
+        description: Text analysis result. Null when text was not provided for this item.
+      - name: results[].overall_quality_score
+        type: number
+        description: >-
+          Weighted quality score from 0.0 to 1.0 combining email and phone fields only.
+          Weights are email 0.5 and phone 0.4, adjusted proportionally when one field is absent.
+          Text does not currently contribute to this score — scoring will be enabled once
+          toxicity_score is available from the sentiment service.
+          Returns 0.0 when only text is provided.
+      - name: results[].error
+        type: string or null
+        description: >-
+          Error message when this item could not be processed due to an unexpected failure,
+          such as a service timeout or malformed input. Null when the item was processed
+          successfully, regardless of whether the fields passed validation or not.
+      - name: total
+        type: integer
+        description: Total number of items in the batch.
+      - name: valid_count
+        type: integer
+        description: Number of items where all provided fields have valid set to true.
+      - name: invalid_count
+        type: integer
+        description: Number of items where at least one provided field has valid set to false.
+      - name: average_quality_score
+        type: number
+        description: Average of overall_quality_score across all items in the batch.
+    errors:
+      - code: 422
+        message: validation_failed
+        description: The request body is invalid.
+      - code: 401
+        message: unauthorized
+        description: Missing or invalid API key.
+    code_examples:
+      curl: |
+        curl -X POST https://api.requiems.xyz/v1/systems/input/validate/batch \
+          -H "requiems-api-key: YOUR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "items": [
+              {"email": "alice@example.com", "phone": "+12015551001"},
+              {"email": "bob@example.com", "phone": "+12015551002"},
+              {"email": "carol@example.com", "phone": "+12015551003"}
+            ]
+          }'
+      python: |
+        import requests
+
+        response = requests.post(
+          "https://api.requiems.xyz/v1/systems/input/validate/batch",
+          headers={"requiems-api-key": "YOUR_API_KEY"},
+          json={
+            "items": [
+              {"email": "alice@example.com", "phone": "+12015551001"},
+              {"email": "bob@example.com", "phone": "+12015551002"},
+              {"email": "carol@example.com", "phone": "+12015551003"}
+            ]
+          }
+        )
+
+        data = response.json()["data"]
+
+        print(f"Total: {data['total']} | Valid: {data['valid_count']} | Invalid: {data['invalid_count']}")
+        print(f"Average quality score: {data['average_quality_score']}")
+
+        for item in data["results"]:
+          print(f"\n[{item['index']}]")
+          if item.get("error"):
+            print(f"  Error: {item['error']}")
+            continue
+          if item.get("email"):
+            print(f"  Email valid: {item['email']['valid']} | Score: {item['email']['quality_score']}")
+          if item.get("phone"):
+            print(f"  Phone valid: {item['phone']['valid']} | Score: {item['phone']['quality_score']}")
+          print(f"  Overall quality score: {item['overall_quality_score']}")
+      javascript: |
+        const { data } = await fetch('https://api.requiems.xyz/v1/systems/input/validate/batch', {
+          method: 'POST',
+          headers: { 'requiems-api-key': 'YOUR_API_KEY', 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: [
+              { email: 'alice@example.com', phone: '+12015551001' },
+              { email: 'bob@example.com', phone: '+12015551002' },
+              { email: 'carol@example.com', phone: '+12015551003' }
+            ]
+          })
+        }).then(r => r.json());
+
+        console.log(`Total: ${data.total} | Valid: ${data.valid_count} | Invalid: ${data.invalid_count}`);
+        console.log(`Average quality score: ${data.average_quality_score}`);
+
+        for (const item of data.results) {
+          console.log(`\n[${item.index}]`);
+          if (item.error) { console.log(`  Error: ${item.error}`); continue; }
+          if (item.email) console.log(`  Email valid: ${item.email.valid} | Score: ${item.email.quality_score}`);
+          if (item.phone) console.log(`  Phone valid: ${item.phone.valid} | Score: ${item.phone.quality_score}`);
+          console.log(`  Overall quality score: ${item.overall_quality_score}`);
+        }
+      ruby: |
+        require 'net/http'
+        require 'json'
+
+        uri = URI('https://api.requiems.xyz/v1/systems/input/validate/batch')
+        request = Net::HTTP::Post.new(uri)
+        request['requiems-api-key'] = 'YOUR_API_KEY'
+        request['Content-Type'] = 'application/json'
+        request.body = {
+          items: [
+            { email: 'alice@example.com', phone: '+12015551001' },
+            { email: 'bob@example.com', phone: '+12015551002' },
+            { email: 'carol@example.com', phone: '+12015551003' }
+          ]
+        }.to_json
+
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |h| h.request(request) }
+        data = JSON.parse(response.body)['data']
+
+        puts "Total: #{data['total']} | Valid: #{data['valid_count']} | Invalid: #{data['invalid_count']}"
+        puts "Average quality score: #{data['average_quality_score']}"
+
+        data['results'].each do |item|
+          puts "\n[#{item['index']}]"
+          if item['error']
+            puts "  Error: #{item['error']}"
+            next
+          end
+          puts "  Email valid: #{item['email']['valid']} | Score: #{item['email']['quality_score']}" if item['email']
+          puts "  Phone valid: #{item['phone']['valid']} | Score: #{item['phone']['quality_score']}" if item['phone']
+          puts "  Overall quality score: #{item['overall_quality_score']}"
+        end
+
   - name: Input Validate
     method: POST
     path: /v1/systems/input/validate

--- a/apps/dashboard/config/api_docs/data-integrity.yml
+++ b/apps/dashboard/config/api_docs/data-integrity.yml
@@ -135,10 +135,14 @@ endpoints:
         description: Number of items where all provided fields have valid set to true.
       - name: invalid_count
         type: integer
-        description: Number of items where at least one provided field has valid set to false.
+        description: >-
+          Number of items where at least one provided field has valid set to false,
+          or where processing failed due to a timeout or unexpected error.
       - name: average_quality_score
         type: number
-        description: Average of overall_quality_score across all items in the batch.
+        description: >-
+          Average of overall_quality_score across all successfully processed items.
+          Items that failed due to a timeout or unexpected error are excluded from this average.
     errors:
       - code: 422
         message: validation_failed


### PR DESCRIPTION
## Endpoint

Adds `POST /input/validate/batch` for validating up to 50 contact records concurrently. Each item requires email and phone; text is optional. Up to 8 items are processed in parallel, each with a 2-second timeout. Results preserve the original request order via the index field and include per-item validation outcome, quality scores, and an error field for processing failures. The response includes batch-level aggregates: total, valid_count, invalid_count, and average_quality_score.

## Tests

Covers two valid items, mixed valid and invalid items, one item timeout, over 50 items (422), empty items (422), and X-Usage-Count header value.

## Docs

Adds documentation for the batch endpoint including request fields, response fields, error codes, and code examples.

## Handle

Adds a UsageCounter interface to httpx. Responses that implement UsageCount() int are detected automatically by Handle at response time, which sets the X-Usage-Count response header without requiring changes to handler registration. This was needed because the batch endpoint has a non-standard response shape with additional aggregates beyond a simple results array, making HandleBatch unsuitable. BatchResponse implements this interface returning Total, allowing the endpoint to opt in to usage tracking without being forced into HandleBatch's response contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new batch input validation endpoint that accepts up to 50 contact records per request.
  * Returns per-item validation results for email, phone, and text (including optional normalization/safety details), along with batch-level aggregates such as total, valid/invalid counts, and average quality score.
  * Includes a usage-count response header reflecting the number of submitted items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->