### PR TITLE
Chore: Bump DB Schema

### DIFF
--- a/apps/dashboard/db/schema.rb
+++ b/apps/dashboard/db/schema.rb
@@ -103,7 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_000002) do
     t.index ["status"], name: "index_private_deployment_requests_on_status"
     t.index ["subdomain_slug"], name: "index_private_deployment_requests_on_subdomain_slug", unique: true, where: "(subdomain_slug IS NOT NULL)"
     t.index ["user_id"], name: "index_private_deployment_requests_on_user_id"
-    t.check_constraint "status::text = ANY (ARRAY['pending_payment'::character varying::text, 'pending'::character varying::text, 'deploying'::character varying::text, 'active'::character varying::text, 'cancelled'::character varying::text])", name: "private_deployment_requests_status_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending_payment'::character varying, 'pending'::character varying, 'deploying'::character varying, 'active'::character varying, 'cancelled'::character varying]::text[])", name: "private_deployment_requests_status_check"
   end
 
   create_table "referrals", force: :cascade do |t|
@@ -173,8 +173,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_000002) do
     t.index ["api_key_id", "used_at"], name: "index_usage_logs_on_api_key_and_time"
     t.index ["api_key_id"], name: "index_usage_logs_on_api_key_id"
     t.index ["endpoint", "used_at"], name: "index_usage_logs_on_endpoint_and_time"
+    t.index ["request_method"], name: "index_usage_logs_on_request_method"
     t.index ["status_code"], name: "index_usage_logs_on_status_code"
     t.index ["usage_date"], name: "index_usage_logs_on_usage_date"
+    t.index ["user_id", "request_method"], name: "index_usage_logs_on_user_id_and_request_method"
     t.index ["user_id", "used_at"], name: "index_usage_logs_on_user_and_time"
     t.index ["user_id"], name: "index_usage_logs_on_user_id"
   end


### PR DESCRIPTION
Rails team recommends committing `schema.rb` so `git diff` captures schema changes during code review. Without it, migrations are the only source of truth, making it harder to spot unintended schema drift.

The old per-element `::text` casting was non-canonical. Rails 8.1 now generates `::text[]` on the entire array. Committing the schema pins the canonical form.

Migrations for `request_method` and `user_id` + `request_method` indexes on `usage_logs` were already applied but never captured in `schema.rb` (since it wasn't tracked). Committing it brings the checked-in schema in sync with the actual database state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema and indexing to enhance system performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->