### PR TITLE
fix: resolve .gitignore conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ temp/
 tickets/
 apps/dashboard/public/documents/*.pdf
 .claude
+apps/api/dbs/


### PR DESCRIPTION
## PR Summary

### 📝 Description
Adds `apps/api/dbs/` to `.gitignore` to exclude database and dataset files that shouldn't be tracked in the repository.

### 📁 Ignored files
- `cities15000.txt`
- `GeoLite2-ASN.mmdb`
- `GeoLite2-City.mmdb`
- `IP2PROXY-LITE-PX2.BIN`
- `postal_codes.txt`

### 🎯 Motivation
These files are third-party datasets/databases (GeoIP data, postal codes, cities) that:
- Are large/binary files that add no value to the Git history
- Are generated or downloaded separately (not source code)
- Can be updated independently without cluttering commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude an additional local database directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->