### PR TITLE
fix: convert signals from string to array in ES and FR home locales

### DIFF
--- a/apps/dashboard/config/locales/es/home.es.yml
+++ b/apps/dashboard/config/locales/es/home.es.yml
@@ -15,7 +15,7 @@ es:
       back: Volver a ejemplos
       breadcrumb_examples: Ejemplos
       breadcrumb_home: Inicio
-      in_the_meantime: 'Mientras tanto:'
+      in_the_meantime: "Mientras tanto:"
       tip_demo: Prueba la demo en vivo para verlo en acción
       tip_docs_html: Explora la %{docs_link} de las APIs usadas en este proyecto
       tip_github: Consulta el código fuente en GitHub para ver cómo está construido
@@ -45,16 +45,16 @@ es:
       offerings:
         heading: Lo que ofrecemos
         items:
-        - Validación de correo y teléfono, detección de desechables y comprobaciones
-          de red relacionadas
-        - 'APIs de texto y contenido: filtro de profanidad, sentimiento, lorem ipsum,
-          diccionario y más'
-        - Generación de QR y códigos de barras, más utilidades financieras (IBAN,
-          SWIFT, BIN y más)
-        - 'Lugares y planificación: zonas horarias, días hábiles, festivos, geocodificación'
-        - Infraestructura alojada en la UE con precios transparentes
-        - Documentación y ejemplos pensados para producción, incluidos formatos amigables
-          para IA
+          - Validación de correo y teléfono, detección de desechables y comprobaciones
+            de red relacionadas
+          - "APIs de texto y contenido: filtro de profanidad, sentimiento, lorem ipsum,
+            diccionario y más"
+          - Generación de QR y códigos de barras, más utilidades financieras (IBAN,
+            SWIFT, BIN y más)
+          - "Lugares y planificación: zonas horarias, días hábiles, festivos, geocodificación"
+          - Infraestructura alojada en la UE con precios transparentes
+          - Documentación y ejemplos pensados para producción, incluidos formatos amigables
+            para IA
       title: Acerca de nosotros - Requiems API
       values:
         dx_text: Nos obsesionamos con hacer que nuestras APIs sean fáciles de integrar
@@ -71,8 +71,8 @@ es:
           honesta.
         transparency_title: Transparencia
     api_reference:
-      all_api_requests_require_authentication: 'Todas las solicitudes a la API requieren
-        autenticación mediante una clave de API en el encabezado de la solicitud:'
+      all_api_requests_require_authentication: "Todas las solicitudes a la API requieren
+        autenticación mediante una clave de API en el encabezado de la solicitud:"
       api_reference: Referencia de la API
       api_reference_requiems_api: Referencia de la API - API de Requiems
       available_apis: API disponibles
@@ -116,10 +116,10 @@ es:
       what_to_expect:
         heading: Qué esperar
         items:
-        - Tutoriales técnicos y guías de integración
-        - Mejores prácticas de desarrollo de API
-        - Actualizaciones de la plataforma y anuncios de nuevas APIs
-        - Casos de éxito de desarrolladores
+          - Tutoriales técnicos y guías de integración
+          - Mejores prácticas de desarrollo de API
+          - Actualizaciones de la plataforma y anuncios de nuevas APIs
+          - Casos de éxito de desarrolladores
     changelog:
       badge_coming_soon: Próximamente
       badge_latest: Reciente
@@ -129,94 +129,94 @@ es:
       stay_updated:
         heading: Mantente actualizado
         sign_up_cta: Crear una cuenta
-        signed_in: 'Enviaremos notificaciones de actualización a tu correo registrado:
-          %{email}'
+        signed_in: "Enviaremos notificaciones de actualización a tu correo registrado:
+          %{email}"
         text: "¿Quieres recibir notificaciones sobre nuevas versiones y funcionalidades?"
       title: Registro de cambios - Requiems API
       v001:
         gateway:
           heading: Cloudflare Worker Gateway
           items:
-          - Validación de claves API usando Cloudflare KV
-          - Limitación de tasa con contadores KV
-          - Seguimiento de uso de solicitudes con D1 SQLite
-          - Proxy de solicitudes al backend API
-          - Análisis y registro de uso
+            - Validación de claves API usando Cloudflare KV
+            - Limitación de tasa con contadores KV
+            - Seguimiento de uso de solicitudes con D1 SQLite
+            - Proxy de solicitudes al backend API
+            - Análisis y registro de uso
         init:
           heading: Inicialización del proyecto
           items:
-          - Arquitectura monorepo multi-lenguaje establecida
-          - Selección del stack tecnológico (Go, Rails 8, Cloudflare Workers)
-          - 'Diseño de arquitectura de tres niveles: Edge Gateway → Backend API →
-            Base de datos'
-          - Planificación del esquema de base de datos y endpoints de API
+            - Arquitectura monorepo multi-lenguaje establecida
+            - Selección del stack tecnológico (Go, Rails 8, Cloudflare Workers)
+            - "Diseño de arquitectura de tres niveles: Edge Gateway → Backend API →
+              Base de datos"
+            - Planificación del esquema de base de datos y endpoints de API
       v002:
         deploy:
           heading: Despliegue en producción
           items:
-          - Go Backend API desplegado con base de datos PostgreSQL
-          - Aplicación Rails 8 Dashboard con autenticación de usuarios
-          - Sistema de gestión de claves API y seguimiento de uso
-          - Panel de administración para gestión de usuarios y suscripciones
-          - Entorno de desarrollo Docker Compose
+            - Go Backend API desplegado con base de datos PostgreSQL
+            - Aplicación Rails 8 Dashboard con autenticación de usuarios
+            - Sistema de gestión de claves API y seguimiento de uso
+            - Panel de administración para gestión de usuarios y suscripciones
+            - Entorno de desarrollo Docker Compose
         features:
           heading: Funcionalidades
           items:
-          - Endpoints de validación de correo electrónico (detección de correo desechable)
-          - APIs de utilidades de texto (consejos, lorem ipsum, citas, palabras aleatorias)
-          - Registro y autenticación de usuarios (Devise)
-          - Panel de análisis de uso
-          - Integración de suscripción y facturación
-          - Endpoints de verificación de salud y monitoreo
+            - Endpoints de validación de correo electrónico (detección de correo desechable)
+            - APIs de utilidades de texto (consejos, lorem ipsum, citas, palabras aleatorias)
+            - Registro y autenticación de usuarios (Devise)
+            - Panel de análisis de uso
+            - Integración de suscripción y facturación
+            - Endpoints de verificación de salud y monitoreo
       v010:
         bugs:
           heading: Corrección de errores
           items:
-          - Corregido el orden de ejecución del callback de generación de claves API
-          - Resuelto el problema de inicialización del mapeo de Devise en el entorno
-            de prueba
-          - Corregido el manejo del campo de estado de usuario para estados suspendidos/bloqueados
-          - Agregadas configuraciones de tiempo de espera del servidor HTTP para cumplimiento
-            de seguridad
-          - Corregido el formato de código en todas las aplicaciones
+            - Corregido el orden de ejecución del callback de generación de claves API
+            - Resuelto el problema de inicialización del mapeo de Devise en el entorno
+              de prueba
+            - Corregido el manejo del campo de estado de usuario para estados suspendidos/bloqueados
+            - Agregadas configuraciones de tiempo de espera del servidor HTTP para cumplimiento
+              de seguridad
+            - Corregido el formato de código en todas las aplicaciones
         ci:
           heading: Integración continua
           items:
-          - Pipeline de CI completo con pruebas automatizadas en todas las aplicaciones
-          - 'Go API: pruebas con detección de condiciones de carrera, golangci-lint
-            (21 linters), cobertura de código'
-          - 'Rails Dashboard: suite de pruebas completa (60 pruebas, 207 aserciones),
-            análisis de seguridad'
-          - 'Cloudflare Worker: verificaciones TypeScript, suite Vitest (71 pruebas),
-            linting Biome'
-          - Ejecución basada en rutas para compilaciones eficientes
-          - Análisis de seguridad como requisitos de bloqueo (Brakeman, bundler-audit)
+            - Pipeline de CI completo con pruebas automatizadas en todas las aplicaciones
+            - "Go API: pruebas con detección de condiciones de carrera, golangci-lint
+              (21 linters), cobertura de código"
+            - "Rails Dashboard: suite de pruebas completa (60 pruebas, 207 aserciones),
+              análisis de seguridad"
+            - "Cloudflare Worker: verificaciones TypeScript, suite Vitest (71 pruebas),
+              linting Biome"
+            - Ejecución basada en rutas para compilaciones eficientes
+            - Análisis de seguridad como requisitos de bloqueo (Brakeman, bundler-audit)
         coverage:
           heading: Cobertura de pruebas
           items:
-          - 'Rails Dashboard: 100% de tasa de aprobación de pruebas (60 pruebas)'
-          - 'Cloudflare Worker: 71 pruebas aprobadas con 29% de cobertura'
-          - 'Go API: suite de pruebas completa con detección de condiciones de carrera'
+            - "Rails Dashboard: 100% de tasa de aprobación de pruebas (60 pruebas)"
+            - "Cloudflare Worker: 71 pruebas aprobadas con 29% de cobertura"
+            - "Go API: suite de pruebas completa con detección de condiciones de carrera"
       v020:
         features:
           heading: Funcionalidades planeadas
           items:
-          - Documentación de API mejorada con playground interactivo
-          - Webhooks de uso para notificaciones en tiempo real
-          - Controles avanzados de limitación de tasa por clave API
-          - Exportación e informes de uso de API
-          - Funciones de colaboración en equipo (espacios de trabajo compartidos)
-          - APIs de validación adicionales (números de teléfono, tarjetas de crédito)
-        planned_release: 'Lanzamiento planeado: Q1 2026'
+            - Documentación de API mejorada con playground interactivo
+            - Webhooks de uso para notificaciones en tiempo real
+            - Controles avanzados de limitación de tasa por clave API
+            - Exportación e informes de uso de API
+            - Funciones de colaboración en equipo (espacios de trabajo compartidos)
+            - APIs de validación adicionales (números de teléfono, tarjetas de crédito)
+        planned_release: "Lanzamiento planeado: Q1 2026"
         roadmap:
           heading: Hoja de ruta futura (v1.0.0+)
           items:
-          - APIs de datos (geolocalización IP, conversión de divisas)
-          - APIs financieras (cotizaciones de acciones, precios de criptomonedas)
-          - APIs de imágenes (optimización, marcadores de posición, códigos QR)
-          - Soporte para API GraphQL
-          - Bibliotecas SDK (Python, JavaScript, Go, Ruby)
-          - Documentación de cumplimiento de cero retención de datos
+            - APIs de datos (geolocalización IP, conversión de divisas)
+            - APIs financieras (cotizaciones de acciones, precios de criptomonedas)
+            - APIs de imágenes (optimización, marcadores de posición, códigos QR)
+            - Soporte para API GraphQL
+            - Bibliotecas SDK (Python, JavaScript, Go, Ruby)
+            - Documentación de cumplimiento de cero retención de datos
       v0_0_1: v0.0.1
       v0_0_2: v0.0.2
       v0_1_0: v0.1.0
@@ -260,8 +260,8 @@ es:
       click_here: Haz clic aquí si no eres redirigido
       redirecting: Redirigiendo a la documentación de la API...
     domain_checker:
-      domain_checker_api_instant_domain: 'API de verificación de dominios: disponibilidad
-        instantánea de dominios y consulta WHOIS.'
+      domain_checker_api_instant_domain: "API de verificación de dominios: disponibilidad
+        instantánea de dominios y consulta WHOIS."
     error_codes:
       2xx_error_codes: 2xx %{error_codes}
       4xx_error_codes: 4xx %{error_codes}
@@ -273,81 +273,81 @@ es:
         heading: Mejores prácticas para el manejo de errores
         help_text: "¿Necesitas ayuda para solucionar problemas?"
         items:
-        - Siempre verifica el código de estado antes de procesar la respuesta
-        - Implementa retroceso exponencial para la lógica de reintento en errores
-          5xx
-        - Registra detalles de errores para depuración pero nunca expongas datos sensibles
-        - Maneja los límites de tasa con elegancia respetando los encabezados retry-after
-        - Muestra mensajes de error amigables para el usuario en lugar de respuestas
-          API sin procesar
+          - Siempre verifica el código de estado antes de procesar la respuesta
+          - Implementa retroceso exponencial para la lógica de reintento en errores
+            5xx
+          - Registra detalles de errores para depuración pero nunca expongas datos sensibles
+          - Maneja los límites de tasa con elegancia respetando los encabezados retry-after
+          - Muestra mensajes de error amigables para el usuario en lugar de respuestas
+            API sin procesar
       client_errors_heading: Errores del cliente
       codes:
         client_errors:
-        - code: '400'
-          name: Solicitud incorrecta
-          description: La solicitud estaba mal formada o contiene parámetros inválidos.
-          note: 'Causas comunes: campos requeridos faltantes, JSON inválido, tipos
-            de datos incorrectos'
-        - code: '401'
-          name: No autorizado
-          description: Se requiere autenticación o ha fallado. Tu clave API puede
-            estar faltando o ser inválida.
-          note: 'Causas comunes: clave API faltante, clave API inválida, clave expirada'
-        - code: '403'
-          name: Prohibido
-          description: No tienes permiso para acceder a este recurso. Tu clave API
-            puede carecer de los permisos requeridos.
-          note: 'Causas comunes: permisos insuficientes, cuenta suspendida, acceso
-            a endpoint de prueba con clave de producción'
-        - code: '404'
-          name: No encontrado
-          description: El recurso solicitado no existe. Verifica la URL de tu endpoint.
-          note: 'Causas comunes: URL incorrecta, error tipográfico en la ruta del
-            endpoint, recurso eliminado'
-        - code: '422'
-          name: Entidad no procesable
-          description: La solicitud estaba bien formada pero contiene errores semánticos
-            o fallas de validación.
-          note: 'Causas comunes: formato de correo inválido, valores fuera de rango,
-            fallas de validación de lógica de negocio'
-        - code: '429'
-          name: Demasiadas solicitudes
-          description: Has superado tu límite de tasa. Espera antes de hacer más solicitudes
-            o actualiza tu plan.
-          note: 'Causas comunes: demasiadas solicitudes por minuto, cuota diaria superada'
+          - code: "400"
+            name: Solicitud incorrecta
+            description: La solicitud estaba mal formada o contiene parámetros inválidos.
+            note: "Causas comunes: campos requeridos faltantes, JSON inválido, tipos
+              de datos incorrectos"
+          - code: "401"
+            name: No autorizado
+            description: Se requiere autenticación o ha fallado. Tu clave API puede
+              estar faltando o ser inválida.
+            note: "Causas comunes: clave API faltante, clave API inválida, clave expirada"
+          - code: "403"
+            name: Prohibido
+            description: No tienes permiso para acceder a este recurso. Tu clave API
+              puede carecer de los permisos requeridos.
+            note: "Causas comunes: permisos insuficientes, cuenta suspendida, acceso
+              a endpoint de prueba con clave de producción"
+          - code: "404"
+            name: No encontrado
+            description: El recurso solicitado no existe. Verifica la URL de tu endpoint.
+            note: "Causas comunes: URL incorrecta, error tipográfico en la ruta del
+              endpoint, recurso eliminado"
+          - code: "422"
+            name: Entidad no procesable
+            description: La solicitud estaba bien formada pero contiene errores semánticos
+              o fallas de validación.
+            note: "Causas comunes: formato de correo inválido, valores fuera de rango,
+              fallas de validación de lógica de negocio"
+          - code: "429"
+            name: Demasiadas solicitudes
+            description: Has superado tu límite de tasa. Espera antes de hacer más solicitudes
+              o actualiza tu plan.
+            note: "Causas comunes: demasiadas solicitudes por minuto, cuota diaria superada"
         server_errors:
-        - code: '500'
-          name: Error interno del servidor
-          description: Ocurrió un error inesperado en nuestros servidores. Es un problema
-            temporal.
-          note: 'Acción: Reintenta la solicitud. Si el problema persiste, contacta
-            al soporte.'
-        - code: '502'
-          name: Puerta de enlace incorrecta
-          description: La puerta de enlace recibió una respuesta inválida del servidor
-            backend.
-          note: 'Acción: Reintenta la solicitud después de una breve pausa.'
-        - code: '503'
-          name: Servicio no disponible
-          description: El servicio no está disponible temporalmente, generalmente
-            por mantenimiento o sobrecarga.
-          note: 'Acción: Verifica nuestra página de estado y reintenta después de
-            una pausa.'
-        - code: '504'
-          name: Tiempo de espera de la puerta de enlace
-          description: La puerta de enlace no recibió respuesta del servidor backend
-            a tiempo.
-          note: 'Acción: Reintenta la solicitud. Considera implementar retroceso exponencial.'
+          - code: "500"
+            name: Error interno del servidor
+            description: Ocurrió un error inesperado en nuestros servidores. Es un problema
+              temporal.
+            note: "Acción: Reintenta la solicitud. Si el problema persiste, contacta
+              al soporte."
+          - code: "502"
+            name: Puerta de enlace incorrecta
+            description: La puerta de enlace recibió una respuesta inválida del servidor
+              backend.
+            note: "Acción: Reintenta la solicitud después de una breve pausa."
+          - code: "503"
+            name: Servicio no disponible
+            description: El servicio no está disponible temporalmente, generalmente
+              por mantenimiento o sobrecarga.
+            note: "Acción: Verifica nuestra página de estado y reintenta después de
+              una pausa."
+          - code: "504"
+            name: Tiempo de espera de la puerta de enlace
+            description: La puerta de enlace no recibió respuesta del servidor backend
+              a tiempo.
+            note: "Acción: Reintenta la solicitud. Considera implementar retroceso exponencial."
         success:
-        - code: '200'
-          name: OK
-          description: La solicitud fue exitosa y la respuesta contiene los datos
-            solicitados.
-          note: 'Común con: solicitudes GET, POST, PUT'
-        - code: '201'
-          name: Creado
-          description: Se creó exitosamente un nuevo recurso.
-          note: 'Común con: solicitudes POST para crear recursos'
+          - code: "200"
+            name: OK
+            description: La solicitud fue exitosa y la respuesta contiene los datos
+              solicitados.
+            note: "Común con: solicitudes GET, POST, PUT"
+          - code: "201"
+            name: Creado
+            description: Se creó exitosamente un nuevo recurso.
+            note: "Común con: solicitudes POST para crear recursos"
       description: Comprende los códigos de estado HTTP y cómo manejarlos
       heading: Referencia de códigos de error
       server_errors_heading: Errores del servidor
@@ -355,7 +355,7 @@ es:
       title: Referencia de códigos de error - Requiems API
     faq:
       authentication:
-        a1: 'Incluye tu clave API en el encabezado Authorization como token Bearer:'
+        a1: "Incluye tu clave API en el encabezado Authorization como token Bearer:"
         a2_html: Las claves de prueba (que comienzan con %{test_key}) son para desarrollo
           y pruebas. Las claves de producción (%{live_key}) son para uso en producción.
           Ambos tipos de clave cuentan para tu cuota mensual de solicitudes.
@@ -406,16 +406,16 @@ es:
       intro: Facturación, autenticación, límites de tasa y cómo pasar del registro
         a producción con rapidez.
       rate_limits:
-        a1: 'Los límites de tasa varían según el plan:'
+        a1: "Los límites de tasa varían según el plan:"
         a2_html: Cuando recibas un error 429, implementa retroceso exponencial. Espera
           unos segundos y vuelve a intentarlo. Consulta el encabezado %{retry_after_header}
           para el tiempo de espera recomendado. Considera actualizar tu plan si constantemente
           alcanzas los límites de tasa.
-        business: 'Negocio: %{rate_limit} solicitudes/minuto'
-        developer: 'Desarrollador: %{rate_limit} solicitudes/minuto'
-        free: 'Gratuito: %{rate_limit} solicitudes/minuto'
+        business: "Negocio: %{rate_limit} solicitudes/minuto"
+        developer: "Desarrollador: %{rate_limit} solicitudes/minuto"
+        free: "Gratuito: %{rate_limit} solicitudes/minuto"
         heading: Límites de tasa
-        professional: 'Profesional: %{rate_limit} solicitudes/minuto'
+        professional: "Profesional: %{rate_limit} solicitudes/minuto"
         q1: "¿Cuáles son los límites de tasa?"
         q2: "¿Cómo debo manejar los errores de límite de tasa?"
       still_questions:
@@ -427,12 +427,12 @@ es:
       subheading: Respuestas a preguntas frecuentes sobre facturación, autenticación,
         límites de tasa e integración.
       support:
-        a1: 'Ofrecemos múltiples canales de soporte:'
-        a2: 'Los tiempos de respuesta varían según el plan:'
+        a1: "Ofrecemos múltiples canales de soporte:"
+        a2: "Los tiempos de respuesta varían según el plan:"
         a3_html: "¡Sí! Los clientes empresariales obtienen soporte dedicado con tiempos
           de respuesta garantizados, acceso directo a nuestro equipo de ingeniería
           y asistencia prioritaria. %{sales_link} para saber más."
-        business_time: 'Negocio: 24 horas'
+        business_time: "Negocio: 24 horas"
         contact_channel:
           description: Soporte por correo (respuesta 24-48 horas)
           label: Formulario de contacto
@@ -440,12 +440,12 @@ es:
         docs_channel:
           description: Guías completas y referencia de la API
           label: Documentación
-        free_dev: 'Gratuito y Desarrollador: 48 horas'
+        free_dev: "Gratuito y Desarrollador: 48 horas"
         github_channel:
           description: Reporta errores o solicita funciones
           label: Issues de GitHub
         heading: Soporte
-        professional_time: 'Profesional: 12 horas (soporte prioritario)'
+        professional_time: "Profesional: 12 horas (soporte prioritario)"
         q1: "¿Cómo puedo obtener ayuda?"
         q2: "¿Cuáles son sus tiempos de respuesta de soporte?"
         q3: "¿Ofrecen soporte empresarial?"
@@ -455,7 +455,7 @@ es:
         description: Obtén la documentación completa de cualquier API en formato Markdown
           añadiendo /index.md a su URL.
         heading: Markdown por API
-        pattern: 'Patrón: /apis/{api-id}/index.md'
+        pattern: "Patrón: /apis/{api-id}/index.md"
       cta:
         browse_apis: Ver APIs
         full_docs: Descargar llms-full.txt
@@ -494,80 +494,80 @@ es:
         text: Consulta nuestra documentación completa o contacta a nuestro equipo
           de soporte
       terms:
-      - name: API (Interfaz de programación de aplicaciones)
-        definition: Un conjunto de definiciones y protocolos que permite que diferentes
-          aplicaciones de software se comuniquen entre sí. Las APIs definen los métodos
-          y formatos de datos que las aplicaciones pueden usar para solicitar e intercambiar
-          información.
-        example_prefix: 'Ejemplo: Requiems API proporciona una API REST para validar
-          direcciones de correo electrónico programáticamente.'
-      - name: Endpoint
-        definition: Una URL específica donde una API puede acceder a los recursos
-          que necesita. Cada endpoint corresponde a una función o recurso específico
-          en la API.
-        example_prefix: 'Ejemplo:'
-        example_code: POST /v1/networking/disposable/check
-      - name: Autenticación
-        definition: El proceso de verificar la identidad de un usuario o aplicación.
-          Las APIs generalmente requieren autenticación para garantizar que solo los
-          usuarios autorizados puedan acceder al servicio.
-        example_prefix: 'Ejemplo: Incluir tu clave API en el encabezado Authorization:'
-        example_code: 'Authorization: Bearer TU_CLAVE_API'
-      - name: Clave API
-        definition: Un identificador único utilizado para autenticar solicitudes a
-          una API. Las claves API actúan como identificador y token secreto para la
-          autenticación.
-        example_prefix: 'Ejemplo:'
-        example_code: rq_live_1234567890abcdef
-      - name: Limitación de tasa
-        definition: Una técnica para controlar el número de solicitudes que un usuario
-          puede hacer a una API dentro de un período de tiempo dado. Esto ayuda a
-          prevenir abusos y garantiza un uso justo.
-        example_prefix: 'Ejemplo: El plan gratuito permite 30 solicitudes por minuto'
-      - name: Solicitudes
-        definition: La unidad de uso de la API. Cada llamada a la API cuenta como
-          1 solicitud contra tu cuota mensual del plan. Algunos endpoints pueden contar
-          como más de 1 solicitud, lo cual siempre se indica explícitamente en la
-          documentación de ese endpoint.
-        example_prefix: 'Ejemplo: Llamar al endpoint de validación de correo una vez
-          usa 1 solicitud de tu cuota mensual.'
-      - name: REST (Transferencia de estado representacional)
-        definition: Un estilo arquitectónico para diseñar aplicaciones en red. Las
-          APIs REST usan solicitudes HTTP para realizar operaciones CRUD (Crear, Leer,
-          Actualizar, Eliminar) sobre recursos.
-        example_prefix: 'Ejemplo: Usar GET para recuperar datos, POST para crear,
-          PUT para actualizar, DELETE para eliminar'
-      - name: JSON (Notación de objetos de JavaScript)
-        definition: Un formato de intercambio de datos ligero que es fácil de leer
-          y escribir para humanos, y fácil de analizar y generar para máquinas. La
-          mayoría de las APIs modernas usan JSON para los cuerpos de solicitud y respuesta.
-        example_prefix: 'Ejemplo:'
-        example_code: '{"email": "test@example.com", "is_disposable": false}'
-      - name: Códigos de estado HTTP
-        definition: Códigos de tres dígitos devueltos por los servidores web para
-          indicar el resultado de una solicitud HTTP. Los códigos comunes incluyen
-          200 (éxito), 404 (no encontrado) y 500 (error del servidor).
-        example_prefix: 'Más información:'
-        example_link_href: "/es/error_codes"
-        example_link_text: Referencia de códigos de error
-      - name: Webhook
-        definition: Un método para que una aplicación proporcione información en tiempo
-          real a otras aplicaciones. En lugar de que hagas solicitudes repetidas a
-          la API, el servidor envía datos a tu URL especificada cuando ocurre un evento.
-        example_prefix: 'Ejemplo: Recibir una notificación cuando tu saldo de solicitudes
-          caiga por debajo de un umbral'
-      - name: Parámetros de consulta
-        definition: Pares clave-valor añadidos a una URL para filtrar, ordenar o modificar
-          la respuesta de la API. Aparecen después de un signo de interrogación (?)
-          en la URL.
-        example_prefix: 'Ejemplo:'
-        example_code: "/v1/words?limit=10&min_length=5"
-      - name: Encabezados
-        definition: Información adicional enviada con las solicitudes y respuestas
-          HTTP. Los encabezados pueden contener tokens de autenticación, tipos de
-          contenido, metadatos personalizados y más.
-        example_prefix: 'Ejemplo:'
-        example_code: 'Content-Type: application/json'
+        - name: API (Interfaz de programación de aplicaciones)
+          definition: Un conjunto de definiciones y protocolos que permite que diferentes
+            aplicaciones de software se comuniquen entre sí. Las APIs definen los métodos
+            y formatos de datos que las aplicaciones pueden usar para solicitar e intercambiar
+            información.
+          example_prefix: "Ejemplo: Requiems API proporciona una API REST para validar
+            direcciones de correo electrónico programáticamente."
+        - name: Endpoint
+          definition: Una URL específica donde una API puede acceder a los recursos
+            que necesita. Cada endpoint corresponde a una función o recurso específico
+            en la API.
+          example_prefix: "Ejemplo:"
+          example_code: POST /v1/networking/disposable/check
+        - name: Autenticación
+          definition: El proceso de verificar la identidad de un usuario o aplicación.
+            Las APIs generalmente requieren autenticación para garantizar que solo los
+            usuarios autorizados puedan acceder al servicio.
+          example_prefix: "Ejemplo: Incluir tu clave API en el encabezado Authorization:"
+          example_code: "Authorization: Bearer TU_CLAVE_API"
+        - name: Clave API
+          definition: Un identificador único utilizado para autenticar solicitudes a
+            una API. Las claves API actúan como identificador y token secreto para la
+            autenticación.
+          example_prefix: "Ejemplo:"
+          example_code: rq_live_1234567890abcdef
+        - name: Limitación de tasa
+          definition: Una técnica para controlar el número de solicitudes que un usuario
+            puede hacer a una API dentro de un período de tiempo dado. Esto ayuda a
+            prevenir abusos y garantiza un uso justo.
+          example_prefix: "Ejemplo: El plan gratuito permite 30 solicitudes por minuto"
+        - name: Solicitudes
+          definition: La unidad de uso de la API. Cada llamada a la API cuenta como
+            1 solicitud contra tu cuota mensual del plan. Algunos endpoints pueden contar
+            como más de 1 solicitud, lo cual siempre se indica explícitamente en la
+            documentación de ese endpoint.
+          example_prefix: "Ejemplo: Llamar al endpoint de validación de correo una vez
+            usa 1 solicitud de tu cuota mensual."
+        - name: REST (Transferencia de estado representacional)
+          definition: Un estilo arquitectónico para diseñar aplicaciones en red. Las
+            APIs REST usan solicitudes HTTP para realizar operaciones CRUD (Crear, Leer,
+            Actualizar, Eliminar) sobre recursos.
+          example_prefix: "Ejemplo: Usar GET para recuperar datos, POST para crear,
+            PUT para actualizar, DELETE para eliminar"
+        - name: JSON (Notación de objetos de JavaScript)
+          definition: Un formato de intercambio de datos ligero que es fácil de leer
+            y escribir para humanos, y fácil de analizar y generar para máquinas. La
+            mayoría de las APIs modernas usan JSON para los cuerpos de solicitud y respuesta.
+          example_prefix: "Ejemplo:"
+          example_code: '{"email": "test@example.com", "is_disposable": false}'
+        - name: Códigos de estado HTTP
+          definition: Códigos de tres dígitos devueltos por los servidores web para
+            indicar el resultado de una solicitud HTTP. Los códigos comunes incluyen
+            200 (éxito), 404 (no encontrado) y 500 (error del servidor).
+          example_prefix: "Más información:"
+          example_link_href: "/es/error_codes"
+          example_link_text: Referencia de códigos de error
+        - name: Webhook
+          definition: Un método para que una aplicación proporcione información en tiempo
+            real a otras aplicaciones. En lugar de que hagas solicitudes repetidas a
+            la API, el servidor envía datos a tu URL especificada cuando ocurre un evento.
+          example_prefix: "Ejemplo: Recibir una notificación cuando tu saldo de solicitudes
+            caiga por debajo de un umbral"
+        - name: Parámetros de consulta
+          definition: Pares clave-valor añadidos a una URL para filtrar, ordenar o modificar
+            la respuesta de la API. Aparecen después de un signo de interrogación (?)
+            en la URL.
+          example_prefix: "Ejemplo:"
+          example_code: "/v1/words?limit=10&min_length=5"
+        - name: Encabezados
+          definition: Información adicional enviada con las solicitudes y respuestas
+            HTTP. Los encabezados pueden contener tokens de autenticación, tipos de
+            contenido, metadatos personalizados y más.
+          example_prefix: "Ejemplo:"
+          example_code: "Content-Type: application/json"
       title: Glosario de API - Requiems API
     index:
       categories:
@@ -612,17 +612,17 @@ es:
           inteligencia, y devuelve una sola decisión estructurada. Sin lógica de puntuación
           que construir. Sin pipeline que mantener.
         value_table:
-        - field: risk_score
-          plain: "¿Qué tan arriesgado es este registro? 0 es limpio, 1 es alto riesgo."
-        - field: is_safe
-          plain: Decisión única sí/no. Úsala para bloquear o permitir el registro.
-        - field: confidence
-          plain: Qué tan seguro está el motor. Un valor más alto significa menos falsos
-            positivos.
-        - field: flags
-          plain: Las razones específicas por las que se marcó al usuario.
-        - field: signals
-          plain: Resultados en bruto de cada comprobación ejecutada en segundo plano.
+          - field: risk_score
+            plain: "¿Qué tan arriesgado es este registro? 0 es limpio, 1 es alto riesgo."
+          - field: is_safe
+            plain: Decisión única sí/no. Úsala para bloquear o permitir el registro.
+          - field: confidence
+            plain: Qué tan seguro está el motor. Un valor más alto significa menos falsos
+              positivos.
+          - field: flags
+            plain: Las razones específicas por las que se marcó al usuario.
+          - field: signals
+            plain: Resultados en bruto de cada comprobación ejecutada en segundo plano.
         value_table_heading: Qué significa cada campo
       faq:
         a1: "¡Sí! Obtienes 500 solicitudes al mes completamente gratis sin necesidad
@@ -660,24 +660,24 @@ es:
         playground_desc: Prueba cada endpoint directamente en la documentación. Ve
           respuestas reales al instante, sin escribir código.
         playground_title: Playground de APIs en vivo
-        subheading: 'Desde fundadores en solitario hasta agencias: documentación precisa,
+        subheading: "Desde fundadores en solitario hasta agencias: documentación precisa,
           playgrounds en vivo y ejemplos listos para pegar. Integra en minutos, no
-          en días.'
+          en días."
       hero:
         cta_primary: Obtener clave API
         cta_secondary: Explorar sistemas
         description: Autenticación, validación, detección de fraude, inteligencia
           de pagos y datos globales, entregados a través de una API unificada.
         proof_badges:
-        - Pipelines de datos propietarios
-        - Procesamiento en tiempo real
-        - Construido para producción
+          - Pipelines de datos propietarios
+          - Procesamiento en tiempo real
+          - Construido para producción
         title_line1: Backend todo en uno
         title_line2: para SaaS.
       how_it_works:
         heading: Cómo funciona
-        step1_body: 'Selecciona el problema que quieres resolver: identidad, pagos,
-          datos globales o integridad de datos.'
+        step1_body: "Selecciona el problema que quieres resolver: identidad, pagos,
+          datos globales o integridad de datos."
         step1_title: Elige un sistema
         step2_body: Usa endpoints de alto nivel o compón flujos según tus necesidades.
         step2_title: Llama a un solo endpoint
@@ -732,55 +732,70 @@ es:
           data_integrity:
             blurb: Validar y normalizar los datos de correo electrónico, teléfono
               y texto introducidos al enviarlos.
-            signals: "[formación]"
+            signals:
+              - Validación de entrada
+              - Normalización de texto
+              - Moderación de contenido
             title: Integridad de los datos
           developer_utilities:
             blurb: Herramientas útiles que no deberías tener que reconstruir.
-            signals: "[formación]"
+            signals:
+              - Códigos QR
+              - Codificación y conversiones
+              - Utilidades varias
             title: Utilidades para desarrolladores
           global_data:
             blurb: Geocodificación, zonas horarias y calendarios de días festivos
               para más de 100 países.
-            signals: "[formación]"
+            signals:
+              - Geocodificación
+              - Zonas horarias y festivos
+              - Inteligencia de direcciones
             title: Datos globales
           identity_risk:
             blurb: Bloquea el fraude durante el registro mediante correo electrónico,
               teléfono, dirección IP y señales de comportamiento.
-            signals: "[formación]"
+            signals:
+              - Puntuación de riesgo
+              - Inteligencia de correo, teléfono e IP
+              - Señales de dominio y comportamiento
             title: Identidad y riesgo
           payments_intelligence:
             blurb: Validar los datos BIN, IBAN y SWIFT mediante la detección de discrepancias
               de geolocalización.
-            signals: "[formación]"
+            signals:
+              - Validación BIN y de tarjeta
+              - Comprobaciones IBAN / SWIFT
+              - Señales de riesgo en transacciones
             title: Inteligencia de pagos
         explore_cta: Explorar sistema
         heading: Sistemas de nivel producción
         subheading: Cada sistema combina señales propietarias en una decisión estructurada
           única, entregada en una sola llamada a la API.
         utilities_label: Extras
-      title: 'Requiems API: Backend todo en uno para productos SaaS'
+      title: "Requiems API: Backend todo en uno para productos SaaS"
       trusted_by:
         label: Equipos que llevan productos reales a producción
       use_cases:
         heading: Hecho para productos reales
         items:
-        - title: Protección de registro en SaaS
-          body: Evita cuentas falsas, bots y abuso desde el primer día.
-        - title: Onboarding fintech
-          body: Valida datos financieros y reduce la fricción en el alta.
-        - title: Prevención de fraude en marketplaces
-          body: Detecta usuarios y transacciones de riesgo en tiempo real.
-        - title: Soporte de productos globales
-          body: Atiende usuarios internacionales con datos precisos en todas partes.
+          - title: Protección de registro en SaaS
+            body: Evita cuentas falsas, bots y abuso desde el primer día.
+          - title: Onboarding fintech
+            body: Valida datos financieros y reduce la fricción en el alta.
+          - title: Prevención de fraude en marketplaces
+            body: Detecta usuarios y transacciones de riesgo en tiempo real.
+          - title: Soporte de productos globales
+            body: Atiende usuarios internacionales con datos precisos en todas partes.
         subheading: Problemas concretos, resueltos.
       why_different:
         heading: Infraestructura, no pegamento de integraciones
         points:
-        - Sin dependencia de APIs de terceros
-        - Sistemas propietarios de puntuación y validación
-        - Esquema unificado en todos los endpoints
-        - Diseño de baja latencia y alto rendimiento
-        - Construido para desarrolladores que lanzan productos reales
+          - Sin dependencia de APIs de terceros
+          - Sistemas propietarios de puntuación y validación
+          - Esquema unificado en todos los endpoints
+          - Diseño de baja latencia y alto rendimiento
+          - Construido para desarrolladores que lanzan productos reales
         subheading: La mayoría de agregadores de APIs revenden llamadas de terceros.
           Nosotros construimos pipelines propietarios.
     pricing:
@@ -809,40 +824,40 @@ es:
         q4: "¿Qué centros de datos utilizan?"
         q5: "¿Hay una prueba gratuita para los planes de pago?"
       header:
-        description: 'Comienza gratis y escala cuando lo necesites. Cada plan incluye
-          el catálogo completo: una clave, sin elegir funciones a la carta.'
+        description: "Comienza gratis y escala cuando lo necesites. Cada plan incluye
+          el catálogo completo: una clave, sin elegir funciones a la carta."
         heading: Precios simples y transparentes
       plans:
         business:
           cta: Iniciar prueba gratuita
           description: Para empresas y equipos en crecimiento
           features:
-          - 1.000.000 solicitudes/mes
-          - 10.000 solicitudes/minuto
-          - Todos los endpoints de la API
-          - Soporte prioritario por correo (respuesta 4h)
-          - Centros de datos en la UE
-          - SLAs personalizados disponibles
+            - 1.000.000 solicitudes/mes
+            - 10.000 solicitudes/minuto
+            - Todos los endpoints de la API
+            - Soporte prioritario por correo (respuesta 4h)
+            - Centros de datos en la UE
+            - SLAs personalizados disponibles
           name: Negocio
         developer:
           cta: Iniciar prueba gratuita
           description: Para desarrolladores que crean apps de producción
           features:
-          - 100.000 solicitudes/mes
-          - 5.000 solicitudes/minuto
-          - Todos los endpoints de la API
-          - Soporte por correo (respuesta 24h)
-          - Centros de datos en la UE
+            - 100.000 solicitudes/mes
+            - 5.000 solicitudes/minuto
+            - Todos los endpoints de la API
+            - Soporte por correo (respuesta 24h)
+            - Centros de datos en la UE
           name: Desarrollador
         free:
           cta: Comenzar gratis
           description: Perfecto para pruebas y proyectos pequeños
           features:
-          - 500 solicitudes/mes
-          - 30 solicitudes/minuto
-          - Todos los endpoints de la API
-          - Soporte de la comunidad
-          - Centros de datos en la UE
+            - 500 solicitudes/mes
+            - 30 solicitudes/minuto
+            - Todos los endpoints de la API
+            - Soporte de la comunidad
+            - Centros de datos en la UE
           name: Gratuito
         per_month: "/mes"
         popular_badge: Más popular
@@ -856,14 +871,14 @@ es:
             accesible en yourcompany.requiems.xyz. Facturación mensual o anual. Sin
             cargos por exceso, solicitudes ilimitadas.
           features:
-          - VPS dedicado en Hetzner
-          - Solo las APIs que necesitas
-          - HTTPS directo, sin capa de Cloudflare
-          - Tu subdominio en requiems.xyz
-          - Solicitudes ilimitadas
-          - Suscripción mensual o anual
-          - Listo en 24-48 horas
-          - 15% de descuento con facturación anual
+            - VPS dedicado en Hetzner
+            - Solo las APIs que necesitas
+            - HTTPS directo, sin capa de Cloudflare
+            - Tu subdominio en requiems.xyz
+            - Solicitudes ilimitadas
+            - Suscripción mensual o anual
+            - Listo en 24-48 horas
+            - 15% de descuento con facturación anual
           heading: Tu propia instancia dedicada de API
           units:
             ram: RAM
@@ -874,12 +889,12 @@ es:
           cta: Iniciar prueba gratuita
           description: Para aplicaciones de alto volumen
           features:
-          - 10.000.000 solicitudes/mes
-          - 50.000 solicitudes/minuto
-          - Todos los endpoints de la API
-          - Soporte prioritario (respuesta 1h)
-          - Centros de datos en la UE
-          - SLAs personalizados
+            - 10.000.000 solicitudes/mes
+            - 50.000 solicitudes/minuto
+            - Todos los endpoints de la API
+            - Soporte prioritario (respuesta 1h)
+            - Centros de datos en la UE
+            - SLAs personalizados
           name: Profesional
         save_per_year: Ahorra $%{amount}/año
       security:
@@ -916,8 +931,8 @@ es:
     privacy:
       contact:
         heading: Contáctanos
-        text: 'Para preguntas relacionadas con la privacidad o para ejercer tus derechos,
-          contáctanos en:'
+        text: "Para preguntas relacionadas con la privacidad o para ejercer tus derechos,
+          contáctanos en:"
       data_retention:
         heading: Retención de datos
         text: Conservamos la información de tu cuenta mientras esté activa. Los registros
@@ -926,33 +941,33 @@ es:
       data_storage:
         heading: Almacenamiento y seguridad de datos
         items:
-        - Cifrado TLS 1.3 para datos en tránsito
-        - Cero retención de payloads de API — entradas procesadas solo en memoria volátil
-        - Auditorías de seguridad y monitoreo regulares
-        - Controles de acceso y mecanismos de autenticación
-        text: 'Todos los datos se almacenan en servidores ubicados en la Unión Europea.
-          Implementamos medidas de seguridad estándar de la industria que incluyen:'
+          - Cifrado TLS 1.3 para datos en tránsito
+          - Cero retención de payloads de API — entradas procesadas solo en memoria volátil
+          - Auditorías de seguridad y monitoreo regulares
+          - Controles de acceso y mecanismos de autenticación
+        text: "Todos los datos se almacenan en servidores ubicados en la Unión Europea.
+          Implementamos medidas de seguridad estándar de la industria que incluyen:"
       gdpr:
         heading: Tus derechos (GDPR)
-        intro: 'Si te encuentras en el Espacio Económico Europeo, tienes los siguientes
-          derechos:'
+        intro: "Si te encuentras en el Espacio Económico Europeo, tienes los siguientes
+          derechos:"
         items:
-        - Derecho de acceso a tus datos personales
-        - Derecho de rectificación de datos inexactos
-        - Derecho de supresión ("derecho al olvido")
-        - Derecho a limitar el tratamiento
-        - Derecho a la portabilidad de datos
-        - Derecho de oposición al tratamiento
+          - Derecho de acceso a tus datos personales
+          - Derecho de rectificación de datos inexactos
+          - Derecho de supresión ("derecho al olvido")
+          - Derecho a limitar el tratamiento
+          - Derecho a la portabilidad de datos
+          - Derecho de oposición al tratamiento
       heading: Política de privacidad
       how_we_use:
         heading: Cómo usamos tu información
         items:
-        - Proporcionar, mantener y mejorar nuestros servicios
-        - Procesar tus transacciones y enviar información relacionada
-        - Enviarte avisos técnicos, actualizaciones y mensajes de soporte
-        - Monitorear y analizar patrones y tendencias de uso
-        - Detectar, prevenir y abordar problemas técnicos y fraudes
-        - Cumplir con las obligaciones legales
+          - Proporcionar, mantener y mejorar nuestros servicios
+          - Procesar tus transacciones y enviar información relacionada
+          - Enviarte avisos técnicos, actualizaciones y mensajes de soporte
+          - Monitorear y analizar patrones y tendencias de uso
+          - Detectar, prevenir y abordar problemas técnicos y fraudes
+          - Cumplir con las obligaciones legales
       information_we_collect:
         account:
           heading: Información de la cuenta
@@ -969,7 +984,7 @@ es:
           heading: Información técnica
           text: Recopilamos automáticamente direcciones IP, cadenas de agente de usuario
             y otra información técnica con fines de seguridad y operativos.
-      last_updated: 'Última actualización: %{date}'
+      last_updated: "Última actualización: %{date}"
       overview:
         heading: Descripción general
         text: Requiems API ("nosotros", "nuestro" o "nos") se compromete a proteger
@@ -979,18 +994,18 @@ es:
       third_party:
         heading: Servicios de terceros
         items:
-        - name: LemonSqueezy
-          desc: Procesamiento de pagos (consulta su política de privacidad)
-        - name: Cloudflare
-          desc: Infraestructura y protección DDoS
-        text: 'Utilizamos los siguientes servicios de terceros:'
+          - name: LemonSqueezy
+            desc: Procesamiento de pagos (consulta su política de privacidad)
+          - name: Cloudflare
+            desc: Infraestructura y protección DDoS
+        text: "Utilizamos los siguientes servicios de terceros:"
       title: Política de privacidad - Requiems API
     status:
       all_operational: Todos los sistemas están operativos
       all_operational_desc: Todos los servicios de Requiems API funcionan correctamente
       contact_support: Contactar soporte
       having_issues: "¿Tienes problemas?"
-      last_updated: 'Última actualización: %{datetime}'
+      last_updated: "Última actualización: %{datetime}"
       metrics:
         data_centers: Centros de datos
         heading: Métricas de rendimiento
@@ -1050,14 +1065,14 @@ es:
       api_access:
         acceptable_use:
           heading: 2.3 Uso aceptable
-          intro: 'Aceptas no usar la API para:'
+          intro: "Aceptas no usar la API para:"
           items:
-          - Actividades ilegales o para violar cualquier ley
-          - Intentar obtener acceso no autorizado a nuestros sistemas
-          - Transmitir malware, virus o código dañino
-          - Acoso, spam o comportamiento abusivo
-          - Reventa o redistribución del acceso a la API sin permiso
-          - Ingeniería inversa o intento de extraer el código fuente
+            - Actividades ilegales o para violar cualquier ley
+            - Intentar obtener acceso no autorizado a nuestros sistemas
+            - Transmitir malware, virus o código dañino
+            - Acoso, spam o comportamiento abusivo
+            - Reventa o redistribución del acceso a la API sin permiso
+            - Ingeniería inversa o intento de extraer el código fuente
         heading: 2. Acceso y uso de la API
         keys:
           heading: 2.1 Claves API
@@ -1114,7 +1129,7 @@ es:
           de Bobadilla Tech y están protegidos por derechos de autor y otras leyes
           de propiedad intelectual. No puedes copiar, modificar ni crear obras derivadas
           sin permiso.
-      last_updated: 'Última actualización: %{date}'
+      last_updated: "Última actualización: %{date}"
       liability:
         heading: 8. Limitación de responsabilidad
         text: EN LA MÁXIMA MEDIDA PERMITIDA POR LA LEY, BOBADILLA TECH NO SERÁ RESPONSABLE
@@ -1124,22 +1139,22 @@ es:
           OTRAS PÉRDIDAS INTANGIBLES.
       sla:
         heading: 4. Nivel de servicio y disponibilidad
-        intro: 'Apuntamos a una disponibilidad del 99,99%, pero no garantizamos un
-          servicio ininterrumpido. No somos responsables de:'
+        intro: "Apuntamos a una disponibilidad del 99,99%, pero no garantizamos un
+          servicio ininterrumpido. No somos responsables de:"
         items:
-        - Ventanas de mantenimiento programado
-        - Eventos de fuerza mayor
-        - Fallos de servicios de terceros
-        - Problemas causados por el uso indebido de la API
+          - Ventanas de mantenimiento programado
+          - Eventos de fuerza mayor
+          - Fallos de servicios de terceros
+          - Problemas causados por el uso indebido de la API
       termination:
         heading: 7. Rescisión
-        intro: 'Podemos suspender o terminar tu acceso a la API en cualquier momento
-          por:'
+        intro: "Podemos suspender o terminar tu acceso a la API en cualquier momento
+          por:"
         items:
-        - Violación de estos términos
-        - Falta de pago de honorarios
-        - Actividad fraudulenta o ilegal
-        - A nuestra discreción con 30 días de aviso
+          - Violación de estos términos
+          - Falta de pago de honorarios
+          - Actividad fraudulenta o ilegal
+          - A nuestra discreción con 30 días de aviso
         self_cancel: Puedes cancelar tu cuenta en cualquier momento desde la configuración
           de tu panel.
       title: Términos de servicio - Requiems API

--- a/apps/dashboard/config/locales/fr/home.fr.yml
+++ b/apps/dashboard/config/locales/fr/home.fr.yml
@@ -15,7 +15,7 @@ fr:
       back: Retour aux exemples
       breadcrumb_examples: Exemples
       breadcrumb_home: Accueil
-      in_the_meantime: 'En attendant :'
+      in_the_meantime: "En attendant :"
       tip_demo: Essayez la démo en direct pour le voir en action
       tip_docs_html: Explorez la %{docs_link} des APIs utilisées dans ce projet
       tip_github: Consultez le code source sur GitHub pour voir comment c'est construit
@@ -45,16 +45,16 @@ fr:
       offerings:
         heading: Ce que nous proposons
         items:
-        - Validation e-mail et téléphone, détection des jetables et contrôles réseau
-          associés
-        - 'APIs texte et contenu : filtre grossièreté, sentiment, lorem ipsum, dictionnaire,
-          etc.'
-        - Génération QR et codes-barres, plus utilitaires financiers (IBAN, SWIFT,
-          BIN, etc.)
-        - 'Lieux et planification : fuseaux, jours ouvrés, jours fériés, géocodage'
-        - Infrastructure hébergée dans l'UE avec tarification transparente
-        - Documentation et exemples pensés pour la mise en production, formats adaptés
-          à l'IA
+          - Validation e-mail et téléphone, détection des jetables et contrôles réseau
+            associés
+          - "APIs texte et contenu : filtre grossièreté, sentiment, lorem ipsum, dictionnaire,
+            etc."
+          - Génération QR et codes-barres, plus utilitaires financiers (IBAN, SWIFT,
+            BIN, etc.)
+          - "Lieux et planification : fuseaux, jours ouvrés, jours fériés, géocodage"
+          - Infrastructure hébergée dans l'UE avec tarification transparente
+          - Documentation et exemples pensés pour la mise en production, formats adaptés
+            à l'IA
       title: À propos — Requiems API
       values:
         dx_text: Nous voulons que nos APIs soient simples à intégrer et agréables
@@ -116,10 +116,10 @@ fr:
       what_to_expect:
         heading: À quoi s'attendre
         items:
-        - Tutoriels techniques et guides d'intégration
-        - Bonnes pratiques de développement d'API
-        - Mises à jour de la plateforme et annonces de nouvelles APIs
-        - Retours d'expérience développeurs
+          - Tutoriels techniques et guides d'intégration
+          - Bonnes pratiques de développement d'API
+          - Mises à jour de la plateforme et annonces de nouvelles APIs
+          - Retours d'expérience développeurs
     changelog:
       badge_coming_soon: À venir
       badge_latest: Récent
@@ -129,8 +129,8 @@ fr:
       stay_updated:
         heading: Restez informé
         sign_up_cta: Créer un compte
-        signed_in: 'Nous enverrons les notifications à votre adresse enregistrée :
-          %{email}'
+        signed_in: "Nous enverrons les notifications à votre adresse enregistrée :
+          %{email}"
         text: Souhaitez-vous être averti des nouvelles versions et fonctionnalités
           ?
       title: Journal des modifications — Requiems API
@@ -138,84 +138,84 @@ fr:
         gateway:
           heading: Passerelle Cloudflare Worker
           items:
-          - Validation des clés API via Cloudflare KV
-          - Limitation de débit avec compteurs KV
-          - Suivi d'usage des requêtes avec D1 SQLite
-          - Proxy des requêtes vers l'API backend
-          - Analyse et journalisation d'usage
+            - Validation des clés API via Cloudflare KV
+            - Limitation de débit avec compteurs KV
+            - Suivi d'usage des requêtes avec D1 SQLite
+            - Proxy des requêtes vers l'API backend
+            - Analyse et journalisation d'usage
         init:
           heading: Initialisation du projet
           items:
-          - Architecture monorepo multilingue
-          - Choix de stack (Go, Rails 8, Cloudflare Workers)
-          - 'Architecture à trois niveaux : passerelle edge → API backend → base de
-            données'
-          - Schéma de base et conception des points de terminaison
+            - Architecture monorepo multilingue
+            - Choix de stack (Go, Rails 8, Cloudflare Workers)
+            - "Architecture à trois niveaux : passerelle edge → API backend → base de
+              données"
+            - Schéma de base et conception des points de terminaison
       v002:
         deploy:
           heading: Mise en production
           items:
-          - API backend Go déployée avec PostgreSQL
-          - Application Dashboard Rails 8 avec authentification
-          - Gestion des clés API et suivi d'utilisation
-          - Panneau d'administration utilisateurs et abonnements
-          - Environnement de développement Docker Compose
+            - API backend Go déployée avec PostgreSQL
+            - Application Dashboard Rails 8 avec authentification
+            - Gestion des clés API et suivi d'utilisation
+            - Panneau d'administration utilisateurs et abonnements
+            - Environnement de développement Docker Compose
         features:
           heading: Fonctionnalités
           items:
-          - Points de terminaison de validation e-mail (détection jetable)
-          - APIs utilitaires texte (conseils, lorem ipsum, citations, mots aléatoires)
-          - Inscription et authentification (Devise)
-          - Tableau de bord d'analyse d'utilisation
-          - Intégration abonnement et facturation
-          - Points de terminaison de santé et supervision
+            - Points de terminaison de validation e-mail (détection jetable)
+            - APIs utilitaires texte (conseils, lorem ipsum, citations, mots aléatoires)
+            - Inscription et authentification (Devise)
+            - Tableau de bord d'analyse d'utilisation
+            - Intégration abonnement et facturation
+            - Points de terminaison de santé et supervision
       v010:
         bugs:
           heading: Corrections de bogues
           items:
-          - Correction de l'ordre d'exécution du callback de génération des clés API
-          - Résolution du mapping Devise en environnement de test
-          - Correction du champ de statut utilisateur pour suspendu / banni
-          - Ajout des timeouts serveur HTTP pour la conformité sécurité
-          - Correction du formatage du code sur toutes les applications
+            - Correction de l'ordre d'exécution du callback de génération des clés API
+            - Résolution du mapping Devise en environnement de test
+            - Correction du champ de statut utilisateur pour suspendu / banni
+            - Ajout des timeouts serveur HTTP pour la conformité sécurité
+            - Correction du formatage du code sur toutes les applications
         ci:
           heading: Intégration continue
           items:
-          - Pipeline CI complet avec tests automatisés sur toutes les applications
-          - 'API Go : tests avec détection de courses, golangci-lint (21 linters),
-            couverture de code'
-          - 'Dashboard Rails : suite de tests complète (60 tests, 207 assertions),
-            analyses de sécurité'
-          - 'Worker Cloudflare : vérifications TypeScript, suite Vitest (71 tests),
-            lint Biome'
-          - Exécution par chemins pour des builds efficaces
-          - Analyses de sécurité bloquantes (Brakeman, bundler-audit)
+            - Pipeline CI complet avec tests automatisés sur toutes les applications
+            - "API Go : tests avec détection de courses, golangci-lint (21 linters),
+              couverture de code"
+            - "Dashboard Rails : suite de tests complète (60 tests, 207 assertions),
+              analyses de sécurité"
+            - "Worker Cloudflare : vérifications TypeScript, suite Vitest (71 tests),
+              lint Biome"
+            - Exécution par chemins pour des builds efficaces
+            - Analyses de sécurité bloquantes (Brakeman, bundler-audit)
         coverage:
           heading: Couverture de tests
           items:
-          - 'Dashboard Rails : 100 % de tests réussis (60 tests)'
-          - 'Worker Cloudflare : 71 tests réussis, 29 % de couverture'
-          - 'API Go : suite complète avec détection de courses'
+            - "Dashboard Rails : 100 % de tests réussis (60 tests)"
+            - "Worker Cloudflare : 71 tests réussis, 29 % de couverture"
+            - "API Go : suite complète avec détection de courses"
       v020:
         features:
           heading: Fonctionnalités prévues
           items:
-          - Documentation API enrichie avec playground interactif
-          - Webhooks d'usage pour notifications en temps réel
-          - Contrôles avancés de limitation de débit par clé API
-          - Export et rapports d'utilisation API
-          - Fonctionnalités d'équipe (espaces de travail partagés)
-          - APIs de validation supplémentaires (téléphone, carte bancaire)
-        planned_release: 'Version prévue : T1 2026'
+            - Documentation API enrichie avec playground interactif
+            - Webhooks d'usage pour notifications en temps réel
+            - Contrôles avancés de limitation de débit par clé API
+            - Export et rapports d'utilisation API
+            - Fonctionnalités d'équipe (espaces de travail partagés)
+            - APIs de validation supplémentaires (téléphone, carte bancaire)
+        planned_release: "Version prévue : T1 2026"
         roadmap:
           heading: Feuille de route (v1.0.0+)
           items:
-          - APIs données (géolocalisation IP, conversion de devises)
-          - APIs finance (cotations, crypto)
-          - APIs image (optimisation, placeholders, QR)
-          - Support GraphQL
-          - Bibliothèques SDK (Python, JavaScript, Go, Ruby)
-          - Documentation de conformité à rétention zéro de données
+            - APIs données (géolocalisation IP, conversion de devises)
+            - APIs finance (cotations, crypto)
+            - APIs image (optimisation, placeholders, QR)
+            - Support GraphQL
+            - Bibliothèques SDK (Python, JavaScript, Go, Ruby)
+            - Documentation de conformité à rétention zéro de données
       v0_0_1: v0.0.1
       v0_0_2: v0.0.2
       v0_1_0: v0.1.0
@@ -271,69 +271,69 @@ fr:
         heading: Bonnes pratiques de gestion des erreurs
         help_text: Besoin d'aide pour le dépannage ?
         items:
-        - Vérifiez toujours le code de statut avant de traiter le corps de la réponse
-        - Implémentez un backoff exponentiel pour les erreurs 5xx
-        - Journalisez les détails sans exposer de données sensibles
-        - Respectez les en-têtes retry-after en cas de limitation de débit
-        - Affichez des messages clairs plutôt que la réponse brute de l'API
+          - Vérifiez toujours le code de statut avant de traiter le corps de la réponse
+          - Implémentez un backoff exponentiel pour les erreurs 5xx
+          - Journalisez les détails sans exposer de données sensibles
+          - Respectez les en-têtes retry-after en cas de limitation de débit
+          - Affichez des messages clairs plutôt que la réponse brute de l'API
       client_errors_heading: Erreurs client
       codes:
         client_errors:
-        - code: '400'
-          name: Requête incorrecte
-          description: Requête mal formée ou paramètres invalides.
-          note: 'Causes fréquentes : champs obligatoires manquants, JSON invalide,
-            types incorrects'
-        - code: '401'
-          name: Non autorisé
-          description: Authentification requise ou échouée. Clé API manquante ou invalide.
-          note: 'Causes fréquentes : absence de clé, clé invalide ou expirée'
-        - code: '403'
-          name: Interdit
-          description: Vous n'avez pas la permission d'accéder à cette ressource.
-          note: 'Causes fréquentes : permissions insuffisantes, compte suspendu, endpoint
-            test avec clé production'
-        - code: '404'
-          name: Introuvable
-          description: La ressource n'existe pas. Vérifiez l'URL du point de terminaison.
-          note: 'Causes fréquentes : URL erronée, faute de frappe, ressource supprimée'
-        - code: '422'
-          name: Entité non traitable
-          description: Requête syntaxiquement correcte mais erreurs sémantiques ou
-            de validation.
-          note: 'Causes fréquentes : format e-mail invalide, valeurs hors bornes,
-            règles métier'
-        - code: '429'
-          name: Trop de requêtes
-          description: Limite de débit dépassée. Attendez ou changez de formule.
-          note: 'Causes fréquentes : trop de requêtes par minute, quota journalier
-            dépassé'
+          - code: "400"
+            name: Requête incorrecte
+            description: Requête mal formée ou paramètres invalides.
+            note: "Causes fréquentes : champs obligatoires manquants, JSON invalide,
+              types incorrects"
+          - code: "401"
+            name: Non autorisé
+            description: Authentification requise ou échouée. Clé API manquante ou invalide.
+            note: "Causes fréquentes : absence de clé, clé invalide ou expirée"
+          - code: "403"
+            name: Interdit
+            description: Vous n'avez pas la permission d'accéder à cette ressource.
+            note: "Causes fréquentes : permissions insuffisantes, compte suspendu, endpoint
+              test avec clé production"
+          - code: "404"
+            name: Introuvable
+            description: La ressource n'existe pas. Vérifiez l'URL du point de terminaison.
+            note: "Causes fréquentes : URL erronée, faute de frappe, ressource supprimée"
+          - code: "422"
+            name: Entité non traitable
+            description: Requête syntaxiquement correcte mais erreurs sémantiques ou
+              de validation.
+            note: "Causes fréquentes : format e-mail invalide, valeurs hors bornes,
+              règles métier"
+          - code: "429"
+            name: Trop de requêtes
+            description: Limite de débit dépassée. Attendez ou changez de formule.
+            note: "Causes fréquentes : trop de requêtes par minute, quota journalier
+              dépassé"
         server_errors:
-        - code: '500'
-          name: Erreur interne du serveur
-          description: Erreur inattendue côté serveur. Problème temporaire.
-          note: 'Action : réessayez. Si le problème persiste, contactez le support.'
-        - code: '502'
-          name: Passerelle invalide
-          description: La passerelle a reçu une réponse invalide du serveur backend.
-          note: 'Action : réessayez après une courte pause.'
-        - code: '503'
-          name: Service indisponible
-          description: Service temporairement indisponible (maintenance ou surcharge).
-          note: 'Action : consultez la page de statut et réessayez plus tard.'
-        - code: '504'
-          name: Délai de passerelle dépassé
-          description: La passerelle n'a pas reçu de réponse du backend à temps.
-          note: 'Action : réessayez avec backoff exponentiel.'
+          - code: "500"
+            name: Erreur interne du serveur
+            description: Erreur inattendue côté serveur. Problème temporaire.
+            note: "Action : réessayez. Si le problème persiste, contactez le support."
+          - code: "502"
+            name: Passerelle invalide
+            description: La passerelle a reçu une réponse invalide du serveur backend.
+            note: "Action : réessayez après une courte pause."
+          - code: "503"
+            name: Service indisponible
+            description: Service temporairement indisponible (maintenance ou surcharge).
+            note: "Action : consultez la page de statut et réessayez plus tard."
+          - code: "504"
+            name: Délai de passerelle dépassé
+            description: La passerelle n'a pas reçu de réponse du backend à temps.
+            note: "Action : réessayez avec backoff exponentiel."
         success:
-        - code: '200'
-          name: OK
-          description: La requête a réussi et la réponse contient les données demandées.
-          note: 'Fréquent avec : GET, POST, PUT'
-        - code: '201'
-          name: Créé
-          description: Une nouvelle ressource a été créée avec succès.
-          note: 'Fréquent avec : POST de création'
+          - code: "200"
+            name: OK
+            description: La requête a réussi et la réponse contient les données demandées.
+            note: "Fréquent avec : GET, POST, PUT"
+          - code: "201"
+            name: Créé
+            description: Une nouvelle ressource a été créée avec succès.
+            note: "Fréquent avec : POST de création"
       description: Comprendre les codes de statut HTTP et les gérer
       heading: Référence des codes d'erreur
       server_errors_heading: Erreurs serveur
@@ -389,16 +389,16 @@ fr:
       intro: Facturation, authentification, limites de débit et passage de l'inscription
         à la production rapidement.
       rate_limits:
-        a1: 'Elles varient selon la formule :'
+        a1: "Elles varient selon la formule :"
         a2_html: En cas d'erreur 429, implémentez un backoff exponentiel. Attendez
           quelques secondes avant de réessayer. Consultez l'en-tête %{retry_after_header}
           pour le délai recommandé. Envisagez une formule supérieure si vous atteignez
           souvent la limite.
-        business: 'Business : %{rate_limit} requêtes/minute'
-        developer: 'Développeur : %{rate_limit} requêtes/minute'
-        free: 'Gratuit : %{rate_limit} requêtes/minute'
+        business: "Business : %{rate_limit} requêtes/minute"
+        developer: "Développeur : %{rate_limit} requêtes/minute"
+        free: "Gratuit : %{rate_limit} requêtes/minute"
         heading: Limites de débit
-        professional: 'Professionnel : %{rate_limit} requêtes/minute'
+        professional: "Professionnel : %{rate_limit} requêtes/minute"
         q1: Quelles sont les limites de débit ?
         q2: Comment gérer les erreurs de limite de débit ?
       still_questions:
@@ -410,12 +410,12 @@ fr:
       subheading: Réponses aux questions courantes sur la facturation, l'authentification,
         les limites de débit et l'intégration.
       support:
-        a1: 'Plusieurs canaux :'
-        a2: 'Ils varient selon la formule :'
+        a1: "Plusieurs canaux :"
+        a2: "Ils varient selon la formule :"
         a3_html: Oui ! Les clients entreprise bénéficient d'un support dédié avec
           délais garantis, accès direct à l'équipe d'ingénierie et assistance prioritaire.
           %{sales_link} pour en savoir plus.
-        business_time: 'Business : 24 h'
+        business_time: "Business : 24 h"
         contact_channel:
           description: Support e-mail (réponse sous 24–48 h)
           label: Formulaire de contact
@@ -423,12 +423,12 @@ fr:
         docs_channel:
           description: Guides complets et référence API
           label: Documentation
-        free_dev: 'Gratuit et Développeur : 48 h'
+        free_dev: "Gratuit et Développeur : 48 h"
         github_channel:
           description: Signaler des bogues ou demander des fonctionnalités
           label: Issues GitHub
         heading: Support
-        professional_time: 'Professionnel : 12 h (support prioritaire)'
+        professional_time: "Professionnel : 12 h (support prioritaire)"
         q1: Comment obtenir de l'aide ?
         q2: Quels sont vos délais de réponse ?
         q3: Proposez-vous un support entreprise ?
@@ -438,7 +438,7 @@ fr:
         description: Obtenez la documentation complète d'une API en Markdown en ajoutant
           /index.md à son URL.
         heading: Markdown par API
-        pattern: 'Modèle : /apis/{api-id}/index.md'
+        pattern: "Modèle : /apis/{api-id}/index.md"
       cta:
         browse_apis: Parcourir les APIs
         full_docs: Télécharger llms-full.txt
@@ -475,71 +475,71 @@ fr:
         heading: Besoin d'aide ?
         text: Consultez notre documentation complète ou contactez le support
       terms:
-      - name: API (interface de programmation d'applications)
-        definition: Un ensemble de définitions et de protocoles permettant à des applications
-          logicielles de communiquer entre elles. Les APIs définissent les méthodes
-          et formats d'échange d'informations.
-        example_prefix: 'Exemple : Requiems API fournit une API REST pour valider
-          des adresses e-mail par programme.'
-      - name: Point de terminaison (endpoint)
-        definition: Une URL précise où une API accède aux ressources nécessaires.
-          Chaque point de terminaison correspond à une fonction ou ressource donnée.
-        example_prefix: 'Exemple :'
-        example_code: POST /v1/networking/disposable/check
-      - name: Authentification
-        definition: Vérification de l'identité d'un utilisateur ou d'une application.
-          Les APIs exigent en général une authentification pour limiter l'accès aux
-          clients autorisés.
-        example_prefix: 'Exemple : inclure votre clé API dans l''en-tête Authorization
-          :'
-        example_code: 'Authorization: Bearer VOTRE_CLE_API'
-      - name: Clé API
-        definition: Identifiant unique servant à authentifier les requêtes. Elle sert
-          à la fois d'identifiant et de secret.
-        example_prefix: 'Exemple :'
-        example_code: rq_live_1234567890abcdef
-      - name: Limitation de débit
-        definition: Technique pour limiter le nombre de requêtes dans une fenêtre
-          de temps. Limite les abus et garantit un usage équitable.
-        example_prefix: 'Exemple : la formule gratuite autorise 30 requêtes par minute'
-      - name: Requêtes
-        definition: Unité d'usage de l'API. Chaque appel compte pour 1 requête sur
-          votre quota mensuel. Certains points de terminaison peuvent compter plus
-          ; c'est indiqué dans leur documentation.
-        example_prefix: 'Exemple : un appel au point de terminaison de validation
-          e-mail consomme 1 requête sur votre quota.'
-      - name: REST (Representational State Transfer)
-        definition: Style d'architecture pour applications réseau. Les APIs REST utilisent
-          HTTP pour les opérations CRUD sur les ressources.
-        example_prefix: 'Exemple : GET pour lire, POST pour créer, PUT pour mettre
-          à jour, DELETE pour supprimer'
-      - name: JSON (JavaScript Object Notation)
-        definition: Format d'échange léger, lisible par les humains et facile à parser
-          par les machines. La plupart des APIs modernes utilisent JSON pour les corps
-          de requête/réponse.
-        example_prefix: 'Exemple :'
-        example_code: '{"email": "test@example.com", "is_disposable": false}'
-      - name: Codes de statut HTTP
-        definition: 'Codes à trois chiffres indiquant le résultat d''une requête HTTP.
-          Exemples : 200 (succès), 404 (introuvable), 500 (erreur serveur).'
-        example_prefix: 'En savoir plus :'
-        example_link_href: "/fr/error_codes"
-        example_link_text: Référence des codes d'erreur
-      - name: Webhook
-        definition: Mécanisme pour qu'une application pousse des informations en temps
-          réel vers une autre, au lieu de requêtes répétées depuis le client.
-        example_prefix: 'Exemple : recevoir une notification lorsque votre solde de
-          requêtes passe sous un seuil'
-      - name: Paramètres de requête
-        definition: Paires clé-valeur ajoutées à l'URL pour filtrer, trier ou modifier
-          la réponse. Ils apparaissent après le « ? ».
-        example_prefix: 'Exemple :'
-        example_code: "/v1/words?limit=10&min_length=5"
-      - name: En-têtes
-        definition: 'Métadonnées envoyées avec les requêtes et réponses HTTP : jetons
-          d''authentification, types de contenu, etc.'
-        example_prefix: 'Exemple :'
-        example_code: 'Content-Type: application/json'
+        - name: API (interface de programmation d'applications)
+          definition: Un ensemble de définitions et de protocoles permettant à des applications
+            logicielles de communiquer entre elles. Les APIs définissent les méthodes
+            et formats d'échange d'informations.
+          example_prefix: "Exemple : Requiems API fournit une API REST pour valider
+            des adresses e-mail par programme."
+        - name: Point de terminaison (endpoint)
+          definition: Une URL précise où une API accède aux ressources nécessaires.
+            Chaque point de terminaison correspond à une fonction ou ressource donnée.
+          example_prefix: "Exemple :"
+          example_code: POST /v1/networking/disposable/check
+        - name: Authentification
+          definition: Vérification de l'identité d'un utilisateur ou d'une application.
+            Les APIs exigent en général une authentification pour limiter l'accès aux
+            clients autorisés.
+          example_prefix: 'Exemple : inclure votre clé API dans l''en-tête Authorization
+            :'
+          example_code: "Authorization: Bearer VOTRE_CLE_API"
+        - name: Clé API
+          definition: Identifiant unique servant à authentifier les requêtes. Elle sert
+            à la fois d'identifiant et de secret.
+          example_prefix: "Exemple :"
+          example_code: rq_live_1234567890abcdef
+        - name: Limitation de débit
+          definition: Technique pour limiter le nombre de requêtes dans une fenêtre
+            de temps. Limite les abus et garantit un usage équitable.
+          example_prefix: "Exemple : la formule gratuite autorise 30 requêtes par minute"
+        - name: Requêtes
+          definition: Unité d'usage de l'API. Chaque appel compte pour 1 requête sur
+            votre quota mensuel. Certains points de terminaison peuvent compter plus
+            ; c'est indiqué dans leur documentation.
+          example_prefix: "Exemple : un appel au point de terminaison de validation
+            e-mail consomme 1 requête sur votre quota."
+        - name: REST (Representational State Transfer)
+          definition: Style d'architecture pour applications réseau. Les APIs REST utilisent
+            HTTP pour les opérations CRUD sur les ressources.
+          example_prefix: "Exemple : GET pour lire, POST pour créer, PUT pour mettre
+            à jour, DELETE pour supprimer"
+        - name: JSON (JavaScript Object Notation)
+          definition: Format d'échange léger, lisible par les humains et facile à parser
+            par les machines. La plupart des APIs modernes utilisent JSON pour les corps
+            de requête/réponse.
+          example_prefix: "Exemple :"
+          example_code: '{"email": "test@example.com", "is_disposable": false}'
+        - name: Codes de statut HTTP
+          definition: 'Codes à trois chiffres indiquant le résultat d''une requête HTTP.
+            Exemples : 200 (succès), 404 (introuvable), 500 (erreur serveur).'
+          example_prefix: "En savoir plus :"
+          example_link_href: "/fr/error_codes"
+          example_link_text: Référence des codes d'erreur
+        - name: Webhook
+          definition: Mécanisme pour qu'une application pousse des informations en temps
+            réel vers une autre, au lieu de requêtes répétées depuis le client.
+          example_prefix: "Exemple : recevoir une notification lorsque votre solde de
+            requêtes passe sous un seuil"
+        - name: Paramètres de requête
+          definition: Paires clé-valeur ajoutées à l'URL pour filtrer, trier ou modifier
+            la réponse. Ils apparaissent après le « ? ».
+          example_prefix: "Exemple :"
+          example_code: "/v1/words?limit=10&min_length=5"
+        - name: En-têtes
+          definition: 'Métadonnées envoyées avec les requêtes et réponses HTTP : jetons
+            d''authentification, types de contenu, etc.'
+          example_prefix: "Exemple :"
+          example_code: "Content-Type: application/json"
       title: Glossaire API — Requiems API
     index:
       categories:
@@ -583,18 +583,18 @@ fr:
           et intelligence, puis renvoie une décision structurée unique. Aucune logique
           de scoring à construire. Aucun pipeline à maintenir.
         value_table:
-        - field: risk_score
-          plain: Quel est le risque de cette inscription ? 0 est propre, 1 est à haut
-            risque.
-        - field: is_safe
-          plain: Décision unique oui/non. Utilisez-la pour bloquer ou autoriser l'inscription.
-        - field: confidence
-          plain: Niveau de certitude du moteur. Plus élevé signifie moins de faux
-            positifs.
-        - field: flags
-          plain: Les raisons précises pour lesquelles l'utilisateur a été signalé.
-        - field: signals
-          plain: Résultats bruts de chaque contrôle exécuté en arrière-plan.
+          - field: risk_score
+            plain: Quel est le risque de cette inscription ? 0 est propre, 1 est à haut
+              risque.
+          - field: is_safe
+            plain: Décision unique oui/non. Utilisez-la pour bloquer ou autoriser l'inscription.
+          - field: confidence
+            plain: Niveau de certitude du moteur. Plus élevé signifie moins de faux
+              positifs.
+          - field: flags
+            plain: Les raisons précises pour lesquelles l'utilisateur a été signalé.
+          - field: signals
+            plain: Résultats bruts de chaque contrôle exécuté en arrière-plan.
         value_table_heading: Signification de chaque champ
       faq:
         a1: Oui ! 500 requêtes par mois entièrement gratuites, sans carte bancaire.
@@ -631,23 +631,23 @@ fr:
         playground_desc: Testez chaque point de terminaison dans la doc. Réponses
           réelles instantanément, sans écrire de code.
         playground_title: Playground API en direct
-        subheading: 'Des fondateurs solo aux agences : documentation précise, playgrounds
-          en ligne et exemples prêts à copier. Intégrez en minutes, pas en jours.'
+        subheading: "Des fondateurs solo aux agences : documentation précise, playgrounds
+          en ligne et exemples prêts à copier. Intégrez en minutes, pas en jours."
       hero:
         cta_primary: Obtenir une clé API
         cta_secondary: Explorer les systèmes
         description: Authentification, validation, détection de fraude, intelligence
           paiements et données mondiales, livrés via une API unifiée.
         proof_badges:
-        - Pipelines de données propriétaires
-        - Traitement en temps réel
-        - Conçu pour la production
+          - Pipelines de données propriétaires
+          - Traitement en temps réel
+          - Conçu pour la production
         title_line1: Backend tout-en-un
         title_line2: pour produits SaaS.
       how_it_works:
         heading: Comment ça marche
-        step1_body: 'Choisissez le problème à résoudre : identité, paiements, données
-          mondiales ou intégrité des données.'
+        step1_body: "Choisissez le problème à résoudre : identité, paiements, données
+          mondiales ou intégrité des données."
         step1_title: Choisir un système
         step2_body: Utilisez des points de terminaison de haut niveau ou composez
           des flux selon vos besoins.
@@ -702,55 +702,70 @@ fr:
           data_integrity:
             blurb: Valider et normaliser les données saisies (e-mail, téléphone et
               SMS) lors de leur soumission.
-            signals: "[tableau]"
+            signals:
+              - Validation des entrées
+              - Normalisation de texte
+              - Modération de contenu
             title: Intégrité des données
           developer_utilities:
             blurb: Des outils utiles que vous ne devriez pas avoir à reconstruire.
-            signals: "[tableau]"
+            signals:
+              - Codes QR
+              - Encodage et conversions
+              - Utilitaires divers
             title: Utilitaires développeur
           global_data:
             blurb: Géocodage, fuseaux horaires et calendriers des jours fériés pour
               plus de 100 pays.
-            signals: "[tableau]"
+            signals:
+              - Géocodage
+              - Fuseaux horaires et jours fériés
+              - Intelligence d'adresse
             title: Données mondiales
           identity_risk:
             blurb: Bloquez la fraude dès l'inscription grâce à la détection des fraudes
               par e-mail, téléphone, adresse IP et indicateurs comportementaux.
-            signals: "[tableau]"
+            signals:
+              - Score de risque
+              - Intelligence e-mail, téléphone et IP
+              - Signaux de domaine et comportementaux
             title: Identité et risque
           payments_intelligence:
             blurb: Valider les données BIN, IBAN et SWIFT grâce à la détection des
               incohérences de géolocalisation.
-            signals: "[tableau]"
+            signals:
+              - Validation BIN et carte
+              - Contrôles IBAN / SWIFT
+              - Signaux de risque transactionnel
             title: Renseignements sur les paiements
         explore_cta: Explorer le système
         heading: Systèmes de niveau production
         subheading: Chaque système compose des signaux propriétaires en une décision
           structurée unique, livrée en un seul appel API.
         utilities_label: Extras
-      title: 'Requiems API : Backend tout-en-un pour produits SaaS'
+      title: "Requiems API : Backend tout-en-un pour produits SaaS"
       trusted_by:
         label: Plébiscité par des équipes qui livrent de vrais produits
       use_cases:
         heading: Conçu pour de vrais produits
         items:
-        - title: Protection d'inscription SaaS
-          body: Bloquez les faux comptes, les bots et les abus dès le premier jour.
-        - title: Onboarding fintech
-          body: Validez les données financières et réduisez la friction à l'inscription.
-        - title: Prévention de la fraude sur les marketplaces
-          body: Détectez les utilisateurs et transactions à risque en temps réel.
-        - title: Support produit mondial
-          body: Servez des utilisateurs internationaux avec des données précises partout.
+          - title: Protection d'inscription SaaS
+            body: Bloquez les faux comptes, les bots et les abus dès le premier jour.
+          - title: Onboarding fintech
+            body: Validez les données financières et réduisez la friction à l'inscription.
+          - title: Prévention de la fraude sur les marketplaces
+            body: Détectez les utilisateurs et transactions à risque en temps réel.
+          - title: Support produit mondial
+            body: Servez des utilisateurs internationaux avec des données précises partout.
         subheading: Des problèmes concrets, résolus.
       why_different:
         heading: Infrastructure, pas de colle d'intégration
         points:
-        - Aucune dépendance aux APIs tierces
-        - Systèmes propriétaires de scoring et de validation
-        - Schéma unifié sur tous les points de terminaison
-        - Conception faible latence et haut débit
-        - Conçu pour les développeurs qui livrent de vrais produits
+          - Aucune dépendance aux APIs tierces
+          - Systèmes propriétaires de scoring et de validation
+          - Schéma unifié sur tous les points de terminaison
+          - Conception faible latence et haut débit
+          - Conçu pour les développeurs qui livrent de vrais produits
         subheading: La plupart des agrégateurs d'API revendent des appels tiers. Nous
           construisons des pipelines propriétaires.
     pricing:
@@ -785,32 +800,32 @@ fr:
           cta: Démarrer l'essai gratuit
           description: Pour les entreprises et équipes en croissance
           features:
-          - 1 000 000 requêtes/mois
-          - 10 000 requêtes/minute
-          - Tous les points de terminaison
-          - Support e-mail prioritaire (réponse sous 4 h)
-          - Centres de données dans l'UE
-          - SLA personnalisés possibles
+            - 1 000 000 requêtes/mois
+            - 10 000 requêtes/minute
+            - Tous les points de terminaison
+            - Support e-mail prioritaire (réponse sous 4 h)
+            - Centres de données dans l'UE
+            - SLA personnalisés possibles
           name: Business
         developer:
           cta: Démarrer l'essai gratuit
           description: Pour les applications en production
           features:
-          - 100 000 requêtes/mois
-          - 5 000 requêtes/minute
-          - Tous les points de terminaison
-          - Support e-mail (réponse sous 24 h)
-          - Centres de données dans l'UE
+            - 100 000 requêtes/mois
+            - 5 000 requêtes/minute
+            - Tous les points de terminaison
+            - Support e-mail (réponse sous 24 h)
+            - Centres de données dans l'UE
           name: Développeur
         free:
           cta: Commencer gratuitement
           description: Idéal pour tester et les petits projets
           features:
-          - 500 requêtes/mois
-          - 30 requêtes/minute
-          - Tous les points de terminaison
-          - Support communautaire
-          - Centres de données dans l'UE
+            - 500 requêtes/mois
+            - 30 requêtes/minute
+            - Tous les points de terminaison
+            - Support communautaire
+            - Centres de données dans l'UE
           name: Gratuit
         per_month: "/mois"
         popular_badge: Le plus populaire
@@ -824,14 +839,14 @@ fr:
             accessible sur yourcompany.requiems.xyz. Facturation mensuelle ou annuelle.
             Pas de dépassement facturé, requêtes illimitées.
           features:
-          - VPS dédié Hetzner
-          - Uniquement les APIs dont vous avez besoin
-          - HTTPS direct, sans couche Cloudflare
-          - Votre sous-domaine sur requiems.xyz
-          - Requêtes illimitées
-          - Abonnement mensuel ou annuel
-          - Mise en service sous 24–48 h
-          - 15 % de remise en facturation annuelle
+            - VPS dédié Hetzner
+            - Uniquement les APIs dont vous avez besoin
+            - HTTPS direct, sans couche Cloudflare
+            - Votre sous-domaine sur requiems.xyz
+            - Requêtes illimitées
+            - Abonnement mensuel ou annuel
+            - Mise en service sous 24–48 h
+            - 15 % de remise en facturation annuelle
           heading: Votre propre instance API dédiée
           units:
             ram: RAM
@@ -842,12 +857,12 @@ fr:
           cta: Démarrer l'essai gratuit
           description: Pour les applications à fort volume
           features:
-          - 10 000 000 requêtes/mois
-          - 50 000 requêtes/minute
-          - Tous les points de terminaison
-          - Support prioritaire (réponse sous 1 h)
-          - Centres de données dans l'UE
-          - SLA personnalisés
+            - 10 000 000 requêtes/mois
+            - 50 000 requêtes/minute
+            - Tous les points de terminaison
+            - Support prioritaire (réponse sous 1 h)
+            - Centres de données dans l'UE
+            - SLA personnalisés
           name: Professionnel
         save_per_year: Économisez %{amount} $/an
       security:
@@ -883,8 +898,8 @@ fr:
     privacy:
       contact:
         heading: Nous contacter
-        text: 'Pour toute question relative à la confidentialité ou pour exercer vos
-          droits, contactez-nous à :'
+        text: "Pour toute question relative à la confidentialité ou pour exercer vos
+          droits, contactez-nous à :"
       data_retention:
         heading: Conservation des données
         text: Nous conservons les informations de compte tant que le compte est actif.
@@ -893,10 +908,10 @@ fr:
       data_storage:
         heading: Stockage et sécurité des données
         items:
-        - Chiffrement TLS 1.3 pour les données en transit
-        - Zéro rétention des payloads API — entrées traitées uniquement en mémoire volatile
-        - Audits et surveillance de sécurité réguliers
-        - Contrôles d'accès et mécanismes d'authentification
+          - Chiffrement TLS 1.3 pour les données en transit
+          - Zéro rétention des payloads API — entrées traitées uniquement en mémoire volatile
+          - Audits et surveillance de sécurité réguliers
+          - Contrôles d'accès et mécanismes d'authentification
         text: 'Toutes les données sont stockées sur des serveurs situés dans l''Union
           européenne. Nous mettons en œuvre des mesures de sécurité conformes aux
           usages du secteur, notamment :'
@@ -905,22 +920,22 @@ fr:
         intro: 'Si vous êtes dans l''Espace économique européen, vous disposez des
           droits suivants :'
         items:
-        - Droit d'accès à vos données personnelles
-        - Droit de rectification des données inexactes
-        - Droit à l'effacement (« droit à l'oubli »)
-        - Droit à la limitation du traitement
-        - Droit à la portabilité des données
-        - Droit d'opposition au traitement
+          - Droit d'accès à vos données personnelles
+          - Droit de rectification des données inexactes
+          - Droit à l'effacement (« droit à l'oubli »)
+          - Droit à la limitation du traitement
+          - Droit à la portabilité des données
+          - Droit d'opposition au traitement
       heading: Politique de confidentialité
       how_we_use:
         heading: Utilisation de vos informations
         items:
-        - Fournir, maintenir et améliorer nos services
-        - Traiter vos transactions et envoyer les informations associées
-        - Vous envoyer des avis techniques, mises à jour et messages de support
-        - Surveiller et analyser les tendances d'usage
-        - Détecter, prévenir et traiter les problèmes techniques et la fraude
-        - Respecter nos obligations légales
+          - Fournir, maintenir et améliorer nos services
+          - Traiter vos transactions et envoyer les informations associées
+          - Vous envoyer des avis techniques, mises à jour et messages de support
+          - Surveiller et analyser les tendances d'usage
+          - Détecter, prévenir et traiter les problèmes techniques et la fraude
+          - Respecter nos obligations légales
       information_we_collect:
         account:
           heading: Compte
@@ -928,15 +943,15 @@ fr:
             nom et les informations de facturation.
         api_usage:
           heading: Données d'usage API
-          text: 'Nous collectons des métadonnées sur vos requêtes : horodatages, point
+          text: "Nous collectons des métadonnées sur vos requêtes : horodatages, point
             de terminaison appelé, codes de réponse. Nous ne journalisons PAS le contenu
-            réel des requêtes ou réponses.'
+            réel des requêtes ou réponses."
         heading: Informations collectées
         technical:
           heading: Informations techniques
           text: Nous collectons automatiquement les adresses IP, les user-agents et
             d'autres données techniques pour la sécurité et l'exploitation.
-      last_updated: 'Dernière mise à jour : %{date}'
+      last_updated: "Dernière mise à jour : %{date}"
       overview:
         heading: Vue d'ensemble
         text: Requiems API (« nous », « notre ») s'engage à protéger votre vie privée.
@@ -946,18 +961,18 @@ fr:
       third_party:
         heading: Services tiers
         items:
-        - name: LemonSqueezy
-          desc: Traitement des paiements (voir leur politique de confidentialité)
-        - name: Cloudflare
-          desc: Infrastructure et protection DDoS
-        text: 'Nous utilisons les services tiers suivants :'
+          - name: LemonSqueezy
+            desc: Traitement des paiements (voir leur politique de confidentialité)
+          - name: Cloudflare
+            desc: Infrastructure et protection DDoS
+        text: "Nous utilisons les services tiers suivants :"
       title: Politique de confidentialité — Requiems API
     status:
       all_operational: Tous les systèmes sont opérationnels
       all_operational_desc: Tous les services Requiems API fonctionnent normalement
       contact_support: Contacter le support
       having_issues: Un problème ?
-      last_updated: 'Dernière mise à jour : %{datetime}'
+      last_updated: "Dernière mise à jour : %{datetime}"
       metrics:
         data_centers: Centres de données
         heading: Indicateurs de performance
@@ -1016,12 +1031,12 @@ fr:
           heading: 2.3 Usage acceptable
           intro: 'Vous vous engagez à ne pas utiliser l''API pour :'
           items:
-          - Des activités illégaires ou contraires aux lois
-          - Tenter d'accéder sans autorisation à nos systèmes
-          - Transmettre malware, virus ou code nuisible
-          - Harcèlement, spam ou comportement abusif
-          - Revendre ou redistribuer l'accès sans autorisation
-          - Rétro-ingénierie ou extraction du code source
+            - Des activités illégaires ou contraires aux lois
+            - Tenter d'accéder sans autorisation à nos systèmes
+            - Transmettre malware, virus ou code nuisible
+            - Harcèlement, spam ou comportement abusif
+            - Revendre ou redistribuer l'accès sans autorisation
+            - Rétro-ingénierie ou extraction du code source
         heading: 2. Accès et utilisation de l'API
         keys:
           heading: 2.1 Clés API
@@ -1072,7 +1087,7 @@ fr:
         text: L'API, la documentation et les matériaux associés appartiennent à Bobadilla
           Tech et sont protégés par le droit d'auteur et autres droits de propriété
           intellectuelle. Copie, modification ou œuvres dérivées interdites sans autorisation.
-      last_updated: 'Dernière mise à jour : %{date}'
+      last_updated: "Dernière mise à jour : %{date}"
       liability:
         heading: 8. Limitation de responsabilité
         text: DANS LA LIMITE AUTORISÉE PAR LA LOI, BOBADILLA TECH DÉCLINE TOUTE RESPONSABILITÉ
@@ -1081,22 +1096,22 @@ fr:
           OU AUTRES PERTES INTANGIBLES.
       sla:
         heading: 4. Niveau de service et disponibilité
-        intro: 'Nous visons 99,99 % de disponibilité mais ne garantissons pas un service
-          ininterrompu. Nous déclinons toute responsabilité pour :'
+        intro: "Nous visons 99,99 % de disponibilité mais ne garantissons pas un service
+          ininterrompu. Nous déclinons toute responsabilité pour :"
         items:
-        - Les fenêtres de maintenance planifiées
-        - Les cas de force majeure
-        - Les pannes de services tiers
-        - Les problèmes causés par un mauvais usage de l'API
+          - Les fenêtres de maintenance planifiées
+          - Les cas de force majeure
+          - Les pannes de services tiers
+          - Les problèmes causés par un mauvais usage de l'API
       termination:
         heading: 7. Résiliation
-        intro: 'Nous pouvons suspendre ou résilier votre accès à tout moment en cas
-          de :'
+        intro: "Nous pouvons suspendre ou résilier votre accès à tout moment en cas
+          de :"
         items:
-        - Violation des présentes conditions
-        - Non-paiement
-        - Activité frauduleuse ou illégale
-        - Décision de notre part avec préavis de 30 jours
+          - Violation des présentes conditions
+          - Non-paiement
+          - Activité frauduleuse ou illégale
+          - Décision de notre part avec préavis de 30 jours
         self_cancel: Vous pouvez supprimer votre compte à tout moment depuis les paramètres
           du tableau de bord.
       title: Conditions d'utilisation — Requiems API


### PR DESCRIPTION
## Replace string placeholders with YAML arrays in ES and FR home locales

The signals keys under home.index.systems.cards were set as string placeholders instead of YAML arrays, causing a NoMethodError when the home page tried to iterate over them.

- Converted 5 signals entries in home.es.yml from "[formación]" to proper YAML lists
- Converted 5 signals entries in home.fr.yml from "[tableau]" to proper YAML lists
- Translations sourced from existing systems.es.yml and systems.fr.yml for consistency



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Spanish and French dashboard content for home, FAQs, pricing, error code references, glossary entries, privacy policy, and terms.
  * Improved readability by restructuring long text into clearer lists and multi-line sections.
* **Bug Fixes**
  * Standardized formatting across locale files for more consistent display in the UI.
  * Replaced placeholder or loosely structured content in several dashboard cards with clearer, more detailed copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->