### PR TITLE
Feat/acc 1 weighted signal confidence

### DIFF
--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -37,6 +37,16 @@ type Resolved struct {
 	IPResult    *ipinfo.LookupResponse
 }
 
+const (
+	emailMXWeight         = 0.95 // emailMXWeight reflects ~95% reliability of MX record validation.
+	emailDisposableWeight = 0.85 // emailDisposableWeight is slightly lower as some disposable providers use legitimate domains.
+	voipWeight            = 0.70 // voipWeight is lower due to inconsistent detection across carriers and regions.
+	vitualWeight          = 0.70 // virtualWeight mirrors voipWeight — virtual numbers share similar detection uncertainty.
+	ipFraudWeight         = 0.80 // ipFraudWeight reflects external provider accuracy, which varies by data freshness.
+	proxyWeight           = 0.90 // proxyWeight is high — proxy detection is well-established and reliable.
+	torWeight             = 0.90 // torWeight is high — TOR exit node lists are maintained and highly accurate.
+)
+
 func Resolve(
 	ctx context.Context,
 	emailSvc EmailChecker,
@@ -146,8 +156,6 @@ type ScoreResult struct {
 	Flags      []string
 }
 
-const totalSignals = 3
-
 func Compute(s Signals) ScoreResult {
 	flags := make([]string, 0, 4)
 	score := scoreEmail(s, &flags) + scorePhone(s, &flags) + scoreIP(s, &flags)
@@ -237,15 +245,52 @@ func roundScore(score float64) float64 {
 }
 
 func signalConfidence(s Signals) float64 {
-	present := 0
+	numerator := 0.0
+	denominator := 0.0
+
 	if s.EmailPresent {
-		present++
+		denominator += emailMXWeight + emailDisposableWeight
+
+		if !s.EmailNoMX {
+			numerator += emailMXWeight
+		}
+
+		if !s.EmailDisposable {
+			numerator += emailDisposableWeight
+		}
 	}
 	if s.PhonePresent {
-		present++
+
+		denominator += voipWeight + vitualWeight
+
+		if !s.PhoneVoIP {
+			numerator += voipWeight
+		}
+
+		if !s.PhoneVirtual {
+			numerator += vitualWeight
+		}
 	}
 	if s.IPPresent {
-		present++
+		denominator += ipFraudWeight + torWeight + proxyWeight
+
+		if !s.IsProxy {
+			numerator += proxyWeight
+		}
+
+		if !s.IsTOR {
+			numerator += torWeight
+		}
+
+		if s.FraudScore == 0 {
+			numerator += ipFraudWeight
+		}
+
 	}
-	return math.Round(float64(present)/float64(totalSignals)*100) / 100
+
+	if denominator == 0 {
+		return 0
+	}
+
+	return math.Round(numerator/denominator*100) / 100
 }

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer.go
@@ -101,6 +101,7 @@ func Resolve(
 				mu.Lock()
 				out.VPNResult = &r
 				out.Signals.IPPresent = true
+				out.Signals.IPRiskChecked = true
 				out.Signals.IsTOR = r.IsTor
 				out.Signals.IsProxy = r.IsProxy
 				out.Signals.IsVPN = r.IsVPN
@@ -140,13 +141,14 @@ type Signals struct {
 	PhoneVirtual bool
 	PhoneCountry string
 
-	IPPresent  bool
-	IsTOR      bool
-	IsProxy    bool
-	IsVPN      bool
-	IsHosting  bool
-	FraudScore int
-	IPCountry  string
+	IPPresent     bool
+	IPRiskChecked bool
+	IsTOR         bool
+	IsProxy       bool
+	IsVPN         bool
+	IsHosting     bool
+	FraudScore    int
+	IPCountry     string
 }
 
 type ScoreResult struct {
@@ -271,7 +273,7 @@ func signalConfidence(s Signals) float64 {
 			numerator += vitualWeight
 		}
 	}
-	if s.IPPresent {
+	if s.IPRiskChecked {
 		denominator += ipFraudWeight + torWeight + proxyWeight
 
 		if !s.IsProxy {

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
@@ -1,0 +1,130 @@
+package scorer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalConfidence_NoSignals(t *testing.T) {
+	s := Signals{}
+
+	got := signalConfidence(s)
+
+	assert.Equal(t, 0.0, got)
+}
+
+func TestSignalConfidence_SingleHighQualitySignal(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailDisposable: false,
+		EmailNoMX:       false,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Greater(t, got, 0.7)
+}
+
+func TestSignalConfidence_EmailAllRisk(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       true,
+		EmailDisposable: true,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Equal(t, 0.0, got)
+}
+
+func TestSignalConfidence_AllSignalsClean(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: false,
+
+		PhonePresent: true,
+		PhoneVoIP:    false,
+		PhoneVirtual: false,
+
+		IPPresent:  true,
+		IsProxy:    false,
+		IsTOR:      false,
+		FraudScore: 0,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Equal(t, 1.0, got)
+}
+
+func TestSignalConfidence_Mixed(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: true,
+
+		PhonePresent: true,
+		PhoneVoIP:    false,
+		PhoneVirtual: false,
+
+		IPPresent:  true,
+		IsProxy:    true,
+		IsTOR:      false,
+		FraudScore: 0,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Greater(t, got, 0.0)
+	assert.Less(t, got, 1.0)
+}
+
+func TestCompute_ConfidenceMatchesSignalConfidence(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: false,
+	}
+
+	result := Compute(s)
+	expected := signalConfidence(s)
+
+	assert.Equal(t, expected, result.Confidence)
+}
+
+func TestCompute_IsSafe_LowScoreHighConfidence(t *testing.T) {
+	s := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: false,
+	}
+
+	result := Compute(s)
+
+	assert.True(t, result.IsSafe)
+}
+
+func TestCompute_IsSafe_FalseWhenTOROrProxy(t *testing.T) {
+	tor := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: false,
+		IPPresent:       true,
+		IsTOR:           true,
+		FraudScore:      0,
+	}
+
+	proxy := Signals{
+		EmailPresent:    true,
+		EmailNoMX:       false,
+		EmailDisposable: false,
+		IPPresent:       true,
+		IsProxy:         true,
+		FraudScore:      0,
+	}
+
+	assert.False(t, Compute(tor).IsSafe)
+	assert.False(t, Compute(proxy).IsSafe)
+}

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
@@ -1,10 +1,87 @@
 package scorer
 
 import (
+	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	ipinfo "requiems-api/services/networking/ip/info"
+	ipvpn "requiems-api/services/networking/ip/vpn"
+	"requiems-api/services/validation/email"
+	"requiems-api/services/validation/phone"
 )
+
+type stubEmail struct{ r email.Validation }
+
+func (s *stubEmail) ValidateEmail(_ context.Context, _ string) email.Validation { return s.r }
+
+type stubPhone struct{ r phone.ValidateResponse }
+
+func (s *stubPhone) Validate(_ string) phone.ValidateResponse { return s.r }
+
+type stubVPN struct {
+	r   ipvpn.IPCheckResponse
+	err error
+}
+
+func (s *stubVPN) CheckIP(_ context.Context, _ net.IP) (ipvpn.IPCheckResponse, error) {
+	return s.r, s.err
+}
+
+type stubIPInfo struct {
+	r   ipinfo.LookupResponse
+	err error
+}
+
+func (s *stubIPInfo) CheckInfo(_ context.Context, _ string) (ipinfo.LookupResponse, error) {
+	return s.r, s.err
+}
+
+func cleanEmail() email.Validation {
+	v, mx := true, true
+	normalized := "user@example.com"
+	domain := "example.com"
+	return email.Validation{Valid: v, SyntaxValid: true, MxValid: mx, Disposable: false, Normalized: &normalized, Domain: &domain}
+}
+
+func TestResolve_CleanEmail_SetsExpectedSignals(t *testing.T) {
+	ctx := context.Background()
+
+	resolved := Resolve(
+		ctx,
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{},
+		nil,
+		nil,
+		"user@example.com", "", "",
+	)
+
+	assert.True(t, resolved.Signals.EmailPresent)
+	assert.False(t, resolved.Signals.EmailNoMX)
+	assert.False(t, resolved.Signals.EmailDisposable)
+	assert.False(t, resolved.Signals.EmailInvalid)
+	assert.False(t, resolved.Signals.IPRiskChecked)
+}
+
+func TestResolve_IPRiskChecked_WhenVPNSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	resolved := Resolve(
+		ctx,
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{},
+		&stubVPN{r: ipvpn.IPCheckResponse{IsProxy: false, IsTor: false, FraudScore: 0}},
+		&stubIPInfo{},
+		"user@example.com", "", "8.8.8.8",
+	)
+
+	assert.True(t, resolved.Signals.IPRiskChecked)
+	assert.False(t, resolved.Signals.IsProxy)
+	assert.False(t, resolved.Signals.IsTOR)
+	assert.Equal(t, 0, resolved.Signals.FraudScore)
+}
 
 func TestSignalConfidence_NoSignals(t *testing.T) {
 	s := Signals{}

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
@@ -23,7 +23,7 @@ func TestSignalConfidence_SingleHighQualitySignal(t *testing.T) {
 
 	got := signalConfidence(s)
 
-	assert.Greater(t, got, 0.7)
+	assert.Equal(t, 1.0, got)
 }
 
 func TestSignalConfidence_EmailAllRisk(t *testing.T) {

--- a/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
+++ b/apps/api/services/systems/identity_risk/internal/scorer/scorer_test.go
@@ -65,6 +65,23 @@ func TestResolve_CleanEmail_SetsExpectedSignals(t *testing.T) {
 	assert.False(t, resolved.Signals.IPRiskChecked)
 }
 
+func TestResolve_PhonePresent_SetsExpectedSignals(t *testing.T) {
+	ctx := context.Background()
+
+	resolved := Resolve(
+		ctx,
+		&stubEmail{r: cleanEmail()},
+		&stubPhone{r: phone.ValidateResponse{Valid: true, Country: "US"}},
+		nil,
+		nil,
+		"user@example.com", "+13235551234", "",
+	)
+
+	assert.True(t, resolved.Signals.PhonePresent)
+	assert.False(t, resolved.Signals.PhoneInvalid)
+	assert.Equal(t, "US", resolved.Signals.PhoneCountry)
+}
+
 func TestResolve_IPRiskChecked_WhenVPNSucceeds(t *testing.T) {
 	ctx := context.Background()
 
@@ -204,4 +221,32 @@ func TestCompute_IsSafe_FalseWhenTOROrProxy(t *testing.T) {
 
 	assert.False(t, Compute(tor).IsSafe)
 	assert.False(t, Compute(proxy).IsSafe)
+}
+
+func TestSignalConfidence_IPAllClean(t *testing.T) {
+	s := Signals{
+		IPPresent:     true,
+		IPRiskChecked: true,
+		IsProxy:       false,
+		IsTOR:         false,
+		FraudScore:    0,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Equal(t, 1.0, got)
+}
+
+func TestSignalConfidence_IPAllRisk(t *testing.T) {
+	s := Signals{
+		IPPresent:     true,
+		IPRiskChecked: true,
+		IsProxy:       true,
+		IsTOR:         true,
+		FraudScore:    100,
+	}
+
+	got := signalConfidence(s)
+
+	assert.Equal(t, 0.0, got)
 }

--- a/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/risk_score/transport_http_test.go
@@ -166,5 +166,5 @@ func TestRiskScore_OnlyEmailConfidence(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp httpx.Response[Result]
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	assert.LessOrEqual(t, resp.Data.Confidence, 0.34)
+	assert.Greater(t, resp.Data.Confidence, 0.70)
 }

--- a/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
+++ b/apps/api/services/systems/identity_risk/signup_protect/transport_http_test.go
@@ -168,7 +168,7 @@ func TestSignupProtect_OnlyEmailSignalsNullPhoneIP(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	assert.Nil(t, resp.Data.Signals.Phone)
 	assert.Nil(t, resp.Data.Signals.IP)
-	assert.LessOrEqual(t, resp.Data.Confidence, 0.34)
+	assert.Greater(t, resp.Data.Confidence, 0.70)
 }
 
 func TestSignupProtect_NoFieldsProvided(t *testing.T) {


### PR DESCRIPTION
### Changes

**`scorer.go`**
- Defined weight constants with inline rationale comments
- Replaced `signalConfidence` formula with weighted average:
  `sum(weight_i * fired_i) / sum(weight_i for all signals)`
- Removed unused `totalSignals` constant and old commented-out implementation
- IPPresent could be set true by geolocation lookup alone, causing
signalConfidence to credit unverified zero-value risk fields as clean.
Introduced IPRiskChecked flag, only set when VPN risk check succeeds.
Confidence calculation now uses IPRiskChecked instead of IPPresent.

**`scorer_test.go`**
- Added unit tests covering: no signals, single high-quality signal, all risk, all clean, mixed signals, confidence matches `Compute` output, and `IsSafe` behavior with TOR/proxy present
- Updated existing test to reflect new confidence formula — previous assertion expected `confidence <= 0.34` (naive formula); updated to assert `confidence > 0.70` (weighted formula)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved identity risk confidence scoring using weighted reliability across email, phone VoIP/virtual signals, and IP proxy/TOR/fraud attributes.
  * Confidence now depends on whether IP risk checks produced results, rounds to two decimals, and returns `0` when there isn’t enough signal data.

* **Tests**
  * Expanded scorer and resolver coverage, including “safe” behavior for low-risk email-only and non-safe results for proxy/TOR.
  * Updated transport tests to expect higher confidence for email-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->