### PR TITLE
feat: delegate sudoku generation to sudoku-go library

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/bobadilla-tech/sudoku-go v0.1.0 // indirect
 	github.com/boyter/go-string v1.0.5 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -24,6 +24,8 @@ github.com/bobadilla-tech/lorelai v1.3.3 h1:59SqSzL+ICSW6MCA2OTzj6r+EJ7Nv7FXtbXd
 github.com/bobadilla-tech/lorelai v1.3.3/go.mod h1:ql8Jou+8OBienKt7ByAC9J7zuya3D5YVL6ZUFbMiKr0=
 github.com/bobadilla-tech/sentiment-go v1.1.0 h1:lrPpVJgSL/DfCOiOdgDpf0iigJlujYkc7GEZ9if8vVY=
 github.com/bobadilla-tech/sentiment-go v1.1.0/go.mod h1:TFCY/Gcee/+BNLrI7/s8uL80/Gy9Y8OH1KFaSQGafXw=
+github.com/bobadilla-tech/sudoku-go v0.1.0 h1:bLCI5oGAmK6QFll49ffy7dhTpHNq41Oap/wlunHsKWk=
+github.com/bobadilla-tech/sudoku-go v0.1.0/go.mod h1:Q3d0G6CdoNuF9eSd+dc/W6yIDSv2jTDKWFhIUniELxA=
 github.com/boombuler/barcode v1.1.0 h1:ChaYjBR63fr4LFyGn8E8nt7dBSt3MiU3zMOZqFvVkHo=
 github.com/boombuler/barcode v1.1.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boyter/go-string v1.0.5 h1:/xcOlWdgelLYLVkUU0xBLfioGjZ9KIMUMI/RXG138YY=

--- a/apps/api/services/entertainment/sudoku/service.go
+++ b/apps/api/services/entertainment/sudoku/service.go
@@ -2,11 +2,12 @@ package sudoku
 
 import (
 	"fmt"
-	"math/rand/v2"
+
+	sudokulib "github.com/bobadilla-tech/sudoku-go"
 )
 
 // Grid is a 9×9 Sudoku board; 0 represents an empty cell.
-type Grid [9][9]int
+type Grid = sudokulib.Grid
 
 // Puzzle is the response returned by the sudoku endpoint.
 type Puzzle struct {
@@ -15,29 +16,11 @@ type Puzzle struct {
 	Solution   Grid   `json:"solution"`
 }
 
-// cellsToRemove maps a difficulty to the number of cells removed from the
-// solved board when constructing the puzzle. The remaining given cells are:
-//   - easy:   45 givens  (36 removed)
-//   - medium: 35 givens  (46 removed)
-//   - hard:   29 givens  (52 removed)
-var cellsToRemove = map[string]int{
-	"easy":   36,
-	"medium": 46,
-	"hard":   52,
-}
-
-// base is a pre-verified valid Sudoku solution used as the starting template.
-// All row/column/box constraints are satisfied.
-var base = Grid{
-	{1, 2, 3, 4, 5, 6, 7, 8, 9},
-	{4, 5, 6, 7, 8, 9, 1, 2, 3},
-	{7, 8, 9, 1, 2, 3, 4, 5, 6},
-	{2, 3, 4, 5, 6, 7, 8, 9, 1},
-	{5, 6, 7, 8, 9, 1, 2, 3, 4},
-	{8, 9, 1, 2, 3, 4, 5, 6, 7},
-	{3, 4, 5, 6, 7, 8, 9, 1, 2},
-	{6, 7, 8, 9, 1, 2, 3, 4, 5},
-	{9, 1, 2, 3, 4, 5, 6, 7, 8},
+// difficultyMap maps the API string difficulty to the library's Difficulty type.
+var difficultyMap = map[string]sudokulib.Difficulty{
+	"easy":   sudokulib.Easy,
+	"medium": sudokulib.Medium,
+	"hard":   sudokulib.Hard,
 }
 
 // Service generates Sudoku puzzles.
@@ -51,18 +34,20 @@ func NewService() *Service {
 // Generate returns a new Sudoku puzzle at the requested difficulty level.
 // Returns an error if difficulty is not one of: easy, medium, hard.
 func (s *Service) Generate(difficulty string) (Puzzle, error) {
-	if _, ok := cellsToRemove[difficulty]; !ok {
+	d, ok := difficultyMap[difficulty]
+	if !ok {
 		return Puzzle{}, fmt.Errorf("invalid difficulty %q: must be one of easy, medium, hard", difficulty)
 	}
 
-	rng := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())) //nolint:gosec // Good enough for puzzle generation.
-	solution := shuffle(base, rng)
-	puzzle := removeCells(solution, cellsToRemove[difficulty], rng)
+	p, err := sudokulib.Generate(d)
+	if err != nil {
+		return Puzzle{}, err
+	}
 
 	return Puzzle{
 		Difficulty: difficulty,
-		Puzzle:     puzzle,
-		Solution:   solution,
+		Puzzle:     p.Grid,
+		Solution:   p.Solution,
 	}, nil
 }
 
@@ -78,92 +63,4 @@ func (s *Service) GenerateBatch(difficulties []string) ([]Puzzle, error) {
 		results[i] = p
 	}
 	return results, nil
-}
-
-// shuffle produces a new valid solution by permuting the base grid.
-//
-// The transformations applied are:
-//  1. Remap digits — replace each digit 1-9 with a random permutation so the
-//     numbers themselves look different.
-//  2. Shuffle rows within each band — each band contains rows {0,1,2},
-//     {3,4,5}, or {6,7,8}. Permuting rows inside a band preserves row and
-//     column uniqueness while breaking pattern regularity.
-//  3. Shuffle columns within each stack — analogous to row shuffling but for
-//     columns in stacks {0,1,2}, {3,4,5}, {6,7,8}.
-//  4. Shuffle bands — permuting the three row-bands themselves also preserves
-//     validity.
-//  5. Shuffle stacks — permuting the three column-stacks preserves validity.
-func shuffle(g Grid, rng *rand.Rand) Grid {
-	// Step 1: digit remapping.
-	perm := rng.Perm(9)
-	for r := range 9 {
-		for c := range 9 {
-			g[r][c] = perm[g[r][c]-1] + 1
-		}
-	}
-
-	// Step 2: shuffle rows within each band.
-	for band := range 3 {
-		rows := rng.Perm(3)
-		base := band * 3
-		var tmp [3][9]int
-		for i, row := range rows {
-			tmp[i] = g[base+row]
-		}
-		for i := range 3 {
-			g[base+i] = tmp[i]
-		}
-	}
-
-	// Step 3: shuffle columns within each stack.
-	for stack := range 3 {
-		cols := rng.Perm(3)
-		base := stack * 3
-		for r := range 9 {
-			var tmp [3]int
-			for i, col := range cols {
-				tmp[i] = g[r][base+col]
-			}
-			for i := range 3 {
-				g[r][base+i] = tmp[i]
-			}
-		}
-	}
-
-	// Step 4: shuffle bands.
-	bandOrder := rng.Perm(3)
-	var tmpGrid Grid
-	for i, b := range bandOrder {
-		for j := range 3 {
-			tmpGrid[i*3+j] = g[b*3+j]
-		}
-	}
-	g = tmpGrid
-
-	// Step 5: shuffle stacks.
-	stackOrder := rng.Perm(3)
-	for r := range 9 {
-		var tmpRow [9]int
-		for i, s := range stackOrder {
-			for j := range 3 {
-				tmpRow[i*3+j] = g[r][s*3+j]
-			}
-		}
-		g[r] = tmpRow
-	}
-
-	return g
-}
-
-// removeCells blanks out the requested number of cells from the solution to
-// create the puzzle. Cells are removed in a random order.
-func removeCells(solution Grid, count int, rng *rand.Rand) Grid {
-	puzzle := solution
-
-	positions := rng.Perm(81)
-	for _, pos := range positions[:count] {
-		puzzle[pos/9][pos%9] = 0
-	}
-
-	return puzzle
 }

--- a/apps/api/services/entertainment/sudoku/transport_http_test.go
+++ b/apps/api/services/entertainment/sudoku/transport_http_test.go
@@ -91,8 +91,8 @@ func TestSudoku_PuzzleHasEmptyCells(t *testing.T) {
 				}
 			}
 
-			expected := cellsToRemove[d]
-			assert.Equal(t, expected, empty, "difficulty %q: expected %d empty cells, got %d", d, expected, empty)
+			expectedEmpty := map[string]int{"easy": 36, "medium": 46, "hard": 52}
+			assert.Equal(t, expectedEmpty[d], empty, "difficulty %q: expected %d empty cells, got %d", d, expectedEmpty[d], empty)
 		})
 	}
 }


### PR DESCRIPTION
Replaces the embedded sudoku generation algorithm in `service.go` with a call to the new [`sudoku-go`](https://github.com/bobadilla-tech/sudoku-go) library (`v0.1.0`).

## Changes

- `service.go`: removed embedded shuffle/removeCells algorithm; now delegates to `sudokulib.Generate`. API response shape is unchanged.
- `transport_http_test.go`: replaced reference to internal `cellsToRemove` map (removed with the algorithm) with inline expected values.
- `go.mod` / `go.sum`: added `github.com/bobadilla-tech/sudoku-go v0.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Sudoku puzzle generation for easy, medium, and hard difficulties.
  * Generated puzzles now consistently provide the expected number of empty cells.

* **Bug Fixes**
  * Improved validation for unsupported Sudoku difficulty levels.
  * Increased consistency between generated puzzles and their solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->