### PR TITLE
feat: muted ai skills banner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Requiems API core ownership
-* @bobadilla-tech/requiems-api-core-team
+
+- @bobadilla-tech/requiems-api-core-team

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,12 +4,12 @@
 
 Multi-app monorepo with four services:
 
-| App             | Path                           | Language                       |
-| --------------- | ------------------------------ | ------------------------------ |
-| Go API          | `apps/api/`                    | Go 1.26                        |
-| Rails Dashboard | `apps/dashboard/`              | Ruby 3.4.8 / Rails 8           |
-| Auth Gateway    | `apps/workers/auth-gateway/`   | TypeScript (Cloudflare Worker) |
-| API Management  | `apps/workers/api-management/` | TypeScript (Cloudflare Worker) |
+| App                         | Path                           |
+| --------------------------- | ------------------------------ |
+| Go API                      | `apps/api/`                    |
+| Rails Dashboard             | `apps/dashboard/`              |
+| Auth Gateway TS CF Worker   | `apps/workers/auth-gateway/`   |
+| API Management TS CF Worker | `apps/workers/api-management/` |
 
 Shared worker utilities live in `apps/workers/shared/`.
 
@@ -21,7 +21,7 @@ User → Auth Gateway (port 4455) → Go API (port 8080) → PostgreSQL
 Rails Dashboard → API Management (port 5544) → Cloudflare KV/D1
 ```
 
-## Go API — Code Patterns
+## Go API: Code Patterns
 
 Domain-driven design under `services/`. Each feature follows:
 
@@ -107,7 +107,8 @@ pnpm run typecheck
 
 ## Rails Dashboard — i18n (rori18n)
 
-`apps/dashboard` uses [rori18n](https://github.com/bobadilla-tech/rori18n) — a Go CLI that manages i18n YAML files. Install once:
+`apps/dashboard` uses [rori18n](https://github.com/bobadilla-tech/rori18n) — a
+Go CLI that manages i18n YAML files. Install once:
 
 ```bash
 go install github.com/bobadilla-tech/rori18n@latest
@@ -129,8 +130,10 @@ rori18n refactor-key --root apps/dashboard --old shared.old.key --new shared.new
 rori18n audit --root apps/dashboard --all
 ```
 
-Brand names protected from translation live in `apps/dashboard/.translate-dictionary.txt`.
-Do not use `i18n-tasks` write commands — use rori18n instead. `bundle exec i18n-tasks health` is still useful as a passive check.
+Brand names protected from translation live in
+`apps/dashboard/.translate-dictionary.txt`. Do not use `i18n-tasks` write
+commands — use rori18n instead. `bundle exec i18n-tasks health` is still useful
+as a passive check.
 
 ## Before Marking a Task Done
 

--- a/apps/api/services/networking/mx/transport_http.go
+++ b/apps/api/services/networking/mx/transport_http.go
@@ -9,9 +9,9 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"requiems-api/platform/httpx"
+	"requiems-api/platform/middleware"
 )
 
-// BatchRequest is the body for validating multiple domains at once.
 type BatchRequest struct {
 	Domains []string `json:"domains" validate:"required,min=1,max=50,dive,required,fqdn"`
 }
@@ -20,26 +20,24 @@ type BatchRequest struct {
 var domainRe = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$`)
 
 func RegisterRoutes(r chi.Router, svc *Service) {
-	r.Get("/mx/{domain}", func(w http.ResponseWriter, r *http.Request) {
-		domain := chi.URLParam(r, "domain")
+	r.With(middleware.ValidateURLParam("domain", domainRe, "invalid domain name")).
+		Get("/mx/{domain}", func(w http.ResponseWriter, r *http.Request) {
+			domain := chi.URLParam(r, "domain")
 
-		if !domainRe.MatchString(domain) {
-			httpx.Error(w, http.StatusBadRequest, "bad_request", "invalid domain name")
-			return
-		}
+			result, err := svc.Lookup(r.Context(), domain)
 
-		result, err := svc.Lookup(r.Context(), domain)
-		if err != nil {
-			if isDNSNotFound(err) {
-				httpx.Error(w, http.StatusNotFound, "not_found", "no MX records found for domain")
+			if err != nil {
+				if isDNSNotFound(err) {
+					httpx.Error(w, http.StatusNotFound, "not_found", "no MX records found for domain")
+					return
+				}
+				
+				httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal error")
 				return
 			}
-			httpx.Error(w, http.StatusInternalServerError, "internal_error", "internal error")
-			return
-		}
 
-		httpx.JSON(w, http.StatusOK, result)
-	})
+			httpx.JSON(w, http.StatusOK, result)
+		})
 
 	r.Post("/mx/batch", httpx.HandleBatch(
 		func(ctx context.Context, req BatchRequest) (httpx.BatchResponse[BatchLookupItem], error) {
@@ -48,10 +46,11 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	))
 }
 
-// isDNSNotFound reports whether the error is a DNS "no such host" / NXDOMAIN error.
+// Reports whether the error is a DNS "no such host" / NXDOMAIN error.
 func isDNSNotFound(err error) bool {
 	if dnsErr, ok := err.(*net.DNSError); ok {
 		return dnsErr.IsNotFound
 	}
+
 	return false
 }

--- a/apps/api/services/networking/mx/transport_http_test.go
+++ b/apps/api/services/networking/mx/transport_http_test.go
@@ -41,12 +41,12 @@ func TestMXLookup_InvalidDomain(t *testing.T) {
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
-			assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for %q, got %d", tc.domain, w.Code)
+			assert.Equal(t, http.StatusUnprocessableEntity, w.Code, "expected 422 for %q, got %d", tc.domain, w.Code)
 
 			var resp httpx.ErrorResponse
 			err := json.NewDecoder(w.Body).Decode(&resp)
 			require.NoError(t, err)
-			assert.Equal(t, "bad_request", resp.Error)
+			assert.Equal(t, "validation_failed", resp.Error)
 		})
 	}
 }

--- a/apps/api/services/text/words/transport_http.go
+++ b/apps/api/services/text/words/transport_http.go
@@ -51,6 +51,7 @@ func RegisterRoutes(r chi.Router, svc *Service) {
 	r.Post("/words/batch", httpx.HandleBatch(
 		func(ctx context.Context, req BatchRequest) (httpx.BatchResponse[BatchItem], error) {
 			items, err := svc.BatchDefine(ctx, req)
+			
 			return httpx.BatchResponse[BatchItem]{Results: items}, err
 		},
 	))

--- a/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
+++ b/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
@@ -1,15 +1,42 @@
 import { Controller } from "@hotwired/stimulus";
 
+// Keep in sync with the literal in application.html.erb's prepaint <head>
+// script — can't share a single constant without either deferring that
+// script (reintroducing the flash it exists to avoid) or adding a .js.erb
+// build step this app doesn't otherwise use.
 const STORAGE_KEY = "ai-skills-banner-dismissed-until";
 const MUTE_DURATION_MS = 24 * 60 * 60 * 1000;
+const HIDE_CLASS = "hide-ai-skills-banner";
 
 // Manages the AI Skills promotional banner.
 // Hides the banner when dismissed, and mutes it for 24h via localStorage
 // (see the inline script in application.html.erb's <head> that reads this
 // back before paint, mirroring the dark-mode FOUC-avoidance pattern).
+//
+// That head script only runs on a full page load, not on Turbo visits
+// (Turbo swaps <body> — including a fresh banner partial — without
+// re-running already-present <head> scripts). connect() re-syncs the same
+// hide class on every Turbo visit, since Stimulus reconnects controllers
+// whenever their element is (re)inserted by a Turbo body swap.
 export default class extends Controller {
+  connect() {
+    let mutedUntil;
+    try {
+      mutedUntil = localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return;
+    }
+    const isMuted = Boolean(mutedUntil) && Date.now() < Number(mutedUntil);
+    document.documentElement.classList.toggle(HIDE_CLASS, isMuted);
+  }
+
   dismiss() {
-    localStorage.setItem(STORAGE_KEY, Date.now() + MUTE_DURATION_MS);
+    try {
+      localStorage.setItem(STORAGE_KEY, Date.now() + MUTE_DURATION_MS);
+    } catch {
+      // Storage unavailable (private browsing, quota, disabled, etc.) —
+      // still dismiss for this page view even though it won't persist.
+    }
     this.element.remove();
   }
 }

--- a/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
+++ b/apps/dashboard/app/javascript/controllers/ai_skills_banner_controller.js
@@ -1,9 +1,15 @@
 import { Controller } from "@hotwired/stimulus";
 
+const STORAGE_KEY = "ai-skills-banner-dismissed-until";
+const MUTE_DURATION_MS = 24 * 60 * 60 * 1000;
+
 // Manages the AI Skills promotional banner.
-// Hides the banner when dismissed. Reappears on every page reload.
+// Hides the banner when dismissed, and mutes it for 24h via localStorage
+// (see the inline script in application.html.erb's <head> that reads this
+// back before paint, mirroring the dark-mode FOUC-avoidance pattern).
 export default class extends Controller {
   dismiss() {
+    localStorage.setItem(STORAGE_KEY, Date.now() + MUTE_DURATION_MS);
     this.element.remove();
   }
 }

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -25,6 +25,16 @@
       })();
     </script>
 
+    <script>
+      (function() {
+        var mutedUntil = localStorage.getItem('ai-skills-banner-dismissed-until');
+        if (mutedUntil && Date.now() < Number(mutedUntil)) {
+          document.documentElement.classList.add('hide-ai-skills-banner');
+        }
+      })();
+    </script>
+    <style>.hide-ai-skills-banner #ai-skills-banner { display: none; }</style>
+
     <title><%= page_title %></title>
 
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/apps/dashboard/app/views/layouts/application.html.erb
+++ b/apps/dashboard/app/views/layouts/application.html.erb
@@ -26,10 +26,15 @@
     </script>
 
     <script>
+      // Keep this key in sync with STORAGE_KEY in ai_skills_banner_controller.js.
       (function() {
-        var mutedUntil = localStorage.getItem('ai-skills-banner-dismissed-until');
-        if (mutedUntil && Date.now() < Number(mutedUntil)) {
-          document.documentElement.classList.add('hide-ai-skills-banner');
+        try {
+          var mutedUntil = localStorage.getItem('ai-skills-banner-dismissed-until');
+          if (mutedUntil && Date.now() < Number(mutedUntil)) {
+            document.documentElement.classList.add('hide-ai-skills-banner');
+          }
+        } catch (e) {
+          // localStorage unavailable — fail open, banner shows normally.
         }
       })();
     </script>

--- a/docs/design-plans/2026-07-12-ai-skills-banner-24h-dismiss.md
+++ b/docs/design-plans/2026-07-12-ai-skills-banner-24h-dismiss.md
@@ -1,0 +1,47 @@
+# AI Skills Banner: 24h Dismiss Persistence
+
+The AI Skills promotional banner (`partials/shared/ai_skills_banner`, rendered unconditionally on every page in `application.html.erb`) had no persistence: `ai_skills_banner_controller.js`'s only method, `dismiss()`, just called `this.element.remove()`. The banner reappeared on every page load or navigation, even seconds after a user closed it — the file's own comment admitted this ("Reappears on every page reload"). The fix: closing the banner should suppress it for 24 hours, fully client-side, no server or cookie involvement.
+
+---
+
+## What Changed
+
+### 1. Persisting the dismissal
+
+`ai_skills_banner_controller.js`'s `dismiss()` now writes a "muted until" timestamp to `localStorage` in addition to removing the element from the DOM:
+
+```js
+const STORAGE_KEY = "ai-skills-banner-dismissed-until";
+const MUTE_DURATION_MS = 24 * 60 * 60 * 1000;
+
+dismiss() {
+  localStorage.setItem(STORAGE_KEY, Date.now() + MUTE_DURATION_MS);
+  this.element.remove();
+}
+```
+
+The value is a plain numeric string (`Date.now() + 24h`, in ms), not JSON — matching the existing convention used by `theme_controller.js` for the dark-mode preference (`localStorage.setItem("theme", ...)`, no namespacing, no serialization). Each dismiss resets the 24h window from that moment; after it elapses, the banner shows again on the next load.
+
+### 2. Avoiding a flash on reload
+
+A Stimulus controller only connects after the DOM has parsed, so checking the mute state inside `connect()` would let the banner flash visible for a moment on every page load before being hidden — even on days it should stay muted. The app already solves this exact problem for dark mode: `application.html.erb`'s `<head>` has a synchronous inline `<script>` that reads `localStorage` and adds a class to `<html>` *before* the body paints.
+
+This change adds a second inline script right after it, following the same shape:
+
+```erb
+<script>
+  (function() {
+    var mutedUntil = localStorage.getItem('ai-skills-banner-dismissed-until');
+    if (mutedUntil && Date.now() < Number(mutedUntil)) {
+      document.documentElement.classList.add('hide-ai-skills-banner');
+    }
+  })();
+</script>
+<style>.hide-ai-skills-banner #ai-skills-banner { display: none; }</style>
+```
+
+Same file, same IIFE-in-`<head>` idiom, same "add a class to `<html>` before paint" mechanism as the theme script — no new pattern introduced.
+
+### Known tradeoff
+
+This is intentionally 100% client-side (no cookie, no server session state), matching the request. Like the existing dark-mode script it mirrors, it depends on JavaScript running before first paint — with JS disabled or blocked, the banner will show regardless of prior dismissal. This is an accepted tradeoff already present in this codebase for the same class of problem, not a new risk introduced here.


### PR DESCRIPTION
Updates for the ai banner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Skills promotional banner dismissals now persist for 24 hours.
  * Dismissed banners remain hidden across page reloads and navigation.
  * Banner visibility is suppressed before the page is displayed, reducing visual flicker.

* **Documentation**
  * Added documentation describing the 24-hour dismissal behavior and client-side persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->